### PR TITLE
fix(aspectj): remove trailing '||' in thread system pointcut

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJThreadSystemPointcutDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJThreadSystemPointcutDefinitions.aj
@@ -48,7 +48,7 @@ public aspect JavaAspectJThreadSystemPointcutDefinitions {
             call(* java.util.concurrent.ExecutorCompletionService+.submit(..)) ||
             call(* java.lang.Thread+.startVirtualThread(..)) ||
             call(* java.lang.Thread$Builder+.start(..)) ||
-            call(* java.lang.Thread$Builder$OfPlatform+.start(..)) ||
+            call(* java.lang.Thread$Builder$OfPlatform+.start(..))
             );
 
     pointcut threadCreateMethodsWithoutParameters(): (


### PR DESCRIPTION
Summary:

Fixes an AspectJ syntax error in the thread system pointcut caused by a trailing logical OR operator (`||`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a critical monitoring issue that was preventing proper detection of thread creation operations. The monitoring system has been corrected to ensure consistent and complete tracking of all thread initialization methods and lifecycle events. This resolves incomplete thread operation monitoring and improves overall system visibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->