### PR TITLE
Add excludeMain() functionality in AST check

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/ast/asserting/UnwantedNodesAssert.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/ast/asserting/UnwantedNodesAssert.java
@@ -34,8 +34,18 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	 */
 	private final LanguageLevel level;
 
+	/**
+	 * Whether to exclude the main method for the Java parser Default is set to true
+	 */
+	private final boolean excludeMainMethod;
+
 	private UnwantedNodesAssert(Path path, LanguageLevel level) {
+		this(path, level, false);
+	}
+
+	private UnwantedNodesAssert(Path path, LanguageLevel level, boolean excludeMainMethod) {
 		super(requireNonNull(path), UnwantedNodesAssert.class);
+		this.excludeMainMethod = excludeMainMethod;
 		this.level = level;
 		if (!Files.isDirectory(path)) {
 			fail("The source directory %s does not exist", path); //$NON-NLS-1$
@@ -78,7 +88,7 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	 * package, including all of its sub-packages.
 	 *
 	 * @param packageName Java package name in the form of, e.g.,
-	 *                    <code>de.tum.cit.ase.ares.api</code>, which is resolved
+	 *                    <code>de.tum.in.test.api</code>, which is resolved
 	 *                    relative to the path of this UnwantedNodesAssert.
 	 * @return An unwanted node assertion object (for chaining)
 	 * @implNote The package is split at "." with the resulting segments being
@@ -90,7 +100,16 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	public UnwantedNodesAssert withinPackage(String packageName) {
 		Objects.requireNonNull(packageName, "The package name must not be null."); //$NON-NLS-1$
 		var newPath = actual.resolve(Path.of("", packageName.split("\\."))); //$NON-NLS-1$ //$NON-NLS-2$
-		return new UnwantedNodesAssert(newPath, level);
+		return new UnwantedNodesAssert(newPath, level, excludeMainMethod);
+	}
+
+	/**
+	 * Configures if the main method should be excluded from the AST
+	 *
+	 * @return An unwanted node assertion object (for chaining)
+	 */
+	public UnwantedNodesAssert excludeMainMethod() {
+		return new UnwantedNodesAssert(actual, level, true);
 	}
 
 	/**
@@ -100,7 +119,7 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	 * @return An unwanted node assertion object (for chaining)
 	 */
 	public UnwantedNodesAssert withLanguageLevel(LanguageLevel level) {
-		return new UnwantedNodesAssert(actual, level);
+		return new UnwantedNodesAssert(actual, level, excludeMainMethod);
 	}
 
 	/**
@@ -120,7 +139,7 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 		}
 		StaticJavaParser.getParserConfiguration().setLanguageLevel(level);
 		Optional<String> errorMessage = UnwantedNode.getMessageForUnwantedNodesForAllFilesBelow(actual,
-				type.getNodeNameNodeMap());
+				type.getNodeNameNodeMap(), excludeMainMethod);
 		errorMessage.ifPresent(unwantedNodeMessageForAllJavaFiles -> failWithMessage(
 				localized("ast.method.has_no") + System.lineSeparator() + unwantedNodeMessageForAllJavaFiles)); //$NON-NLS-1$
 		return this;

--- a/src/main/java/de/tum/cit/ase/ares/api/ast/asserting/UnwantedNodesAssert.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/ast/asserting/UnwantedNodesAssert.java
@@ -35,18 +35,14 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	private final LanguageLevel level;
 
 	/**
-	 * Whether to exclude the main method for the Java parser Default is set to true
+	 * Whether to exclude the main method for the Java parser Default is set to false
 	 */
 	private final boolean excludeMainMethod;
 
-	private UnwantedNodesAssert(Path path, LanguageLevel level) {
-		this(path, level, false);
-	}
-
 	private UnwantedNodesAssert(Path path, LanguageLevel level, boolean excludeMainMethod) {
 		super(requireNonNull(path), UnwantedNodesAssert.class);
-		this.excludeMainMethod = excludeMainMethod;
 		this.level = level;
+		this.excludeMainMethod = excludeMainMethod;
 		if (!Files.isDirectory(path)) {
 			fail("The source directory %s does not exist", path); //$NON-NLS-1$
 		}
@@ -68,7 +64,7 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 				+ " Make sure the build file is configured correctly." //$NON-NLS-1$
 				+ " If it is not located in the execution folder directly," //$NON-NLS-1$
 				+ " set the location using AresConfiguration methods.")); //$NON-NLS-1$
-		return new UnwantedNodesAssert(path, null);
+		return new UnwantedNodesAssert(path, null, false);
 	}
 
 	/**
@@ -80,7 +76,7 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	 */
 	public static UnwantedNodesAssert assertThatSourcesIn(Path directory) {
 		Objects.requireNonNull(directory, "The given source path must not be null."); //$NON-NLS-1$
-		return new UnwantedNodesAssert(directory, null);
+		return new UnwantedNodesAssert(directory, null, false);
 	}
 
 	/**
@@ -88,7 +84,7 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	 * package, including all of its sub-packages.
 	 *
 	 * @param packageName Java package name in the form of, e.g.,
-	 *                    <code>de.tum.in.test.api</code>, which is resolved
+	 *                    <code>de.tum.cit.ase.ares.api</code>, which is resolved
 	 *                    relative to the path of this UnwantedNodesAssert.
 	 * @return An unwanted node assertion object (for chaining)
 	 * @implNote The package is split at "." with the resulting segments being
@@ -138,8 +134,7 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 			failWithMessage("The 'level' is not set. Please use UnwantedNodesAssert.withLanguageLevel(LanguageLevel)."); //$NON-NLS-1$
 		}
 		StaticJavaParser.getParserConfiguration().setLanguageLevel(level);
-		Optional<String> errorMessage = UnwantedNode.getMessageForUnwantedNodesForAllFilesBelow(actual,
-				type.getNodeNameNodeMap(), excludeMainMethod);
+		Optional<String> errorMessage = UnwantedNode.getMessageForUnwantedNodesForAllFilesBelow(actual, type.getNodeNameNodeMap(), excludeMainMethod);
 		errorMessage.ifPresent(unwantedNodeMessageForAllJavaFiles -> failWithMessage(
 				localized("ast.method.has_no") + System.lineSeparator() + unwantedNodeMessageForAllJavaFiles)); //$NON-NLS-1$
 		return this;

--- a/src/main/java/de/tum/cit/ase/ares/api/ast/asserting/UnwantedNodesAssert.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/ast/asserting/UnwantedNodesAssert.java
@@ -23,120 +23,120 @@ import de.tum.cit.ase.ares.api.util.ProjectSourcesFinder;
  * Checks whole Java files for unwanted nodes
  *
  * @author Markus Paulsen
- * @since 1.12.0
  * @version 1.0.0
+ * @since 1.12.0
  */
 @API(status = Status.MAINTAINED)
 public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Path> {
 
-	/**
-	 * The language level for the Java parser
-	 */
-	private final LanguageLevel level;
+    /**
+     * The language level for the Java parser
+     */
+    private final LanguageLevel level;
 
-	/**
-	 * Whether to exclude the main method for the Java parser Default is set to false
-	 */
-	private final boolean excludeMainMethod;
+    /**
+     * Whether to exclude the main method for the Java parser Default is set to false
+     */
+    private final boolean excludeMainMethod;
 
-	private UnwantedNodesAssert(Path path, LanguageLevel level, boolean excludeMainMethod) {
-		super(requireNonNull(path), UnwantedNodesAssert.class);
-		this.level = level;
-		this.excludeMainMethod = excludeMainMethod;
-		if (!Files.isDirectory(path)) {
-			fail("The source directory %s does not exist", path); //$NON-NLS-1$
-		}
-	}
+    private UnwantedNodesAssert(Path path, LanguageLevel level, boolean excludeMainMethod) {
+        super(requireNonNull(path), UnwantedNodesAssert.class);
+        this.level = level;
+        this.excludeMainMethod = excludeMainMethod;
+        if (!Files.isDirectory(path)) {
+            fail("The source directory %s does not exist", path); //$NON-NLS-1$
+        }
+    }
 
-	/**
-	 * Creates an unwanted node assertion object for all project source files.
-	 * <p>
-	 * The project source directory gets extracted from the build configuration, and
-	 * a <code>pom.xml</code> or <code>build.gradle</code> in the execution path is
-	 * the default build configuration location. The configuration here is the same
-	 * as the one in the structural tests and uses {@link AresConfiguration}.
-	 *
-	 * @return An unwanted node assertion object (for chaining)
-	 */
-	public static UnwantedNodesAssert assertThatProjectSources() {
-		var path = ProjectSourcesFinder.findProjectSourcesPath().orElseThrow(() -> new AssertionError("" //$NON-NLS-1$
-				+ "Could not find project sources folder." //$NON-NLS-1$
-				+ " Make sure the build file is configured correctly." //$NON-NLS-1$
-				+ " If it is not located in the execution folder directly," //$NON-NLS-1$
-				+ " set the location using AresConfiguration methods.")); //$NON-NLS-1$
-		return new UnwantedNodesAssert(path, null, false);
-	}
+    /**
+     * Creates an unwanted node assertion object for all project source files.
+     * <p>
+     * The project source directory gets extracted from the build configuration, and
+     * a <code>pom.xml</code> or <code>build.gradle</code> in the execution path is
+     * the default build configuration location. The configuration here is the same
+     * as the one in the structural tests and uses {@link AresConfiguration}.
+     *
+     * @return An unwanted node assertion object (for chaining)
+     */
+    public static UnwantedNodesAssert assertThatProjectSources() {
+        var path = ProjectSourcesFinder.findProjectSourcesPath().orElseThrow(() -> new AssertionError("" //$NON-NLS-1$
+                + "Could not find project sources folder." //$NON-NLS-1$
+                + " Make sure the build file is configured correctly." //$NON-NLS-1$
+                + " If it is not located in the execution folder directly," //$NON-NLS-1$
+                + " set the location using AresConfiguration methods.")); //$NON-NLS-1$
+        return new UnwantedNodesAssert(path, null, false);
+    }
 
-	/**
-	 * Creates an unwanted node assertion object for all source files at and below
-	 * the given directory path.
-	 *
-	 * @param directory Path to a directory under which all files are considered
-	 * @return An unwanted node assertion object (for chaining)
-	 */
-	public static UnwantedNodesAssert assertThatSourcesIn(Path directory) {
-		Objects.requireNonNull(directory, "The given source path must not be null."); //$NON-NLS-1$
-		return new UnwantedNodesAssert(directory, null, false);
-	}
+    /**
+     * Creates an unwanted node assertion object for all source files at and below
+     * the given directory path.
+     *
+     * @param directory Path to a directory under which all files are considered
+     * @return An unwanted node assertion object (for chaining)
+     */
+    public static UnwantedNodesAssert assertThatSourcesIn(Path directory) {
+        Objects.requireNonNull(directory, "The given source path must not be null."); //$NON-NLS-1$
+        return new UnwantedNodesAssert(directory, null, false);
+    }
 
-	/**
-	 * Creates an unwanted node assertion object for all source files in the given
-	 * package, including all of its sub-packages.
-	 *
-	 * @param packageName Java package name in the form of, e.g.,
-	 *                    <code>de.tum.cit.ase.ares.api</code>, which is resolved
-	 *                    relative to the path of this UnwantedNodesAssert.
-	 * @return An unwanted node assertion object (for chaining)
-	 * @implNote The package is split at "." with the resulting segments being
-	 *           interpreted as directory structure. So
-	 *           <code>assertThatSourcesIn(Path.of("src/main/java")).withinPackage("net.example.test")</code>
-	 *           will yield an assert for all source files located at and below the
-	 *           relative path <code>src/main/java/net/example/test</code>
-	 */
-	public UnwantedNodesAssert withinPackage(String packageName) {
-		Objects.requireNonNull(packageName, "The package name must not be null."); //$NON-NLS-1$
-		var newPath = actual.resolve(Path.of("", packageName.split("\\."))); //$NON-NLS-1$ //$NON-NLS-2$
-		return new UnwantedNodesAssert(newPath, level, excludeMainMethod);
-	}
+    /**
+     * Creates an unwanted node assertion object for all source files in the given
+     * package, including all of its sub-packages.
+     *
+     * @param packageName Java package name in the form of, e.g.,
+     *                    <code>de.tum.cit.ase.ares.api</code>, which is resolved
+     *                    relative to the path of this UnwantedNodesAssert.
+     * @return An unwanted node assertion object (for chaining)
+     * @implNote The package is split at "." with the resulting segments being
+     * interpreted as directory structure. So
+     * <code>assertThatSourcesIn(Path.of("src/main/java")).withinPackage("net.example.test")</code>
+     * will yield an assert for all source files located at and below the
+     * relative path <code>src/main/java/net/example/test</code>
+     */
+    public UnwantedNodesAssert withinPackage(String packageName) {
+        Objects.requireNonNull(packageName, "The package name must not be null."); //$NON-NLS-1$
+        var newPath = actual.resolve(Path.of("", packageName.split("\\."))); //$NON-NLS-1$ //$NON-NLS-2$
+        return new UnwantedNodesAssert(newPath, level, excludeMainMethod);
+    }
 
-	/**
-	 * Configures if the main method should be excluded from the AST
-	 *
-	 * @return An unwanted node assertion object (for chaining)
-	 */
-	public UnwantedNodesAssert excludeMainMethod() {
-		return new UnwantedNodesAssert(actual, level, true);
-	}
+    /**
+     * Configures if the main method should be excluded from the AST
+     *
+     * @return An unwanted node assertion object (for chaining)
+     */
+    public UnwantedNodesAssert excludeMainMethod() {
+        return new UnwantedNodesAssert(actual, level, true);
+    }
 
-	/**
-	 * Configures the language level used by the Java parser
-	 *
-	 * @param level The language level for the Java parser
-	 * @return An unwanted node assertion object (for chaining)
-	 */
-	public UnwantedNodesAssert withLanguageLevel(LanguageLevel level) {
-		return new UnwantedNodesAssert(actual, level, excludeMainMethod);
-	}
+    /**
+     * Configures the language level used by the Java parser
+     *
+     * @param level The language level for the Java parser
+     * @return An unwanted node assertion object (for chaining)
+     */
+    public UnwantedNodesAssert withLanguageLevel(LanguageLevel level) {
+        return new UnwantedNodesAssert(actual, level, excludeMainMethod);
+    }
 
-	/**
-	 * Verifies that the selected Java files do not contain any syntax tree nodes
-	 * (statements, expressions, ...) of the given type.
-	 *
-	 * @param type Unwanted statements
-	 * @return This unwanted node assertion object (for chaining)
-	 * @see ClassType
-	 * @see ConditionalType
-	 * @see ExceptionHandlingType
-	 * @see LoopType
-	 */
-	public UnwantedNodesAssert hasNo(Type type) {
-		if (level == null) {
-			failWithMessage("The 'level' is not set. Please use UnwantedNodesAssert.withLanguageLevel(LanguageLevel)."); //$NON-NLS-1$
-		}
-		StaticJavaParser.getParserConfiguration().setLanguageLevel(level);
-		Optional<String> errorMessage = UnwantedNode.getMessageForUnwantedNodesForAllFilesBelow(actual, type.getNodeNameNodeMap(), excludeMainMethod);
-		errorMessage.ifPresent(unwantedNodeMessageForAllJavaFiles -> failWithMessage(
-				localized("ast.method.has_no") + System.lineSeparator() + unwantedNodeMessageForAllJavaFiles)); //$NON-NLS-1$
-		return this;
-	}
+    /**
+     * Verifies that the selected Java files do not contain any syntax tree nodes
+     * (statements, expressions, ...) of the given type.
+     *
+     * @param type Unwanted statements
+     * @return This unwanted node assertion object (for chaining)
+     * @see ClassType
+     * @see ConditionalType
+     * @see ExceptionHandlingType
+     * @see LoopType
+     */
+    public UnwantedNodesAssert hasNo(Type type) {
+        if (level == null) {
+            failWithMessage("The 'level' is not set. Please use UnwantedNodesAssert.withLanguageLevel(LanguageLevel)."); //$NON-NLS-1$
+        }
+        StaticJavaParser.getParserConfiguration().setLanguageLevel(level);
+        Optional<String> errorMessage = UnwantedNode.getMessageForUnwantedNodesForAllFilesBelow(actual, type.getNodeNameNodeMap(), excludeMainMethod);
+        errorMessage.ifPresent(unwantedNodeMessageForAllJavaFiles -> failWithMessage(
+                localized("ast.method.has_no") + System.lineSeparator() + unwantedNodeMessageForAllJavaFiles)); //$NON-NLS-1$
+        return this;
+    }
 }

--- a/src/main/java/de/tum/cit/ase/ares/api/ast/model/JavaFile.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/ast/model/JavaFile.java
@@ -13,6 +13,8 @@ import org.slf4j.*;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.MethodDeclaration;
 
 /**
  * Stores all required information about a Java file to be analyzed
@@ -26,9 +28,20 @@ public class JavaFile {
 	private final Path javaFilePath;
 	private final CompilationUnit javaFileAST;
 
-	public JavaFile(Path javaFilePath, CompilationUnit javaFileAST) {
+	public JavaFile(Path javaFilePath, CompilationUnit javaFileAST, boolean excludeMainMethod) {
 		this.javaFilePath = javaFilePath;
+		if (excludeMainMethod) {
+			excludeMainMethod(javaFileAST);
+		}
 		this.javaFileAST = javaFileAST;
+	}
+
+	private static void excludeMainMethod(CompilationUnit javaFileAST) {
+		javaFileAST.findAll(MethodDeclaration.class).stream()
+				.filter(method -> method.isStatic() && method.getNameAsString().equals("main")
+						&& method.getParameters().size() == 1 && method.getType().isVoidType()
+						&& method.getParameter(0).getTypeAsString().equals("String[]"))
+				.forEach(Node::remove);
 	}
 
 	public Path getJavaFilePath() {
@@ -47,12 +60,12 @@ public class JavaFile {
 	 * @return The information of the Java-file packed into a JavaFile object (null
 	 *         if the file is not a Java-file)
 	 */
-	public static JavaFile convertFromFile(Path pathOfFile) {
+	public static JavaFile convertFromFile(Path pathOfFile, boolean excludeMainMethod) {
 		if (!JAVAFILEMATCHER.matches(pathOfFile.getFileName())) {
 			return null;
 		}
 		try {
-			return new JavaFile(pathOfFile, StaticJavaParser.parse(pathOfFile));
+			return new JavaFile(pathOfFile, StaticJavaParser.parse(pathOfFile), excludeMainMethod);
 		} catch (IOException e) {
 			LOG.error("Error reading Java file '{}'", pathOfFile.toAbsolutePath(), e); //$NON-NLS-1$
 			throw new AssertionError(localized("ast.method.convert_from_file", pathOfFile.toAbsolutePath()));
@@ -67,9 +80,9 @@ public class JavaFile {
 	 *         list if the directory does not exist or if none of the files in the
 	 *         directory or its subdirectories is a Java-file)
 	 */
-	public static List<JavaFile> readFromDirectory(Path pathOfDirectory) {
+	public static List<JavaFile> readFromDirectory(Path pathOfDirectory, boolean excludeMainMethod) {
 		try (Stream<Path> directoryContentStream = Files.walk(pathOfDirectory)) {
-			return directoryContentStream.map(JavaFile::convertFromFile).filter(Objects::nonNull)
+			return directoryContentStream.map(path -> convertFromFile(path, excludeMainMethod)).filter(Objects::nonNull)
 					.collect(Collectors.toList());
 		} catch (IOException e) {
 			LOG.error("Error reading Java files in '{}'", pathOfDirectory.toAbsolutePath(), e); //$NON-NLS-1$

--- a/src/main/java/de/tum/cit/ase/ares/api/ast/model/JavaFile.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/ast/model/JavaFile.java
@@ -36,11 +36,19 @@ public class JavaFile {
 		this.javaFileAST = javaFileAST;
 	}
 
+	/**
+	 * Excludes the main method from the AST
+	 * @param javaFileAST AST of the Java-file
+	 */
 	private static void excludeMainMethod(CompilationUnit javaFileAST) {
 		javaFileAST.findAll(MethodDeclaration.class).stream()
-				.filter(method -> method.isStatic() && method.getNameAsString().equals("main")
-						&& method.getParameters().size() == 1 && method.getType().isVoidType()
-						&& method.getParameter(0).getTypeAsString().equals("String[]"))
+				.filter(method ->
+						method.isPublic() &&
+								method.isStatic() &&
+								method.getType().isVoidType() &&
+								method.getNameAsString().equals("main") &&
+								method.getParameters().size() == 1 &&
+								method.getParameter(0).getTypeAsString().equals("String[]"))
 				.forEach(Node::remove);
 	}
 
@@ -82,8 +90,7 @@ public class JavaFile {
 	 */
 	public static List<JavaFile> readFromDirectory(Path pathOfDirectory, boolean excludeMainMethod) {
 		try (Stream<Path> directoryContentStream = Files.walk(pathOfDirectory)) {
-			return directoryContentStream.map(path -> convertFromFile(path, excludeMainMethod)).filter(Objects::nonNull)
-					.collect(Collectors.toList());
+			return directoryContentStream.map(path -> convertFromFile(path, excludeMainMethod)).filter(Objects::nonNull).toList();
 		} catch (IOException e) {
 			LOG.error("Error reading Java files in '{}'", pathOfDirectory.toAbsolutePath(), e); //$NON-NLS-1$
 			throw new AssertionError(localized("ast.method.read_from_directory", pathOfDirectory.toAbsolutePath()));

--- a/src/main/java/de/tum/cit/ase/ares/api/ast/model/UnwantedNode.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/ast/model/UnwantedNode.java
@@ -17,127 +17,123 @@ import com.github.javaparser.ast.Node;
 @API(status = Status.INTERNAL)
 public class UnwantedNode {
 
-	private final String unwantedNodeName;
-	private final List<NodePosition> unwantedNodePositions;
+    private final String unwantedNodeName;
+    private final List<NodePosition> unwantedNodePositions;
 
-	public UnwantedNode(JavaFile javaFile, String unwantedNodeName, Class<? extends Node> nodeDefinedAsUnwanted) {
-		this.unwantedNodeName = unwantedNodeName;
-		this.unwantedNodePositions = javaFile.getJavaFileAST().findAll(nodeDefinedAsUnwanted).stream()
-				.map(NodePosition::getPositionOf).collect(Collectors.toList());
-		this.unwantedNodePositions.sort(NodePosition::compareTo);
-	}
+    public UnwantedNode(JavaFile javaFile, String unwantedNodeName, Class<? extends Node> nodeDefinedAsUnwanted) {
+        this.unwantedNodeName = unwantedNodeName;
+        this.unwantedNodePositions = javaFile.getJavaFileAST().findAll(nodeDefinedAsUnwanted).stream()
+                .map(NodePosition::getPositionOf).collect(Collectors.toList());
+        this.unwantedNodePositions.sort(NodePosition::compareTo);
+    }
 
-	public String getUnwantedNodeName() {
-		return unwantedNodeName;
-	}
+    public String getUnwantedNodeName() {
+        return unwantedNodeName;
+    }
 
-	public List<NodePosition> getUnwantedNodePositions() {
-		return unwantedNodePositions;
-	}
+    public List<NodePosition> getUnwantedNodePositions() {
+        return unwantedNodePositions;
+    }
 
-	/**
-	 * Finds all unwanted nodes in an abstract syntax tree of a Java-file
-	 *
-	 * @param javaFile               Abstract syntax tree of a Java-file
-	 * @param nodesDefinedAsUnwanted List of unwanted node information (packed into
-	 *                               UnwantedNode objects)
-	 */
-	public static List<UnwantedNode> getUnwantedNodesInJavaFile(JavaFile javaFile,
-																Map<String, Class<? extends Node>> nodesDefinedAsUnwanted) {
-		return nodesDefinedAsUnwanted.keySet().stream()
-				.map(unwantedNodeName -> new UnwantedNode(javaFile, unwantedNodeName,
-						nodesDefinedAsUnwanted.get(unwantedNodeName)))
-				.filter(unwantedNode -> !unwantedNode.getUnwantedNodePositions().isEmpty())
-				.sorted(Comparator.comparing(uwn -> uwn.getUnwantedNodePositions().get(0)))
-				.collect(Collectors.toList());
-	}
+    /**
+     * Finds all unwanted nodes in an abstract syntax tree of a Java-file
+     *
+     * @param javaFile               Abstract syntax tree of a Java-file
+     * @param nodesDefinedAsUnwanted List of unwanted node information (packed into
+     *                               UnwantedNode objects)
+     */
+    public static List<UnwantedNode> getUnwantedNodesInJavaFile(JavaFile javaFile, Map<String, Class<? extends Node>> nodesDefinedAsUnwanted) {
+        return nodesDefinedAsUnwanted.keySet().stream()
+                .map(unwantedNodeName -> new UnwantedNode(javaFile, unwantedNodeName,
+                        nodesDefinedAsUnwanted.get(unwantedNodeName)))
+                .filter(unwantedNode -> !unwantedNode.getUnwantedNodePositions().isEmpty())
+                .sorted(Comparator.comparing(uwn -> uwn.getUnwantedNodePositions().get(0)))
+                .collect(Collectors.toList());
+    }
 
-	/**
-	 * Detects a provided list of unwanted nodes in a Java-File at a given path
-	 *
-	 * @param pathOfJavaFile         Path to the Java-File, where unwanted nodes
-	 *                               shall be detected
-	 * @param nodesDefinedAsUnwanted List of unwanted nodes
-	 * @return Map of File-Paths and their respective list of unwanted node
-	 *         information (packed into UnwantedNode objects)
-	 */
-	public static Map<Path, List<UnwantedNode>> getUnwantedNodesForFileAt(Path pathOfJavaFile,
-																		  Map<String, Class<? extends Node>> nodesDefinedAsUnwanted, boolean excludeMainMethod) {
-		JavaFile javaFile = JavaFile.convertFromFile(pathOfJavaFile, excludeMainMethod);
-		if (javaFile == null) {
-			return Map.of();
-		}
-		List<UnwantedNode> unwantedNodes = getUnwantedNodesInJavaFile(javaFile, nodesDefinedAsUnwanted);
-		if (unwantedNodes.isEmpty()) {
-			return Map.of();
-		}
-		return Map.of(pathOfJavaFile, unwantedNodes);
-	}
+    /**
+     * Detects a provided list of unwanted nodes in a Java-File at a given path
+     *
+     * @param pathOfJavaFile         Path to the Java-File, where unwanted nodes
+     *                               shall be detected
+     * @param nodesDefinedAsUnwanted List of unwanted nodes
+     * @return Map of File-Paths and their respective list of unwanted node
+     * information (packed into UnwantedNode objects)
+     */
+    public static Map<Path, List<UnwantedNode>> getUnwantedNodesForFileAt(Path pathOfJavaFile, Map<String, Class<? extends Node>> nodesDefinedAsUnwanted, boolean excludeMainMethod) {
+        JavaFile javaFile = JavaFile.convertFromFile(pathOfJavaFile, excludeMainMethod);
+        if (javaFile == null) {
+            return Map.of();
+        }
+        List<UnwantedNode> unwantedNodes = getUnwantedNodesInJavaFile(javaFile, nodesDefinedAsUnwanted);
+        if (unwantedNodes.isEmpty()) {
+            return Map.of();
+        }
+        return Map.of(pathOfJavaFile, unwantedNodes);
+    }
 
-	/**
-	 * Detects a provided list of unwanted nodes in Java-Files below a given path
-	 *
-	 * @param positionString Path to the Directory, at and below where unwanted
-	 *                       nodes shall be detected
-	 * @return List of pairs of File-Path and their respective information about
-	 *         unwanted nodes
-	 */
+    /**
+     * Detects a provided list of unwanted nodes in Java-Files below a given path
+     *
+     * @param positionString Path to the Directory, at and below where unwanted
+     *                       nodes shall be detected
+     * @return List of pairs of File-Path and their respective information about
+     * unwanted nodes
+     */
 
-	public static String getFormattedPositionString(String positionString) {
-		return "   - " + positionString;
-	}
+    public static String getFormattedPositionString(String positionString) {
+        return "   - " + positionString;
+    }
 
-	public static String getFormattedUnwantedNodeString(UnwantedNode unwantedNode) {
-		return unwantedNode
-				.getUnwantedNodePositions().stream().map(String::valueOf).map(
-						UnwantedNode::getFormattedPositionString)
-				.collect(Collectors.joining(System.lineSeparator(),
-						localized("ast.method.get_formatted_unwanted_node_string_prefix",
-								unwantedNode.getUnwantedNodeName()) + System.lineSeparator(),
-						""));
-	}
+    public static String getFormattedUnwantedNodeString(UnwantedNode unwantedNode) {
+        return unwantedNode
+                .getUnwantedNodePositions().stream().map(String::valueOf).map(
+                        UnwantedNode::getFormattedPositionString)
+                .collect(Collectors.joining(System.lineSeparator(),
+                        localized("ast.method.get_formatted_unwanted_node_string_prefix",
+                                unwantedNode.getUnwantedNodeName()) + System.lineSeparator(),
+                        ""));
+    }
 
-	public static String getFormattedFileString(Path filePath, Map<Path, List<UnwantedNode>> unwantedNodes) {
-		return unwantedNodes.get(filePath).stream().map(UnwantedNode::getFormattedUnwantedNodeString)
-				.collect(Collectors.joining(System.lineSeparator(),
-						localized("ast.method.get_formatted_file_string_prefix", filePath) + System.lineSeparator(),
-						""));
-	}
+    public static String getFormattedFileString(Path filePath, Map<Path, List<UnwantedNode>> unwantedNodes) {
+        return unwantedNodes.get(filePath).stream().map(UnwantedNode::getFormattedUnwantedNodeString)
+                .collect(Collectors.joining(System.lineSeparator(),
+                        localized("ast.method.get_formatted_file_string_prefix", filePath) + System.lineSeparator(),
+                        ""));
+    }
 
-	/**
-	 * Creates an error message in case unwanted files are detected
-	 *
-	 * @param pathOfJavaFile          Path to the Java-File, where unwanted nodes
-	 *                                shall be detected
-	 * @param nodeNameUnwantedNodeMap List of unwanted nodes
-	 * @return Error message
-	 */
-	public static Optional<String> getMessageForUnwantedNodesForFileAt(Path pathOfJavaFile,
-																	   Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
-		Map<Path, List<UnwantedNode>> unwantedNodes = getUnwantedNodesForFileAt(pathOfJavaFile, nodeNameUnwantedNodeMap,
-				excludeMainMethod);
-		if (unwantedNodes.isEmpty()) {
-			return Optional.empty();
-		}
-		return Optional.of(unwantedNodes.keySet().stream()
-				.map(filePath -> getFormattedFileString(filePath, unwantedNodes)).reduce(String::concat).orElse(""));
-	}
+    /**
+     * Creates an error message in case unwanted files are detected
+     *
+     * @param pathOfJavaFile          Path to the Java-File, where unwanted nodes
+     *                                shall be detected
+     * @param nodeNameUnwantedNodeMap List of unwanted nodes
+     * @return Error message
+     */
+    public static Optional<String> getMessageForUnwantedNodesForFileAt(Path pathOfJavaFile, Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
+        Map<Path, List<UnwantedNode>> unwantedNodes = getUnwantedNodesForFileAt(pathOfJavaFile, nodeNameUnwantedNodeMap,
+                excludeMainMethod);
+        if (unwantedNodes.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(unwantedNodes.keySet().stream()
+                .map(filePath -> getFormattedFileString(filePath, unwantedNodes)).reduce(String::concat).orElse(""));
+    }
 
-	/**
-	 * Creates an error message in case unwanted files are detected
-	 *
-	 * @param pathOfDirectory         Path to the Directory, at and below where
-	 *                                unwanted nodes shall be detected
-	 * @param nodeNameUnwantedNodeMap List of unwanted nodes
-	 * @return Error message
-	 */
-	public static Optional<String> getMessageForUnwantedNodesForAllFilesBelow(Path pathOfDirectory,
-																			  Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
-		return JavaFile.readFromDirectory(pathOfDirectory, excludeMainMethod).stream()
-				.sorted(Comparator.comparing(JavaFile::getJavaFilePath))
-				.map(javaFile -> getMessageForUnwantedNodesForFileAt(javaFile.getJavaFilePath(),
-						nodeNameUnwantedNodeMap, excludeMainMethod))
-				.filter(Optional::isPresent).map(Optional::get).map(message -> message + System.lineSeparator())
-				.reduce(String::concat).map(String::trim).map(message -> " " + message);
-	}
+    /**
+     * Creates an error message in case unwanted files are detected
+     *
+     * @param pathOfDirectory         Path to the Directory, at and below where
+     *                                unwanted nodes shall be detected
+     * @param nodeNameUnwantedNodeMap List of unwanted nodes
+     * @return Error message
+     */
+    public static Optional<String> getMessageForUnwantedNodesForAllFilesBelow(Path pathOfDirectory, Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
+        return JavaFile.readFromDirectory(pathOfDirectory, excludeMainMethod).stream()
+                .sorted(Comparator.comparing(JavaFile::getJavaFilePath))
+                .map(javaFile -> getMessageForUnwantedNodesForFileAt(javaFile.getJavaFilePath(),
+                        nodeNameUnwantedNodeMap, excludeMainMethod))
+                .filter(Optional::isPresent).map(Optional::get).map(message -> message + System.lineSeparator())
+                .reduce(String::concat).map(String::trim).map(message -> " " + message);
+    }
 }

--- a/src/main/java/de/tum/cit/ase/ares/api/ast/model/UnwantedNode.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/ast/model/UnwantedNode.java
@@ -43,7 +43,7 @@ public class UnwantedNode {
 	 *                               UnwantedNode objects)
 	 */
 	public static List<UnwantedNode> getUnwantedNodesInJavaFile(JavaFile javaFile,
-			Map<String, Class<? extends Node>> nodesDefinedAsUnwanted) {
+																Map<String, Class<? extends Node>> nodesDefinedAsUnwanted) {
 		return nodesDefinedAsUnwanted.keySet().stream()
 				.map(unwantedNodeName -> new UnwantedNode(javaFile, unwantedNodeName,
 						nodesDefinedAsUnwanted.get(unwantedNodeName)))
@@ -62,8 +62,8 @@ public class UnwantedNode {
 	 *         information (packed into UnwantedNode objects)
 	 */
 	public static Map<Path, List<UnwantedNode>> getUnwantedNodesForFileAt(Path pathOfJavaFile,
-			Map<String, Class<? extends Node>> nodesDefinedAsUnwanted) {
-		JavaFile javaFile = JavaFile.convertFromFile(pathOfJavaFile);
+																		  Map<String, Class<? extends Node>> nodesDefinedAsUnwanted, boolean excludeMainMethod) {
+		JavaFile javaFile = JavaFile.convertFromFile(pathOfJavaFile, excludeMainMethod);
 		if (javaFile == null) {
 			return Map.of();
 		}
@@ -113,9 +113,9 @@ public class UnwantedNode {
 	 * @return Error message
 	 */
 	public static Optional<String> getMessageForUnwantedNodesForFileAt(Path pathOfJavaFile,
-			Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap) {
-		Map<Path, List<UnwantedNode>> unwantedNodes = getUnwantedNodesForFileAt(pathOfJavaFile,
-				nodeNameUnwantedNodeMap);
+																	   Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
+		Map<Path, List<UnwantedNode>> unwantedNodes = getUnwantedNodesForFileAt(pathOfJavaFile, nodeNameUnwantedNodeMap,
+				excludeMainMethod);
 		if (unwantedNodes.isEmpty()) {
 			return Optional.empty();
 		}
@@ -132,11 +132,11 @@ public class UnwantedNode {
 	 * @return Error message
 	 */
 	public static Optional<String> getMessageForUnwantedNodesForAllFilesBelow(Path pathOfDirectory,
-			Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap) {
-		return JavaFile.readFromDirectory(pathOfDirectory).stream()
+																			  Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
+		return JavaFile.readFromDirectory(pathOfDirectory, excludeMainMethod).stream()
 				.sorted(Comparator.comparing(JavaFile::getJavaFilePath))
 				.map(javaFile -> getMessageForUnwantedNodesForFileAt(javaFile.getJavaFilePath(),
-						nodeNameUnwantedNodeMap))
+						nodeNameUnwantedNodeMap, excludeMainMethod))
 				.filter(Optional::isPresent).map(Optional::get).map(message -> message + System.lineSeparator())
 				.reduce(String::concat).map(String::trim).map(message -> " " + message);
 	}

--- a/src/test/java/de/tum/cit/ase/ares/integration/AstAssertionTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/AstAssertionTest.java
@@ -661,5 +661,18 @@ public class AstAssertionTest {
 									+ ":" + System.lineSeparator() + "  - For-Statement was found:"
 									+ System.lineSeparator() + "   - Between line 6 (column 3) and line 8 (column 3)"));
 		}
+
+		@TestTest
+		void test_testWithoutExcludeMain_Fail() {
+			String testWithoutExcludeMain_Fail = "testHasNoLoopsOutsideMainMethod_Fail";
+			tests.assertThatEvents().haveExactly(1,
+					testFailedWith(testWithoutExcludeMain_Fail, AssertionError.class,
+							"Unwanted statement found:" + System.lineSeparator() + " - In "
+									+ Path.of("src", "test", "java", "de", "tum", "cit", "ase", "ares", "integration",
+									"testuser", "subject", "structural", "astTestFiles", "excludeMain", "no",
+									"ClassWithNoLoopsOutsideMainMethod.java")
+									+ ":" + System.lineSeparator() + "  - For-Statement was found:"
+									+ System.lineSeparator() + "   - Between line 53 (column 3) and line 55 (column 3)"));
+		}
 	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/integration/AstAssertionTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/AstAssertionTest.java
@@ -638,4 +638,28 @@ public class AstAssertionTest {
 					"The 'level' is not set. Please use UnwantedNodesAssert.withLanguageLevel(LanguageLevel)."));
 		}
 	}
+
+	@Nested
+	@DisplayName("Exclude-Main-Test-Tests")
+	class ExcludeMainTestTests {
+
+		@TestTest
+		void test_testExcludeMain_Success() {
+			String testExcludeMain_Success = "testHasBelowNoLoopsOutsideMainMethod_Success";
+			tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testExcludeMain_Success));
+		}
+
+		@TestTest
+		void test_testExcludeMain_Fail() {
+			String testExcludeMain_Fail = "testHasBelowNoLoopsOutsideMainMethod_Fail";
+			tests.assertThatEvents().haveExactly(1,
+					testFailedWith(testExcludeMain_Fail, AssertionError.class,
+							"Unwanted statement found:" + System.lineSeparator() + " - In "
+									+ Path.of("src", "test", "java", "de", "tum", "cit", "ase", "ares", "integration",
+									"testuser", "subject", "structural", "astTestFiles", "excludeMain", "yes",
+									"ClassWithLoopOutsideMainMethod.java")
+									+ ":" + System.lineSeparator() + "  - For-Statement was found:"
+									+ System.lineSeparator() + "   - Between line 6 (column 3) and line 8 (column 3)"));
+		}
+	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/integration/testuser/AstAssertionUser.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/testuser/AstAssertionUser.java
@@ -436,4 +436,22 @@ public class AstAssertionUser {
 			UnwantedNodesAssert.assertThatProjectSources().hasNo(LoopType.ANY);
 		}
 	}
+
+	@Nested
+	@DisplayName("Exclude-Main-Tests")
+	class ExcludeErrorTests {
+		@Test
+		void testHasBelowNoLoopsOutsideMainMethod_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".excludeMain.no")
+					.excludeMainMethod().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(LoopType.ANY);
+		}
+
+		@Test
+		void testHasBelowNoLoopsOutsideMainMethod_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".excludeMain.yes")
+					.excludeMainMethod().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(LoopType.ANY);
+		}
+	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/integration/testuser/AstAssertionUser.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/testuser/AstAssertionUser.java
@@ -453,5 +453,12 @@ public class AstAssertionUser {
 					.excludeMainMethod().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
 					.hasNo(LoopType.ANY);
 		}
+
+		@Test
+		void testHasNoLoopsOutsideMainMethod_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".excludeMain.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(LoopType.ANY);
+		}
 	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/integration/testuser/subject/structural/astTestFiles/excludeMain/no/ClassWithNoLoopsOutsideMainMethod.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/testuser/subject/structural/astTestFiles/excludeMain/no/ClassWithNoLoopsOutsideMainMethod.java
@@ -1,0 +1,57 @@
+package de.tum.cit.ase.ares.integration.testuser.subject.structural.astTestFiles.excludeMain.no;
+
+public class ClassWithNoLoopsOutsideMainMethod {
+
+	public void ifStatement() {
+		int x = 3;
+		if (x == 1) {
+			System.out.println("Hello");
+		} else if (x == 0) {
+			System.out.println("World");
+		} else {
+			System.out.println("!");
+		}
+	}
+
+	public void ifExpression() {
+		int x = 3;
+		System.out.println(x == 1 ? "Hello" : (x == 0 ? "World" : "!"));
+	}
+
+	public void switchStatement() {
+		String output;
+		switch (3) {
+		case 1:
+			output = "Hello";
+			break;
+		case 0:
+			output = "World";
+			break;
+		default:
+			output = "!";
+			break;
+		}
+		System.out.println(output);
+	}
+
+	public void assertStatement() {
+		assert 3 == 0;
+	}
+
+	public void throwStatement() throws Exception {
+		throw new Exception("This is a checked exception.");
+	}
+
+	public void catchStatement() {
+		try {
+			throwStatement();
+		} catch (Exception e) {
+		}
+	}
+
+	public static void main(String[] args) {
+		for (int i = 0; i < args.length; i++) {
+			int x = i;
+		}
+	}
+}

--- a/src/test/java/de/tum/cit/ase/ares/integration/testuser/subject/structural/astTestFiles/excludeMain/yes/ClassWithLoopOutsideMainMethod.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/testuser/subject/structural/astTestFiles/excludeMain/yes/ClassWithLoopOutsideMainMethod.java
@@ -1,0 +1,16 @@
+package de.tum.cit.ase.ares.integration.testuser.subject.structural.astTestFiles.excludeMain.yes;
+
+public class ClassWithLoopOutsideMainMethod {
+
+	public void forLoop() {
+		for (int i = 0; i < 3; i++) {
+			System.out.println("Hello World");
+		}
+	}
+
+	public static void main(String[] args) {
+		if (args.length > 0) {
+			System.out.println("Hello World");
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Improved the current AST functionality to allow instructors to exclude the Main method from AST checks. This change ensures that when students use for loops or recursion within the Main method for testing purposes, their tests will still pass.


### Description
<!-- Describe your changes in detail -->
- Added a method, `excludeMain()`, to avoid AST checking of the Main method by removing it from the AST.
- The functionality is controlled via a `boolean` flag which is set to false by default.
- The boolean flag is passed down to `JavaFile` and removes the node associated with the `Main` method from the created `CompilationUnit` (AST).

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Programming Exercise with Ares

1. Run the `AstAssertionTests` and ensure that they pass.
2. Create an example exercise template with a main method, but include an `Unwanted type` that you want to detect.
3. Test with `UnwantedNodesAssert` that the method fails with an error message similar to the one in the screenshot below.
4. Now, include the `excludeMain()` method, and the test will pass since the main method won’t be considered as an Unwanted type.
5. Here’s an example test:
```java
@Test
void testHasBelowNoLoopsOutsideMainMethod_Success() {
	UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".excludeMain.no")
		        .excludeMainMethod()
                        .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
			.hasNo(LoopType.ANY);
}
```

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/ls1intum/Ares2/assets/92453703/c0cc3656-ba58-4e8d-9a0d-5fae77fbecb9)