### PR TITLE
Review documentation for consistency, spelling, grammar, and readability

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,13 +22,8 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'adopt'
-
-      - name: Install Maven
-        run: |
-          sudo rm -rf /usr/bin/mvn
-          sudo wget -q -O - "https://apache.osuosl.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz" | sudo tar xzf - -C /usr/share
-          sudo ln -s /usr/share/apache-maven-3.9.8/bin/mvn /usr/bin/mvn
+          distribution: 'temurin'
+          cache: 'maven'
 
       - name: Spotless Check
         run: mvn spotless:check

--- a/docs/HowToMakeAProjectAnAresProject.md
+++ b/docs/HowToMakeAProjectAnAresProject.md
@@ -4,6 +4,8 @@
 > **Scope:** The `build.gradle` and `pom.xml` files.
 > **Ares Version:** 2.0.1-Beta6
 
+> **Note:** This guide is a **setup guide**. It covers adding the Ares dependency, attaching the agent, and configuring the build tool so that Ares can run. For writing security policies that control what student code can do, see the [Security Policy Manual](policy/SecurityPolicyManual.md).
+
 **Related documentation:**
 - [Security Policy Manual](policy/SecurityPolicyManual.md), which explains how to write a security policy YAML file
 - [Security Policy Reader and Director Manual](policy/SecurityPolicyReaderAndDirectorManual.md), which describes the internal processing pipeline
@@ -54,6 +56,8 @@ This manual covers the configuration steps for both Gradle and Maven.
 ---
 
 ## 3. Add Ares dependencies and agent setup
+
+Three steps are **required** regardless of build tool: (1) configure the repository so Gradle or Maven can download Ares; (2) add the Ares library as a dependency; and (3) attach the Ares agent to the test JVM. Blockquoted tips (marked `>`) throughout this section describe optional configuration that can be skipped on a first setup.
 
 ### 3.1 Gradle (recommended)
 

--- a/docs/aop/BlockCommandSystemAccessAOP.md
+++ b/docs/aop/BlockCommandSystemAccessAOP.md
@@ -127,7 +127,7 @@ Ares automatically monitors command system operations by intercepting specific J
 - **Byte Buddy (Instrumentation Mode)**: Automatically adds security checks when Java loads classes (called bytecode manipulation).
 - **AspectJ (AspectJ Mode)**: Automatically adds security checks in a second compilation step (called weaving).
 
-Both implementations set up "checkpoints" that activate **before** the command operation actually happens, giving Ares a chance to verify whether the operation should be allowed or blocked. The validation logic is aligned, and the command pointcuts are kept in sync between AspectJ and instrumentation.
+Both implementations set up "checkpoints" that activate **before** the command operation actually happens, giving Ares a chance to verify whether the operation should be allowed or blocked. The validation logic is aligned. The command pointcuts are kept in sync between AspectJ and instrumentation.
 
 ---
 
@@ -437,7 +437,9 @@ The security validator performs a **series of checks** to decide whether the com
 
 **1. Purpose**
 
-Verify that command system security monitoring is turned on. This check ensures that Ares only performs security validations when explicitly enabled. Without this check, the security system would either always run (causing unnecessary overhead) or never run (leaving the system unprotected). The configuration-based approach allows instructors to enable or disable security monitoring as needed.
+Verify that command system security monitoring is turned on. This check ensures that Ares only performs security validations when explicitly enabled.
+
+Without this check, the security system would either always run (causing unnecessary overhead) or never run (leaving the system unprotected). The configuration-based approach allows instructors to enable or disable security monitoring as needed.
 
 **2. How it works**
 
@@ -494,7 +496,9 @@ Configuration loaded → 🌕 **Continue to 5.2.2**
 
 **1. Purpose**
 
-Walk through the call history to find if restricted student code triggered the command operation. This is like following breadcrumbs backwards to see how we got here. This is the core security check that distinguishes between legitimate framework operations and potentially malicious student code (e.g., trying to execute system commands).
+Walk through the call history to find if restricted student code triggered the command operation. This is like following breadcrumbs backwards to see how we got here.
+
+This is the core security check that distinguishes between legitimate framework operations and potentially malicious student code (e.g., trying to execute system commands).
 
 > 💡 **Analogy:** Like a detective following footprints backwards:
 > - **Crime Scene:** `Runtime.getRuntime().exec("rm -rf /")` [we are here now]

--- a/docs/aop/BlockFileSystemAccessAOP.md
+++ b/docs/aop/BlockFileSystemAccessAOP.md
@@ -20,11 +20,11 @@
 3. [Ares 2 AOP File System Access Control: Student Code Triggers the Access Control Check](#3-ares-2-aop-file-system-access-control-student-code-triggers-the-access-control-check)
 4. [Ares 2 AOP File System Access Control: Collected Information About the File Access](#4-ares-2-aop-file-system-access-control-collected-information-about-the-file-access)
    - [4.1 What Is The Signature Of The Monitored File System Method?](#41-what-is-the-signature-of-the-monitored-file-system-method)
-   - [4.2 What Are The Attribuet Values Of The Object Of The Monitored File System Method?](#42-what-are-the-attribuet-values-of-the-object-of-the-monitored-file-system-method)
+   - [4.2 What Are The Attribute Values Of The Object Of The Monitored File System Method?](#42-what-are-the-attribute-values-of-the-object-of-the-monitored-file-system-method)
    - [4.3 What Are The Parameter Values Of The Monitored File System Method?](#43-what-are-the-parameter-values-of-the-monitored-file-system-method)
    - [4.4 Which Information Is Passed To The Respective Security Validator?](#44-which-information-is-passed-to-the-respective-security-validator)
 5. [Ares 2 AOP File System Access Control: Blocking Or Allowing The File Access](#5-ares-2-aop-file-system-access-control-blocking-or-allowing-the-file-access)
-   - [5.1 Check 1: Is A Respective AOP Mode Enabled Or Is AOP Fully Disabeled?](#51-check-1-is-a-respective-aop-mode-enabled-or-is-aop-fully-disabeled)
+   - [5.1 Check 1: Is A Respective AOP Mode Enabled Or Is AOP Fully Disabled?](#51-check-1-is-a-respective-aop-mode-enabled-or-is-aop-fully-disabled)
    - [5.2 Check 2: Is the Caller Of The Monitored File System Method The Monitored Student Code?](#52-check-2-is-the-caller-of-the-monitored-file-system-method-the-monitored-student-code)
      - [5.2.1 Load Configuration](#521-load-configuration)
      - [5.2.2 Analyze the Call Chain](#522-analyze-the-call-chain)
@@ -75,7 +75,7 @@ This document explains how Ares 2 decides whether student code may access the fi
 1. Student calls `Files.readString("/etc/passwd")`
 2. Ares intercepts the call (AOP) and checks:
    - Does this come from student code? ✓ Yes
-   - Is `/etc/passwd` in the allowed list? ✗ No
+   - Is `/etc/passwd` in the allowlist? ✗ No
 3. Ares blocks and throws a meaningful exception
 
 ---
@@ -99,7 +99,7 @@ This document explains how Ares 2 decides whether student code may access the fi
 <a id="11-how-does-the-uml-activity-diagram-look-like"></a>
 ## 1.1 How Does The UML Activity Diagram look like?
 
-Below is a general overview of the process for deciding whether to allow or block file access as an UML activity diagram. Throughout this document, you will find the following symbols:
+Below is a general overview of the process for deciding whether to allow or block file access as a UML activity diagram. Throughout this document, you will find the following symbols:
 - **🔴 Red** = File access blocked (security policy violation detected)
 - **🌕 Yellow** = Intermediate condition met → continue to the next verification step
 - **🟢 Green** = File access permitted (no security policy violation detected)
@@ -177,7 +177,7 @@ Plain-language summary: if student code triggers a monitored file method and the
 
 **Access is ALLOWED 🟢 if ANY of the aforementioned conditions do not apply**
 
-Summarising this, Ares trusts code when: 
+In summary, Ares trusts code when: 
 - It is located outside of the `restrictedPackage`
 - It is located inside of the `restrictedPackage`, but its classes are listed in `allowedListedClasses` within the student package
 - It is listed as Ares internal code
@@ -690,8 +690,8 @@ public void checkFileSystemInteraction(
 
 ---
 
-<a id="42-what-are-the-attribuet-values-of-the-object-of-the-monitored-file-system-method"></a>
-## 4.2 What Are The Attribuet Values Of The Object Of The Monitored File System Method?
+<a id="42-what-are-the-attribute-values-of-the-object-of-the-monitored-file-system-method"></a>
+## 4.2 What Are The Attribute Values Of The Object Of The Monitored File System Method?
 
 **1. What Information Do We Collect:**
 
@@ -881,8 +881,8 @@ The security validator performs a **series of checks** to decide whether the fil
 
 ---
 
-<a id="51-check-1-is-a-respective-aop-mode-enabled-or-is-aop-fully-disabeled"></a>
-## 5.1 Check 1: Is A Respective AOP Mode Enabled Or Is AOP Fully Disabeled?
+<a id="51-check-1-is-a-respective-aop-mode-enabled-or-is-aop-fully-disabled"></a>
+## 5.1 Check 1: Is A Respective AOP Mode Enabled Or Is AOP Fully Disabled?
 
 **1. Purpose**
 

--- a/docs/architecture/BlockFileSystemAccessArchitecture.md
+++ b/docs/architecture/BlockFileSystemAccessArchitecture.md
@@ -5,7 +5,7 @@
 ## Table of Contents
 
 1. [Ares 2 Architecture File System Access Control: High-Level Overview](#1-ares-2-architecture-file-system-access-control-high-level-overview)
-   - [1.1 How Does The UML Activity Diagram look like?](#11-how-does-the-uml-activity-diagram-look-like)
+   - [1.1 What Does the UML Activity Diagram Look Like?](#11-what-does-the-uml-activity-diagram-look-like)
    - [1.2 What Is Architecture Testing?](#12-what-is-architecture-testing)
    - [1.3 Which Architecture Modes / Implementations Are There?](#13-which-architecture-modes--implementations-are-there)
    - [1.4 What Are The Internal Configuration Settings?](#14-what-are-the-internal-configuration-settings)
@@ -82,10 +82,10 @@ This document explains how Ares 2 decides whether student code may access the fi
 
 ---
 
-<a id="11-how-does-the-uml-activity-diagram-look-like"></a>
-## 1.1 How Does The UML Activity Diagram look like?
+<a id="11-what-does-the-uml-activity-diagram-look-like"></a>
+## 1.1 What Does the UML Activity Diagram Look Like?
 
-Below is a general overview of the process for deciding whether to allow or block file access as an UML activity diagram. Throughout this document, you will find the following symbols:
+Below is a general overview of the process for deciding whether to allow or block file access as a UML activity diagram. Throughout this document, you will find the following symbols:
 - **🔴 Red** = File access blocked (security policy violation detected)
 - **🌕 Yellow** = Intermediate condition met → continue to the next verification step
 - **🟢 Green** = File access permitted (no security policy violation detected)
@@ -180,7 +180,7 @@ Instructors define architecture policies, and Ares 2 translates them into the fo
 - 🔴 AssertionError thrown → Security violation detected in code structure
 - 🟢 No violations found → Code passes architecture analysis
 
-Summarising this, Ares trusts code when: 
+In summary, Ares trusts code when: 
 - It is located outside of the `restrictedPackage`
 - It accesses classes that are in the `allowedPackages` list
 - It is listed as Ares internal code

--- a/docs/architecture/BlockThreadSystemAccessArchitecture.md
+++ b/docs/architecture/BlockThreadSystemAccessArchitecture.md
@@ -5,7 +5,7 @@
 1. [High-Level Overview](#1-high-level-overview)
    - [1.1 Architecture Analysis Approach](#11-architecture-analysis-approach)
    - [1.2 Configuration Settings](#12-configuration-settings)
-   - [1.3 Summary: When Is Thread Creation Blocked?](#13-summary-when-is-thread-creation-blocked)
+   - [1.3 Summary: When Is Thread Manipulation Blocked?](#13-summary-when-is-thread-manipulation-blocked)
    - [1.4 What Code Is Trusted vs. Restricted?](#14-what-code-is-trusted-vs-restricted)
 2. [Ares Monitors Thread Methods](#2-ares-monitors-thread-methods)
    - [2.1 THREAD SYSTEM - CREATE Operations (With Parameters)](#21-thread-system---create-operations-with-parameters)
@@ -47,7 +47,7 @@ Architecture testing validates that code follows specific structural rules by an
 **Two Analysis Frameworks:**
 
 ### **ArchUnit (Static Analysis)**
-- **Type**: Pure static analysis using Archunit framework
+- **Type**: Pure static analysis using ArchUnit framework
 - **Strength**: Fast, no call graph needed
 - **Method**: Analyzes class dependencies and method calls in compiled bytecode
 - **Use Case**: Detecting direct and transitive method access patterns to thread creation APIs
@@ -90,12 +90,12 @@ Security policies are configured through settings that instructors can adjust:
 
 ---
 
-## 1.3 Summary: When Is Thread Creation Blocked?
+## 1.3 Summary: When Is Thread Manipulation Blocked?
 
 Access is **BLOCKED** 🔴 when **ALL** conditions are true:
 
 1. **Architecture Mode Enabled**: `architectureMode == "ARCHUNIT"` or `architectureMode == "WALA"`
-2. **Student Code Contains Thread Creation Calls**: Analysis detects method calls to thread creation APIs
+2. **Student Code Contains Thread Manipulation Calls**: Analysis detects method calls to thread manipulation APIs
 3. **Calls Are Reachable**: The forbidden methods can be reached from student code (directly or transitively)
 4. **Not in Allowed Packages**: The accessed classes are not in the `allowedPackages` list
 
@@ -103,7 +103,7 @@ Access is **BLOCKED** 🔴 when **ALL** conditions are true:
 
 **Key Differences from AOP:**
 - 🔴 Detected at analysis time (before execution), not at runtime
-- 🔴 Blocks ALL thread creation attempts, not based on quotas or thread classes
+- 🔴 Blocks ALL thread manipulation attempts, not based on quotas or thread classes
 - 🔴 Reports potential violations, even if the code path is never executed
 - 🔴 No distinction between different thread types (all treated equally)
 
@@ -122,7 +122,7 @@ Access is **BLOCKED** 🔴 when **ALL** conditions are true:
 
 **Restricted Code (Subject to Security Checks):**
 - All code within `restrictedPackage`
-- All classes that call thread creation methods from the forbidden lists
+- All classes that call thread manipulation methods from the forbidden lists
 
 **Security Assumptions:** 
 - Student code is compiled and available as `.class` files

--- a/docs/policy/SecurityPolicyManual.md
+++ b/docs/policy/SecurityPolicyManual.md
@@ -186,6 +186,8 @@ The interaction between test annotations (`@Public`, `@Hidden`, `@Test`, `@Publi
 
 When you run the tests, Ares 2 will automatically enforce the security policy. If student code tries to do something not explicitly permitted, the test fails with a clear error message.
 
+> **What's next:** The Quick Start above covers the minimum to get up and running. The sections below explain the security model in detail and describe every permission type you can configure.
+
 ---
 
 ## 6. Understanding Security Policies

--- a/docs/policy/SecurityPolicyReaderAndDirectorManual.md
+++ b/docs/policy/SecurityPolicyReaderAndDirectorManual.md
@@ -15,7 +15,7 @@
 1. [Prerequisites](#1-prerequisites)
 2. [Purpose — What Problem Does This Solve?](#2-purpose--what-problem-does-this-solve)
 3. [Architecture Overview](#3-architecture-overview)
-4. [The User Input, Security Policy YAML File](#4-the-user-input--security-policy-yaml-file)
+4. [The User Input, Security Policy YAML File](`#4-the-user-input-security-policy-yaml-file`)
 5. [Reading the Policy — The `reader` Package](#5-reading-the-policy--the-reader-package)
    - [5.1. SecurityPolicyReader (Abstract Class)](#51-securitypolicyreader-abstract-class)
    - [5.2. SecurityPolicyYAMLReader (Concrete Class)](#52-securitypolicyyamlreader-concrete-class)

--- a/docs/policy/SecurityPolicyReaderAndDirectorManual.md
+++ b/docs/policy/SecurityPolicyReaderAndDirectorManual.md
@@ -13,16 +13,16 @@
 ## Table of Contents
 
 1. [Prerequisites](#1-prerequisites)
-2. [Purpose, What Problem Does This Solve?](#2-purpose--what-problem-does-this-solve)
+2. [Purpose — What Problem Does This Solve?](#2-purpose--what-problem-does-this-solve)
 3. [Architecture Overview](#3-architecture-overview)
 4. [The User Input, Security Policy YAML File](#4-the-user-input--security-policy-yaml-file)
-5. [Reading the Policy, The `reader` Package](#5-reading-the-policy--the-reader-package)
+5. [Reading the Policy — The `reader` Package](#5-reading-the-policy--the-reader-package)
    - [5.1. SecurityPolicyReader (Abstract Class)](#51-securitypolicyreader-abstract-class)
    - [5.2. SecurityPolicyYAMLReader (Concrete Class)](#52-securitypolicyyamlreader-concrete-class)
-6. [Directing Test-Case Creation, The `director` Package](#6-directing-test-case-creation--the-director-package)
+6. [Directing Test-Case Creation — The `director` Package](#6-directing-test-case-creation--the-director-package)
    - [6.1. SecurityPolicyDirector (Abstract Class)](#61-securitypolicydirector-abstract-class)
    - [6.2. SecurityPolicyJavaDirector (Concrete Class)](#62-securitypolicyjavadirector-concrete-class)
-7. [Orchestration, SecurityPolicyReaderAndDirector](#7-orchestration--securitypolicyreaderanddirector)
+7. [Orchestration — SecurityPolicyReaderAndDirector](#7-orchestration--securitypolicyreaderanddirector)
    - [7.1. Construction](#71-construction)
    - [7.2. Three-Step Workflow](#72-three-step-workflow)
    - [7.3. Null-Safety Strategy](#73-null-safety-strategy)
@@ -43,7 +43,7 @@
 
 ---
 
-## 2. Purpose, What Problem Does This Solve?
+## 2. Purpose — What Problem Does This Solve?
 
 When students submit programming exercises, instructors need to make sure the submitted code does **not** perform dangerous operations (e.g. deleting files, opening network connections, executing shell commands). Ares 2 automates this by:
 
@@ -112,7 +112,9 @@ The field names are deliberately chosen to read like English sentences (e.g. `re
 
 ---
 
-## 5. Reading the Policy, The `reader` Package
+## 5. Reading the Policy — The `reader` Package
+
+The **reader** is responsible for loading the YAML policy file and turning it into a `SecurityPolicy` Java object. The reader is selected at runtime based on the file extension — for `.yaml` / `.yml` files this is `SecurityPolicyYAMLReader`. If you add a new file format in the future, you only implement `readSecurityPolicyFrom` and add a new branch in the factory method.
 
 ### 5.1. `SecurityPolicyReader` (Abstract Class)
 
@@ -143,7 +145,9 @@ This design makes it trivial to add, say, a `SecurityPolicyJSONReader` in the fu
 
 ---
 
-## 6. Directing Test-Case Creation, The `director` Package
+## 6. Directing Test-Case Creation — The `director` Package
+
+The **director** receives the parsed `SecurityPolicy` and orchestrates the multi-step process of generating, writing, and executing security tests. Think of the reader as fetching the instructions and the director as carrying them out: the reader says "here is what the policy contains," and the director decides which test toolchain to build and how to configure it.
 
 ### 6.1. `SecurityPolicyDirector` (Abstract Class)
 
@@ -196,7 +200,7 @@ This design makes it trivial to add, say, a `SecurityPolicyPythonDirector` in th
 
 ---
 
-## 7. Orchestration, `SecurityPolicyReaderAndDirector`
+## 7. Orchestration — `SecurityPolicyReaderAndDirector`
 
 This is the **entry-point class** that ties together reading, directing, and test-case management. It is the main public API that instructors and automated grading systems interact with. The class implements two important roles:
 - A **Facade**, exposing a simple three-method public interface (`create`, `write`, `execute`) that hides the complexity of reader selection, policy parsing, director selection, and factory configuration.

--- a/docs/securitytest/TestCaseFactoryAndBuilderManual.md
+++ b/docs/securitytest/TestCaseFactoryAndBuilderManual.md
@@ -71,7 +71,7 @@ Given a parsed `SecurityPolicy`, this package must:
 4. **Write** the generated test-case source files to disk.
 5. **Execute** the test cases — first the static architecture checks, then the dynamic AOP enforcement.
 
-Without this package, Ares would know *what* to enforce but could not turn that knowledge into runnable tests.
+Without this package, Ares would know *what* to enforce but could not turn that knowledge into runnable tests. The next section describes how the package is organised to fulfill this responsibility.
 
 ---
 
@@ -294,6 +294,8 @@ The first five parameters (`creator`, `writer`, `executer`, `essentialDataReader
 
 **What it does step by step:**
 
+Each invocation proceeds through two phases — extraction (reading class data from disk) and preparation (computing permissions) — before generating the final test-case objects:
+
 1. **Extraction (cached):**
    - Computes the `classPath` from the `BuildMode` (Maven: `target/classes`, Gradle: `build/classes/java/main`).
    - Imports `JavaClasses` via the `ArchitectureMode` (ArchUnit's `ClassFileImporter`).
@@ -429,6 +431,8 @@ The `FileTools.createThreePartedFormatStringFile(...)` utility handles template 
 |---|---|
 | **Implements** | `Executer` |
 | **Role** | Configures the runtime agent and then executes all generated test cases. |
+
+The execution happens in three ordered steps: agent configuration first, architecture tests second, AOP tests third.
 
 **What it does step by step:**
 

--- a/src/main/java/de/tum/cit/ase/ares/api/Policy.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/Policy.java
@@ -61,8 +61,8 @@ public @interface Policy {
 	 * security restrictions (UNPROTECTED mode).
 	 * </p>
 	 *
-	 * @return {@code true} to keep security checks active (default),
-	 *         {@code false} to deactivate Ares security checks.
+	 * @return {@code true} to keep security checks active (default), {@code false}
+	 *         to deactivate Ares security checks.
 	 */
 	boolean activated() default true;
 }

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/JavaAOPTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/JavaAOPTestCase.java
@@ -167,14 +167,19 @@ public class JavaAOPTestCase extends AOPTestCase {
 			@Nonnull String architectureMode, @Nonnull String aopMode) {
 		try {
 			// JavaAOPTestCaseSettings exists as TWO separate classes at runtime:
-			//   - one loaded by the BOOTSTRAP classloader (read by Byte Buddy / Instrumentation
-			//     advice, since JDK-rewritten classes can only see bootstrap-loaded classes)
-			//   - one loaded by the APPLICATION classloader (read by AspectJ aspects, which
-			//     resolve their own classes through the same loader that loaded the aspect)
-			// Each AOP mode reads its own copy. To keep both modes coherent, the central writer
-			// updates BOTH copies for every configuration change. Resolution order is bootstrap
-			// first, then application; either may be absent in a given mode (e.g. application
-			// loader has no JavaAOPTestCaseSettings if Byte Buddy didn't inject the class), and
+			// - one loaded by the BOOTSTRAP classloader (read by Byte Buddy /
+			// Instrumentation
+			// advice, since JDK-rewritten classes can only see bootstrap-loaded classes)
+			// - one loaded by the APPLICATION classloader (read by AspectJ aspects, which
+			// resolve their own classes through the same loader that loaded the aspect)
+			// Each AOP mode reads its own copy. To keep both modes coherent, the central
+			// writer
+			// updates BOTH copies for every configuration change. Resolution order is
+			// bootstrap
+			// first, then application; either may be absent in a given mode (e.g.
+			// application
+			// loader has no JavaAOPTestCaseSettings if Byte Buddy didn't inject the class),
+			// and
 			// missing copies are silently skipped.
 			setSettingFieldOnLoader(adviceSetting, value, null);
 			setSettingFieldOnLoader(adviceSetting, value, Thread.currentThread().getContextClassLoader());
@@ -204,28 +209,31 @@ public class JavaAOPTestCase extends AOPTestCase {
 	}
 
 	/**
-	 * Sets a single static field of JavaAOPTestCaseSettings as resolved by the given classloader.
-	 *
-	 * <p>Updates exactly the copy of JavaAOPTestCaseSettings reachable from {@code loader}. When
-	 * {@code loader} is {@code null}, the bootstrap classloader's copy is targeted (read by
-	 * Byte Buddy / Instrumentation advice). When {@code loader} is the application classloader,
-	 * the AspectJ-visible copy is targeted. If the requested copy does not exist in this loader
-	 * (e.g. AspectJ-only run with no Byte Buddy injection, or vice versa) the call silently
-	 * returns rather than failing.
+	 * Sets a single static field of JavaAOPTestCaseSettings as resolved by the
+	 * given classloader.
+	 * <p>
+	 * Updates exactly the copy of JavaAOPTestCaseSettings reachable from
+	 * {@code loader}. When {@code loader} is {@code null}, the bootstrap
+	 * classloader's copy is targeted (read by Byte Buddy / Instrumentation advice).
+	 * When {@code loader} is the application classloader, the AspectJ-visible copy
+	 * is targeted. If the requested copy does not exist in this loader (e.g.
+	 * AspectJ-only run with no Byte Buddy injection, or vice versa) the call
+	 * silently returns rather than failing.
 	 *
 	 * @param adviceSetting field name to update
 	 * @param value         new value (may be null)
-	 * @param loader        the classloader that should resolve JavaAOPTestCaseSettings; null = bootstrap
+	 * @param loader        the classloader that should resolve
+	 *                      JavaAOPTestCaseSettings; null = bootstrap
 	 */
 	private static void setSettingFieldOnLoader(@Nonnull String adviceSetting, @Nullable Object value,
-			@Nullable ClassLoader loader)
-			throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
+			@Nullable ClassLoader loader) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
 		Class<?> adviceSettingsClass;
 		try {
 			adviceSettingsClass = Class.forName("de.tum.cit.ase.ares.api.aop.java.JavaAOPTestCaseSettings", true,
 					loader);
 		} catch (ClassNotFoundException missing) {
-			// This loader does not see JavaAOPTestCaseSettings — that AOP mode is inactive in
+			// This loader does not see JavaAOPTestCaseSettings — that AOP mode is inactive
+			// in
 			// the current run, so there is nothing to update. Bail out silently.
 			return;
 		}

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/JavaInstrumentationAgent.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/JavaInstrumentationAgent.java
@@ -74,7 +74,8 @@ public class JavaInstrumentationAgent {
 				JavaInstrumentationBindingDefinitions::createConnectNetworkMethodBinding);
 		installAgentBuilder(inst, unsafeFactory, JavaInstrumentationPointcutDefinitions.methodsWhichCanSendToNetwork,
 				JavaInstrumentationBindingDefinitions::createSendNetworkMethodBinding);
-		installAgentBuilder(inst, unsafeFactory, JavaInstrumentationPointcutDefinitions.methodsWhichCanReceiveFromNetwork,
+		installAgentBuilder(inst, unsafeFactory,
+				JavaInstrumentationPointcutDefinitions.methodsWhichCanReceiveFromNetwork,
 				JavaInstrumentationBindingDefinitions::createReceiveNetworkMethodBinding);
 
 		installAgentBuilder(inst, unsafeFactory, JavaInstrumentationPointcutDefinitions.methodsWhichCanReadFiles,
@@ -95,7 +96,8 @@ public class JavaInstrumentationAgent {
 				JavaInstrumentationBindingDefinitions::createConnectNetworkConstructorBinding);
 		installAgentBuilder(inst, unsafeFactory, JavaInstrumentationPointcutDefinitions.methodsWhichCanSendToNetwork,
 				JavaInstrumentationBindingDefinitions::createSendNetworkConstructorBinding);
-		installAgentBuilder(inst, unsafeFactory, JavaInstrumentationPointcutDefinitions.methodsWhichCanReceiveFromNetwork,
+		installAgentBuilder(inst, unsafeFactory,
+				JavaInstrumentationPointcutDefinitions.methodsWhichCanReceiveFromNetwork,
 				JavaInstrumentationBindingDefinitions::createReceiveNetworkConstructorBinding);
 	}
 
@@ -139,18 +141,17 @@ public class JavaInstrumentationAgent {
 								ClassFileLocator.ForClassLoader.read(JavaInstrumentationAdviceAbstractToolbox.class))));
 
 				// Step 3: Load target value types (used by concrete toolboxes)
-				injectClassesSafely(classInjector,
-						Map.ofEntries(
-								Map.entry(FileTarget.class.getName(),
-										ClassFileLocator.ForClassLoader.read(FileTarget.class)),
-								Map.entry(NetworkTarget.class.getName(),
-										ClassFileLocator.ForClassLoader.read(NetworkTarget.class)),
-								Map.entry(ThreadTarget.class.getName(),
-										ClassFileLocator.ForClassLoader.read(ThreadTarget.class)),
-								Map.entry(CommandTarget.class.getName(),
-										ClassFileLocator.ForClassLoader.read(CommandTarget.class))));
+				injectClassesSafely(classInjector, Map.ofEntries(
+						Map.entry(FileTarget.class.getName(), ClassFileLocator.ForClassLoader.read(FileTarget.class)),
+						Map.entry(NetworkTarget.class.getName(),
+								ClassFileLocator.ForClassLoader.read(NetworkTarget.class)),
+						Map.entry(ThreadTarget.class.getName(),
+								ClassFileLocator.ForClassLoader.read(ThreadTarget.class)),
+						Map.entry(CommandTarget.class.getName(),
+								ClassFileLocator.ForClassLoader.read(CommandTarget.class))));
 
-				// Step 4: Load concrete toolbox implementations (depend on abstract toolbox and targets)
+				// Step 4: Load concrete toolbox implementations (depend on abstract toolbox and
+				// targets)
 				injectClassesSafely(classInjector,
 						Map.ofEntries(
 								Map.entry(JavaInstrumentationAdviceFileSystemToolbox.class.getName(),
@@ -224,7 +225,8 @@ public class JavaInstrumentationAgent {
 			new AgentBuilder.Default()
 					// Ignore ByteBuddy's own classes to avoid infinite recursion
 					.ignore(ElementMatchers.nameStartsWith("net.bytebuddy."))
-					// Ignore deepest JDK internals that must never be instrumented. sun.nio.ch.*Impl
+					// Ignore deepest JDK internals that must never be instrumented.
+					// sun.nio.ch.*Impl
 					// classes are intentionally NOT excluded here so SocketChannelImpl,
 					// DatagramChannelImpl, AsynchronousSocketChannel impls remain instrumentable
 					// for their connect / send / receive methods which the abstract NIO base

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/CommandTarget.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/CommandTarget.java
@@ -6,10 +6,10 @@ import javax.annotation.Nullable;
 /**
  * Internal value type representing a resolved command target.
  * <p>
- * Description: Pairs a nullable command name with an argument array.
- * Used throughout the toolbox as the canonical representation of a command
- * invocation, regardless of whether it originated from a {@code String},
- * a {@code String[]}, or a {@code List<String>}.
+ * Description: Pairs a nullable command name with an argument array. Used
+ * throughout the toolbox as the canonical representation of a command
+ * invocation, regardless of whether it originated from a {@code String}, a
+ * {@code String[]}, or a {@code List<String>}.
  * <p>
  * Design Rationale: Extracted from
  * {@link JavaInstrumentationAdviceCommandSystemToolbox} into its own top-level

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/FileTarget.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/FileTarget.java
@@ -9,9 +9,9 @@ import javax.annotation.Nullable;
  * Internal value type representing a resolved file system target.
  * <p>
  * Description: Wraps a nullable {@link Path} instance. Used throughout the
- * toolbox as the canonical representation of a file system endpoint,
- * regardless of whether it originated from a {@link Path}, a {@link java.io.File},
- * a {@link java.net.URI}, a {@link java.net.URL}, or a {@link String}.
+ * toolbox as the canonical representation of a file system endpoint, regardless
+ * of whether it originated from a {@link Path}, a {@link java.io.File}, a
+ * {@link java.net.URI}, a {@link java.net.URL}, or a {@link String}.
  * <p>
  * Design Rationale: Extracted from
  * {@link JavaInstrumentationAdviceFileSystemToolbox} into its own top-level
@@ -30,8 +30,8 @@ public record FileTarget(@Nullable Path path) {
 	/**
 	 * Returns a human-readable string representation of this file target.
 	 * <p>
-	 * Description: Returns the string form of the path, or {@code <unknown>}
-	 * if the path is {@code null}.
+	 * Description: Returns the string form of the path, or {@code <unknown>} if the
+	 * path is {@code null}.
 	 *
 	 * @return non-null display string
 	 * @since 2.0.0

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceAbstractToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceAbstractToolbox.java
@@ -28,13 +28,13 @@ public abstract class JavaInstrumentationAdviceAbstractToolbox {
 			"com.intellij.rt.debugger.", "jdk.internal.loader.", "jdk.internal.reflect.");
 
 	/**
-	 * Cached StackWalker used by the call-stack inspectors below. The default options
-	 * (no RETAIN_CLASS_REFERENCE) are deliberately chosen because the inspectors only
-	 * read className/methodName strings — keeping Class objects materialized would
-	 * pay extra JNI work on every walked frame. The walker avoids the Exception
-	 * allocation and full StackTraceElement[] materialization that
-	 * Thread.currentThread().getStackTrace() pays on every intercepted JDK call.
-	 * Pointcuts on java.io.InputStream.read fire during ObjectInputStream
+	 * Cached StackWalker used by the call-stack inspectors below. The default
+	 * options (no RETAIN_CLASS_REFERENCE) are deliberately chosen because the
+	 * inspectors only read className/methodName strings — keeping Class objects
+	 * materialized would pay extra JNI work on every walked frame. The walker
+	 * avoids the Exception allocation and full StackTraceElement[] materialization
+	 * that Thread.currentThread().getStackTrace() pays on every intercepted JDK
+	 * call. Pointcuts on java.io.InputStream.read fire during ObjectInputStream
 	 * deserialization of test-result events; the StackWalker path is roughly an
 	 * order of magnitude cheaper for those high-frequency probes.
 	 */
@@ -45,8 +45,8 @@ public abstract class JavaInstrumentationAdviceAbstractToolbox {
 	 * Lazily resolved Class&lt;?&gt; reference for the AOP settings holder. Each
 	 * intercepted JDK call (e.g. java.io.InputStream.read during ObjectInputStream
 	 * deserialization) reads aopMode + restrictedPackage + allowedListedClasses.
-	 * Resolving the class via Class.forName on every access (a native call) is
-	 * the second-largest contributor to advice overhead after the stack walk; this
+	 * Resolving the class via Class.forName on every access (a native call) is the
+	 * second-largest contributor to advice overhead after the stack walk; this
 	 * cached reference reduces it to a single volatile load.
 	 */
 	@Nullable
@@ -112,11 +112,11 @@ public abstract class JavaInstrumentationAdviceAbstractToolbox {
 
 	/**
 	 * Resolves the static settings Field for the given name once and caches the
-	 * resulting Field handle plus the owning Class&lt;?&gt; reference. The reflective
-	 * lookup is the second-largest fixed cost on hot advice paths (called three
-	 * times per intercepted JDK call before this cache existed), so caching it on
-	 * the bootstrap classloader avoids a Class.forName native call and a
-	 * getDeclaredField walk on every interception. The cached field has
+	 * resulting Field handle plus the owning Class&lt;?&gt; reference. The
+	 * reflective lookup is the second-largest fixed cost on hot advice paths
+	 * (called three times per intercepted JDK call before this cache existed), so
+	 * caching it on the bootstrap classloader avoids a Class.forName native call
+	 * and a getDeclaredField walk on every interception. The cached field has
 	 * setAccessible(true) once and stays accessible for the JVM lifetime.
 	 *
 	 * @param fieldName the name of the JavaAOPTestCaseSettings field to resolve
@@ -436,9 +436,9 @@ public abstract class JavaInstrumentationAdviceAbstractToolbox {
 
 	/**
 	 * Per-thread one-shot cache of the last inspectCallstackOnce result. Populated
-	 * by {@link #checkIfCallstackCriteriaIsViolated} and consumed by the immediately
-	 * following {@link #findFirstMethodOutsideOfRestrictedPackage} call so the
-	 * combined check+caller-lookup costs only one walk instead of two.
+	 * by {@link #checkIfCallstackCriteriaIsViolated} and consumed by the
+	 * immediately following {@link #findFirstMethodOutsideOfRestrictedPackage} call
+	 * so the combined check+caller-lookup costs only one walk instead of two.
 	 */
 	@Nonnull
 	private static final ThreadLocal<String[]> CALLSTACK_INSPECTION_CACHE = new ThreadLocal<>();
@@ -530,8 +530,8 @@ public abstract class JavaInstrumentationAdviceAbstractToolbox {
 				return i;
 			}
 		}
-		throw new SecurityException(
-				JavaInstrumentationAdviceAbstractToolbox.localize("security.instrumentation.field.not.found", fieldName, clazz.getName()));
+		throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox
+				.localize("security.instrumentation.field.not.found", fieldName, clazz.getName()));
 	}
 	// </editor-fold>
 

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceCommandSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceCommandSystemToolbox.java
@@ -43,8 +43,8 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 	 * exempted from ignore rules during command system checks.
 	 */
 	@Nonnull
-	private static final Map<String, IgnoreValues> COMMAND_SYSTEM_IGNORE_ATTRIBUTES_EXCEPT = Map
-			.ofEntries(Map.entry("java.lang.ProcessBuilder.start", IgnoreValues.allExcept(findFieldIndex(ProcessBuilder.class, "command"))));
+	private static final Map<String, IgnoreValues> COMMAND_SYSTEM_IGNORE_ATTRIBUTES_EXCEPT = Map.ofEntries(Map.entry(
+			"java.lang.ProcessBuilder.start", IgnoreValues.allExcept(findFieldIndex(ProcessBuilder.class, "command"))));
 
 	/**
 	 * Map of methods with parameter index exceptions for command system ignore
@@ -84,9 +84,9 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 	/**
 	 * Checks if a command target is outside of the allowed commands whitelist.
 	 * <p>
-	 * Description: Returns {@code true} if the allowed lists are null/empty, or
-	 * if no entry in the parallel allowlists matches both the command name and
-	 * the arguments of the target. Command matching is delegated to
+	 * Description: Returns {@code true} if the allowed lists are null/empty, or if
+	 * no entry in the parallel allowlists matches both the command name and the
+	 * arguments of the target. Command matching is delegated to
 	 * {@link #commandMatches} and argument matching to {@link #argumentsMatch}.
 	 *
 	 * @since 2.0.0
@@ -97,8 +97,8 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 	 * @return {@code true} if the command is forbidden; {@code false} if it is
 	 *         explicitly allowed
 	 */
-	private static boolean checkIfCommandIsForbidden(@Nullable CommandTarget actual,
-			@Nullable String[] allowedCommands, @Nullable String[][] allowedArguments) {
+	private static boolean checkIfCommandIsForbidden(@Nullable CommandTarget actual, @Nullable String[] allowedCommands,
+			@Nullable String[][] allowedArguments) {
 		if (actual == null) {
 			return false;
 		}
@@ -109,8 +109,8 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 		for (int i = 0; i < allowedCommands.length; i++) {
 			String allowedCommand = allowedCommands[i];
 			String[] allowedArgument = allowedArguments[i];
-if (commandMatches(actual.command(), allowedCommand)
-						&& argumentsMatch(allowedArgument, actual.arguments())) {
+			if (commandMatches(actual.command(), allowedCommand)
+					&& argumentsMatch(allowedArgument, actual.arguments())) {
 				return false;
 			}
 		}
@@ -303,8 +303,8 @@ if (commandMatches(actual.command(), allowedCommand)
 	 * Analyzes a variable to determine if it violates allowed commands.
 	 * <p>
 	 * Description: Recursively checks if the variable or its elements (if an array
-	 * or List) are in violation of the allowed commands. Returns true if any element
-	 * is forbidden.
+	 * or List) are in violation of the allowed commands. Returns true if any
+	 * element is forbidden.
 	 *
 	 * @since 2.0.0
 	 * @author Markus Paulsen
@@ -322,7 +322,8 @@ if (commandMatches(actual.command(), allowedCommand)
 			// Recurse only when elements are themselves nested Lists/arrays (i.e. multiple
 			// commands). A flat List<String> is a single (command, arg, arg, ...) sequence
 			// and must be handed to variableToCommand whole; otherwise individual args that
-			// happen to contain spaces (e.g. "echo $PATH") would be re-checked as standalone
+			// happen to contain spaces (e.g. "echo $PATH") would be re-checked as
+			// standalone
 			// commands and never match any allow-list entry.
 			if (list.stream().anyMatch(o -> o instanceof List<?> || (o != null && o.getClass().isArray()))) {
 				for (Object element : list) {

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceFileSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceFileSystemToolbox.java
@@ -68,8 +68,10 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 			Map.entry("java.io.File.deleteOnExit", IgnoreValues.allExcept(findFieldIndex(java.io.File.class, "path"))),
 			Map.entry("java.io.File.createNewFile", IgnoreValues.allExcept(findFieldIndex(java.io.File.class, "path"))),
 			// ProcessBuilder.start - only check command field, resolved by name
-			Map.entry("java.lang.ProcessBuilder.start", IgnoreValues.allExcept(findFieldIndex(ProcessBuilder.class, "command"))),
-			Map.entry("java.lang.ProcessBuilder.startPipeline", IgnoreValues.allExcept(findFieldIndex(ProcessBuilder.class, "command"))));
+			Map.entry("java.lang.ProcessBuilder.start",
+					IgnoreValues.allExcept(findFieldIndex(ProcessBuilder.class, "command"))),
+			Map.entry("java.lang.ProcessBuilder.startPipeline",
+					IgnoreValues.allExcept(findFieldIndex(ProcessBuilder.class, "command"))));
 
 	/**
 	 * Map of methods with parameter index exceptions for file system ignore logic.
@@ -107,8 +109,7 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 	 */
 	private static final Set<String> INTERNAL_PATH_SUFFIXES = Set.of("ares/api/localization/Messages.class",
 			"ares/api/localization/messages.class", "ares/api/localization/messages.properties",
-			"ares/api/util/LruCache.class",
-			"ares/api/configuration/essentialFiles/java/EssentialPackages.yaml",
+			"ares/api/util/LruCache.class", "ares/api/configuration/essentialFiles/java/EssentialPackages.yaml",
 			"ares/api/configuration/essentialFiles/java/EssentialClasses.yaml");
 
 	// </editor-fold>
@@ -219,12 +220,13 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 	 * Checks whether an actual (already resolved) path matches an allowed path.
 	 * <p>
 	 * Description: Resolves symlinks in the allowed path to its canonical form,
-	 * then checks whether the candidate path starts with the resolved allowed
-	 * path. Returns {@code false} if the allowed path does not exist and
-	 * non-existing paths are not permitted.
+	 * then checks whether the candidate path starts with the resolved allowed path.
+	 * Returns {@code false} if the allowed path does not exist and non-existing
+	 * paths are not permitted.
 	 *
 	 * @param candidate                           the resolved candidate path
-	 * @param allowedPath                         the allowed path to compare against
+	 * @param allowedPath                         the allowed path to compare
+	 *                                            against
 	 * @param allowNonExistingPathsToBeConsidered whether non-existing paths are
 	 *                                            permitted
 	 * @return {@code true} if the candidate path is covered by the allowed path
@@ -326,7 +328,8 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 	 * Description: Delegates to {@link #variableToPath} and wraps the result.
 	 *
 	 * @param variableValue                       the variable to convert
-	 * @param allowNonExistingPathsToBeConsidered whether to allow non-existing paths
+	 * @param allowNonExistingPathsToBeConsidered whether to allow non-existing
+	 *                                            paths
 	 * @return a {@link FileTarget}, or {@code null} if conversion fails
 	 * @since 2.0.0
 	 * @author Markus Paulsen
@@ -419,8 +422,7 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 			return null;
 		} else {
 			FileTarget target = variableToTarget(observedVariable, allowNonExistingPathsToBeConsidered);
-			if (target != null
-					&& checkIfPathIsForbidden(target, allowedPaths, allowNonExistingPathsToBeConsidered)) {
+			if (target != null && checkIfPathIsForbidden(target, allowedPaths, allowNonExistingPathsToBeConsidered)) {
 				return target.toDisplayString();
 			}
 		}
@@ -706,26 +708,36 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 			}
 		}
 
-		// Semantic rule 1: when both "create" (from CREATE option) and "overwrite" (from WRITE option)
-		// are present, the primary intent is "write to file, creating if not exists" = overwrite.
-		// Merge into a single "overwrite" check with allowNonExisting=true so that non-existing
-		// paths are also validated (they will be created-by-write, not truly "created" as a new
-		// entity). This prevents spurious "illegal create" messages on write-open calls.
+		// Semantic rule 1: when both "create" (from CREATE option) and "overwrite"
+		// (from WRITE option)
+		// are present, the primary intent is "write to file, creating if not exists" =
+		// overwrite.
+		// Merge into a single "overwrite" check with allowNonExisting=true so that
+		// non-existing
+		// paths are also validated (they will be created-by-write, not truly "created"
+		// as a new
+		// entity). This prevents spurious "illegal create" messages on write-open
+		// calls.
 		if (actions.containsKey("create") && actions.containsKey("overwrite")) {
 			Boolean createAllows = actions.get("create");
 			Boolean overwriteAllows = actions.get("overwrite");
 			actions.remove("create");
 			// Keep allowNonExisting=true from "create" so non-existing paths are checked
-			actions.put("overwrite", (createAllows != null && createAllows) || (overwriteAllows != null && overwriteAllows));
+			actions.put("overwrite",
+					(createAllows != null && createAllows) || (overwriteAllows != null && overwriteAllows));
 		}
 
-		// Semantic rule 2: when the method is in the "overwrite" pointcut (defaultAction="overwrite")
-		// but OpenOptions only produced "create" (e.g. Files.writeString(path, s, CREATE) — no WRITE
-		// option), the operation is still semantically "write data to file" = overwrite.
-		// Exception: CREATE_NEW genuinely means "create a new file; fail if it already exists", so
-		// we leave that as "create". Only plain CREATE (create-if-absent) is reclassified.
-		if ("overwrite".equals(defaultAction)
-				&& actions.size() == 1 && actions.containsKey("create")
+		// Semantic rule 2: when the method is in the "overwrite" pointcut
+		// (defaultAction="overwrite")
+		// but OpenOptions only produced "create" (e.g. Files.writeString(path, s,
+		// CREATE) — no WRITE
+		// option), the operation is still semantically "write data to file" =
+		// overwrite.
+		// Exception: CREATE_NEW genuinely means "create a new file; fail if it already
+		// exists", so
+		// we leave that as "create". Only plain CREATE (create-if-absent) is
+		// reclassified.
+		if ("overwrite".equals(defaultAction) && actions.size() == 1 && actions.containsKey("create")
 				&& !options.contains(StandardOpenOption.CREATE_NEW)) {
 			Boolean allowNonExisting = actions.get("create");
 			actions.remove("create");
@@ -963,17 +975,19 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 						parameters, allowedPaths, FILE_SYSTEM_IGNORE_PARAMETERS_EXCEPT
 								.getOrDefault(declaringTypeName + "." + methodName, IgnoreValues.NONE),
 						allowNonExistingPathsToBeConsidered);
-		// When a "create" pointcut intercepts a class/method that semantically truncates/overwrites
-		// (FileOutputStream, FileWriter, PrintWriter, or Files.newBufferedWriter/newOutputStream
-		// without an explicit append=true), the reported verb should be "overwrite" so that
+		// When a "create" pointcut intercepts a class/method that semantically
+		// truncates/overwrites
+		// (FileOutputStream, FileWriter, PrintWriter, or
+		// Files.newBufferedWriter/newOutputStream
+		// without an explicit append=true), the reported verb should be "overwrite" so
+		// that
 		// messages match test expectations.
 		boolean isWriteAliasedAsCreate = "create".equals(action)
 				&& ("java.io.FileOutputStream".equals(declaringTypeName)
 						|| "java.io.FileWriter".equals(declaringTypeName)
 						|| "java.io.PrintWriter".equals(declaringTypeName)
 						|| ("java.nio.file.Files".equals(declaringTypeName)
-								&& ("newBufferedWriter".equals(methodName)
-										|| "newOutputStream".equals(methodName))));
+								&& ("newBufferedWriter".equals(methodName) || "newOutputStream".equals(methodName))));
 		String messageAction = isWriteAliasedAsCreate ? "overwrite" : action;
 		if (pathIllegallyInteractedThroughParameter != null) {
 			// Check if this is a .class file access by ClassLoader - should be allowed
@@ -987,11 +1001,9 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 			// not initiated by student code accessing arbitrary project files.
 			boolean isSystemJarRead = pathIllegallyInteractedThroughParameter.endsWith(".jar")
 					&& (pathIllegallyInteractedThroughParameter.contains("/.m2/repository/")
-							|| pathIllegallyInteractedThroughParameter.contains(
-									java.io.File.separator + ".m2" + java.io.File.separator + "repository"
-											+ java.io.File.separator)
-							|| pathIllegallyInteractedThroughParameter
-									.startsWith(System.getProperty("java.home")));
+							|| pathIllegallyInteractedThroughParameter.contains(java.io.File.separator + ".m2"
+									+ java.io.File.separator + "repository" + java.io.File.separator)
+							|| pathIllegallyInteractedThroughParameter.startsWith(System.getProperty("java.home")));
 			if (!isClassLoaderAccess && !isSystemJarRead) {
 				throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox.localize(
 						"security.advice.illegal.file.execution", fileSystemMethodToCheck, messageAction,
@@ -1014,9 +1026,8 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 
 			if (!isInternalAllowed && pathIllegallyInteractedThroughReceiver.endsWith(".jar")
 					&& (pathIllegallyInteractedThroughReceiver.contains("/.m2/repository/")
-							|| pathIllegallyInteractedThroughReceiver.contains(
-									java.io.File.separator + ".m2" + java.io.File.separator + "repository"
-											+ java.io.File.separator)
+							|| pathIllegallyInteractedThroughReceiver.contains(java.io.File.separator + ".m2"
+									+ java.io.File.separator + "repository" + java.io.File.separator)
 							|| pathIllegallyInteractedThroughReceiver.startsWith(System.getProperty("java.home")))) {
 				isInternalAllowed = true;
 			}
@@ -1075,11 +1086,9 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 			// not initiated by student code accessing arbitrary project files.
 			if (!isInternalAllowed && pathIllegallyInteractedThroughAttribute.endsWith(".jar")
 					&& (pathIllegallyInteractedThroughAttribute.contains("/.m2/repository/")
-							|| pathIllegallyInteractedThroughAttribute.contains(
-									java.io.File.separator + ".m2" + java.io.File.separator + "repository"
-											+ java.io.File.separator)
-							|| pathIllegallyInteractedThroughAttribute
-									.startsWith(System.getProperty("java.home")))) {
+							|| pathIllegallyInteractedThroughAttribute.contains(java.io.File.separator + ".m2"
+									+ java.io.File.separator + "repository" + java.io.File.separator)
+							|| pathIllegallyInteractedThroughAttribute.startsWith(System.getProperty("java.home")))) {
 				isInternalAllowed = true;
 			}
 

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
@@ -39,9 +39,9 @@ import javax.annotation.Nullable;
  * Uses static utility methods and a private constructor to prevent
  * instantiation. Reflection is used to decouple the toolbox from direct
  * dependencies on settings and localization classes, supporting flexible and
- * dynamic test setups. Network targets are resolved to a canonical host-and-port
- * pair before comparison, which avoids the multi-level traversal required for
- * file-path or thread-class checks.
+ * dynamic test setups. Network targets are resolved to a canonical
+ * host-and-port pair before comparison, which avoids the multi-level traversal
+ * required for file-path or thread-class checks.
  *
  * @since 2.0.0
  * @author Kevin Fischer
@@ -140,9 +140,9 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	 * <p>
 	 * Description: Returns {@code false} if either value is null or blank. Accepts
 	 * the wildcard {@code "*"} as an unconditional match for any host. Otherwise
-	 * performs a case-insensitive comparison after trimming, and also accepts suffix
-	 * matches of the form {@code actualHost.endsWith("." + allowedHost)} to support
-	 * subdomain policies.
+	 * performs a case-insensitive comparison after trimming, and also accepts
+	 * suffix matches of the form {@code actualHost.endsWith("." + allowedHost)} to
+	 * support subdomain policies.
 	 *
 	 * @param actualHost  the hostname resolved from the intercepted call; may be
 	 *                    null
@@ -169,9 +169,9 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	/**
 	 * Checks whether an actual port number matches an allowed port.
 	 * <p>
-	 * Description: A value of {@code -1} for {@code allowedPort} acts as a
-	 * wildcard that permits any port number. Otherwise performs an exact integer
-	 * equality check.
+	 * Description: A value of {@code -1} for {@code allowedPort} acts as a wildcard
+	 * that permits any port number. Otherwise performs an exact integer equality
+	 * check.
 	 *
 	 * @param actualPort  the port resolved from the intercepted call
 	 * @param allowedPort the port from the security policy; {@code -1} means any
@@ -196,8 +196,8 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	 * <p>
 	 * Description: Inspects the runtime type of {@code value} and delegates to the
 	 * appropriate extraction logic. Handles {@link InetSocketAddress},
-	 * {@link SocketAddress}, {@code java.net.http.HttpRequest}, {@link URI}, {@link URL},
-	 * {@link URLConnection}, {@link Socket}, {@link DatagramSocket},
+	 * {@link SocketAddress}, {@code java.net.http.HttpRequest}, {@link URI},
+	 * {@link URL}, {@link URLConnection}, {@link Socket}, {@link DatagramSocket},
 	 * {@link SocketChannel}, {@link DatagramChannel}, and {@link String} values.
 	 * Returns {@code null} when the value is {@code null} or of an unrecognised
 	 * type.
@@ -350,38 +350,36 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	 * {@code (host-like, int)} parameter pairs and marks every consumed index in
 	 * {@code consumedIndices}. The first valid pair is returned as the resolved
 	 * {@link NetworkTarget}; subsequent valid pairs are still marked consumed even
-	 * though they do not become the resolved target. If no pair matches, the
-	 * method falls through to the single-parameter scan and marks the index of
-	 * the first directly resolvable parameter.
+	 * though they do not become the resolved target. If no pair matches, the method
+	 * falls through to the single-parameter scan and marks the index of the first
+	 * directly resolvable parameter.
 	 * <p>
 	 * Design Rationale: Tracking consumed indices lets callers exclude these
 	 * positions from the per-parameter walk performed by
 	 * {@link #checkIfVariableCriteriaIsViolated(Object[], String[], int[], IgnoreValues)}.
 	 * Without that exclusion a bare {@link InetAddress} that already participated
 	 * in a successful pair extraction would be re-resolved by
-	 * {@link #variableToTarget(Object)} as {@code (host, -1)} and falsely
-	 * reported as a violation against any allowlist whose port is not {@code -1}.
+	 * {@link #variableToTarget(Object)} as {@code (host, -1)} and falsely reported
+	 * as a violation against any allowlist whose port is not {@code -1}.
 	 * <p>
-	 * Multi-pair signatures such as
-	 * {@code Socket(String, int, InetAddress, int)} or
-	 * {@code SocketFactory.createSocket(String, int, InetAddress, int)} place the
-	 * remote endpoint first and the local-bind endpoint second.
+	 * Multi-pair signatures such as {@code Socket(String, int, InetAddress, int)}
+	 * or {@code SocketFactory.createSocket(String, int, InetAddress, int)} place
+	 * the remote endpoint first and the local-bind endpoint second.
 	 * {@link de.tum.cit.ase.ares.api.policy.policySubComponents.NetworkPermission}
 	 * models policy as a single {@code (host, port)} tuple per permission and has
 	 * no concept of local-bind enforcement, so consuming the local-bind pair
 	 * without separate policy evaluation is correct in the current model. If
 	 * local-bind enforcement is ever added, this helper must be revisited.
 	 *
-	 * @param parameters       the intercepted argument array
-	 * @param consumedIndices  out-parameter; bits are set for every parameter
-	 *                         index that participated in a successful pair or
-	 *                         single-parameter resolution
+	 * @param parameters      the intercepted argument array
+	 * @param consumedIndices out-parameter; bits are set for every parameter index
+	 *                        that participated in a successful pair or
+	 *                        single-parameter resolution
 	 * @return the resolved target, or {@code null} if no target can be derived
 	 * @since 2.0.0
 	 */
 	@Nullable
-	private static NetworkTarget parametersToTarget(@Nonnull Object[] parameters,
-			@Nonnull BitSet consumedIndices) {
+	private static NetworkTarget parametersToTarget(@Nonnull Object[] parameters, @Nonnull BitSet consumedIndices) {
 		NetworkTarget firstTarget = null;
 		for (int i = 0; i + 1 < parameters.length; i++) {
 			if (consumedIndices.get(i) || consumedIndices.get(i + 1)) {
@@ -417,8 +415,7 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	 * @return the resolved target, or {@code null} if the pair is unsupported
 	 */
 	@Nullable
-	private static NetworkTarget hostAndPortToTarget(@Nullable Object hostCandidate,
-			@Nullable Object portCandidate) {
+	private static NetworkTarget hostAndPortToTarget(@Nullable Object hostCandidate, @Nullable Object portCandidate) {
 		Integer port = extractPort(portCandidate);
 		if (port == null) {
 			return null;
@@ -540,9 +537,9 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	/**
 	 * Analyzes a variable to determine if it violates allowed network targets.
 	 * <p>
-	 * Description: Attempts to resolve the variable to a {@link NetworkTarget}
-	 * via {@link #variableToTarget}. Returns {@code true} if the resolved target
-	 * is forbidden according to the allowed hosts and ports whitelist.
+	 * Description: Attempts to resolve the variable to a {@link NetworkTarget} via
+	 * {@link #variableToTarget}. Returns {@code true} if the resolved target is
+	 * forbidden according to the allowed hosts and ports whitelist.
 	 *
 	 * @param observedVariable the variable to analyze
 	 * @param allowedHosts     whitelist of allowed hosts
@@ -564,8 +561,8 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	 * Extracts the display string of the first violating network target from a
 	 * variable.
 	 * <p>
-	 * Description: Resolves the variable to a {@link NetworkTarget} and returns
-	 * its display string if the target is forbidden. Returns {@code null} if no
+	 * Description: Resolves the variable to a {@link NetworkTarget} and returns its
+	 * display string if the target is forbidden. Returns {@code null} if no
 	 * violation is found.
 	 *
 	 * @param observedVariable the variable to inspect
@@ -601,13 +598,13 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	 * @param allowedHosts      whitelist of allowed hosts
 	 * @param allowedPorts      whitelist of allowed ports
 	 * @param ignoreVariables   criteria determining which observedVariables to skip
-	 * @return the first violating target (as display string) or null if none violate
+	 * @return the first violating target (as display string) or null if none
+	 *         violate
 	 * @since 2.0.0
 	 * @author Kevin Fischer
 	 */
 	private static String checkIfVariableCriteriaIsViolated(@Nonnull Object[] observedVariables,
-			@Nullable String[] allowedHosts, @Nullable int[] allowedPorts,
-			@Nonnull IgnoreValues ignoreVariables) {
+			@Nullable String[] allowedHosts, @Nullable int[] allowedPorts, @Nonnull IgnoreValues ignoreVariables) {
 		for (@Nullable
 		Object observedVariable : filterVariables(observedVariables, ignoreVariables)) {
 			if (analyseViolation(observedVariable, allowedHosts, allowedPorts)) {
@@ -628,11 +625,10 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	 * invocation.
 	 * <p>
 	 * Description: Currently returns a singleton list containing the original
-	 * action because network operations (connect, send, receive) do not
-	 * decompose into sub-actions the way file-system operations can. The method
-	 * exists to maintain structural symmetry with the file-system toolbox and to
-	 * provide a natural extension point should future network actions require
-	 * derivation.
+	 * action because network operations (connect, send, receive) do not decompose
+	 * into sub-actions the way file-system operations can. The method exists to
+	 * maintain structural symmetry with the file-system toolbox and to provide a
+	 * natural extension point should future network actions require derivation.
 	 *
 	 * @param defaultAction the network action associated with the pointcut
 	 *                      configuration (e.g., {@code connect})
@@ -651,63 +647,64 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	/**
 	 * Performs the security validation for a single network action.
 	 * <p>
-	 * Description: Resolves the allowed hosts and ports for the given action,
-	 * then evaluates method parameters, the receiver instance, and instance
-	 * attributes against the whitelist. Throws {@link SecurityException} if a
-	 * policy violation is detected.
+	 * Description: Resolves the allowed hosts and ports for the given action, then
+	 * evaluates method parameters, the receiver instance, and instance attributes
+	 * against the whitelist. Throws {@link SecurityException} if a policy violation
+	 * is detected.
 	 *
-	 * @param action                              the concrete network action under
-	 *                                            inspection
-	 * @param declaringTypeName                   fully qualified declaring type name
-	 * @param methodName                          method being intercepted
-	 * @param methodSignature                     JVM method signature
-	 * @param attributes                          instance attributes (if any)
-	 * @param parameters                          intercepted method arguments
-	 * @param instance                            instance on which the method is
-	 *                                            invoked
-	 * @param restrictedPackage                   package prefix under security
-	 *                                            scrutiny; reserved for structural
-	 *                                            symmetry with the file-system
-	 *                                            toolbox; currently unused
-	 * @param allowedClasses                      classes allowed within the
-	 *                                            restricted package; reserved for
-	 *                                            structural symmetry with the
-	 *                                            file-system toolbox; currently
-	 *                                            unused
-	 * @param networkSystemMethodToCheck          offending method discovered in the
+	 * @param action                     the concrete network action under
+	 *                                   inspection
+	 * @param declaringTypeName          fully qualified declaring type name
+	 * @param methodName                 method being intercepted
+	 * @param methodSignature            JVM method signature
+	 * @param attributes                 instance attributes (if any)
+	 * @param parameters                 intercepted method arguments
+	 * @param instance                   instance on which the method is invoked
+	 * @param restrictedPackage          package prefix under security scrutiny;
+	 *                                   reserved for structural symmetry with the
+	 *                                   file-system toolbox; currently unused
+	 * @param allowedClasses             classes allowed within the restricted
+	 *                                   package; reserved for structural symmetry
+	 *                                   with the file-system toolbox; currently
+	 *                                   unused
+	 * @param networkSystemMethodToCheck offending method discovered in the
 	 *                                   restricted call stack
-	 * @param studentCalledMethod     external method initiating the restricted
-	 *                                call (may be null)
-	 * @param fullMethodSignature     human-readable method signature for diagnostics
+	 * @param studentCalledMethod        external method initiating the restricted
+	 *                                   call (may be null)
+	 * @param fullMethodSignature        human-readable method signature for
+	 *                                   diagnostics
 	 * @throws SecurityException if the interaction violates configured policies
 	 * @since 2.0.0
 	 * @author Kevin Fischer
 	 */
 	private static void checkNetworkSystemInteractionForAction(@Nonnull String action,
-			@Nonnull String declaringTypeName,
-			@Nonnull String methodName, @Nonnull String methodSignature, @Nullable Object[] attributes,
-			@Nullable Object[] parameters, @Nullable Object instance, @Nullable String restrictedPackage,
-			@Nullable String[] allowedClasses, @Nonnull String networkSystemMethodToCheck,
-			@Nullable String studentCalledMethod, @Nonnull String fullMethodSignature) {
+			@Nonnull String declaringTypeName, @Nonnull String methodName, @Nonnull String methodSignature,
+			@Nullable Object[] attributes, @Nullable Object[] parameters, @Nullable Object instance,
+			@Nullable String restrictedPackage, @Nullable String[] allowedClasses,
+			@Nonnull String networkSystemMethodToCheck, @Nullable String studentCalledMethod,
+			@Nonnull String fullMethodSignature) {
 		// <editor-fold desc="Resolve allowed hosts and ports">
 		@Nullable
 		final String[] allowedHosts = switch (action) {
 		case "connect" -> getValueFromSettings("hostsAllowedToBeConnectedTo");
 		case "send" -> getValueFromSettings("hostsAllowedToBeSentTo");
 		case "receive" -> getValueFromSettings("hostsAllowedToBeReceivedFrom");
-		default -> throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox.localize("security.advice.settings.invalid.network.permission", action));
+		default -> throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox
+				.localize("security.advice.settings.invalid.network.permission", action));
 		};
 		@Nullable
 		final int[] allowedPorts = switch (action) {
 		case "connect" -> getValueFromSettings("portsAllowedToBeConnectedTo");
 		case "send" -> getValueFromSettings("portsAllowedToBeSentTo");
 		case "receive" -> getValueFromSettings("portsAllowedToBeReceivedFrom");
-		default -> throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox.localize("security.advice.settings.invalid.network.permission", action));
+		default -> throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox
+				.localize("security.advice.settings.invalid.network.permission", action));
 		};
 
 		if ((allowedHosts == null ? 0 : allowedHosts.length) != (allowedPorts == null ? 0 : allowedPorts.length)) {
-			throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox.localize("security.advice.network.allowed.size", action,
-					allowedHosts == null ? 0 : allowedHosts.length, allowedPorts == null ? 0 : allowedPorts.length));
+			throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox.localize(
+					"security.advice.network.allowed.size", action, allowedHosts == null ? 0 : allowedHosts.length,
+					allowedPorts == null ? 0 : allowedPorts.length));
 		}
 		// </editor-fold>
 		// <editor-fold desc="Check parameters">
@@ -715,10 +712,10 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 		@Nonnull
 		final BitSet consumedParameterIndices = new BitSet(hasParameters ? parameters.length : 0);
 		@Nullable
-		NetworkTarget targetFromParameters = hasParameters
-				? parametersToTarget(parameters, consumedParameterIndices)
+		NetworkTarget targetFromParameters = hasParameters ? parametersToTarget(parameters, consumedParameterIndices)
 				: null;
-		if (targetFromParameters != null && checkIfNetworkIsForbidden(targetFromParameters, allowedHosts, allowedPorts)) {
+		if (targetFromParameters != null
+				&& checkIfNetworkIsForbidden(targetFromParameters, allowedHosts, allowedPorts)) {
 			throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox.localize(
 					"security.advice.illegal.network.execution", networkSystemMethodToCheck, action,
 					targetFromParameters.toDisplayString(), fullMethodSignature
@@ -738,10 +735,12 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 			}
 		}
 		@Nullable
-		String networkIllegallyInteractedThroughParameter = (residualParameters == null || residualParameters.length == 0) ? null
-				: checkIfVariableCriteriaIsViolated(residualParameters, allowedHosts, allowedPorts,
-						NETWORK_SYSTEM_IGNORE_PARAMETERS_EXCEPT.getOrDefault(declaringTypeName + "." + methodName,
-								IgnoreValues.NONE));
+		String networkIllegallyInteractedThroughParameter = (residualParameters == null
+				|| residualParameters.length == 0)
+						? null
+						: checkIfVariableCriteriaIsViolated(residualParameters, allowedHosts, allowedPorts,
+								NETWORK_SYSTEM_IGNORE_PARAMETERS_EXCEPT
+										.getOrDefault(declaringTypeName + "." + methodName, IgnoreValues.NONE));
 		if (networkIllegallyInteractedThroughParameter != null) {
 			throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox.localize(
 					"security.advice.illegal.network.execution", networkSystemMethodToCheck, action,
@@ -833,10 +832,9 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 
 		List<Map.Entry<String, Boolean>> actionsToValidate = deriveActionChecks(action);
 		for (Map.Entry<String, Boolean> actionCheck : actionsToValidate) {
-			checkNetworkSystemInteractionForAction(actionCheck.getKey(),
-					declaringTypeName, methodName, methodSignature, attributes, parameters, instance,
-					restrictedPackage, allowedClasses, networkSystemMethodToCheck, studentCalledMethod,
-					fullMethodSignature);
+			checkNetworkSystemInteractionForAction(actionCheck.getKey(), declaringTypeName, methodName, methodSignature,
+					attributes, parameters, instance, restrictedPackage, allowedClasses, networkSystemMethodToCheck,
+					studentCalledMethod, fullMethodSignature);
 		}
 	}
 

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceThreadSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceThreadSystemToolbox.java
@@ -202,8 +202,8 @@ public final class JavaInstrumentationAdviceThreadSystemToolbox extends JavaInst
 	 * <p>
 	 * Description: Handles lambda expressions as a special case (both must be
 	 * lambdas to match). For regular classes, uses {@code Class.forName} and
-	 * {@code isAssignableFrom} to support class hierarchy matching. Falls back
-	 * to exact string comparison when classes cannot be loaded (e.g. JDK internal
+	 * {@code isAssignableFrom} to support class hierarchy matching. Falls back to
+	 * exact string comparison when classes cannot be loaded (e.g. JDK internal
 	 * classes).
 	 *
 	 * @param actualClassname  the class name from the intercepted call
@@ -458,8 +458,7 @@ public final class JavaInstrumentationAdviceThreadSystemToolbox extends JavaInst
 		} else {
 			try {
 				ThreadTarget target = variableToTarget(observedVariable);
-				return checkIfThreadIsForbidden(target, threadClassAllowedToBeCreated,
-						threadNumberAllowedToBeCreated);
+				return checkIfThreadIsForbidden(target, threadClassAllowedToBeCreated, threadNumberAllowedToBeCreated);
 			} catch (SecurityException ignored) {
 				return false;
 			}
@@ -510,8 +509,7 @@ public final class JavaInstrumentationAdviceThreadSystemToolbox extends JavaInst
 		} else {
 			try {
 				ThreadTarget target = variableToTarget(observedVariable);
-				if (checkIfThreadIsForbidden(target, threadClassAllowedToBeCreated,
-						threadNumberAllowedToBeCreated)) {
+				if (checkIfThreadIsForbidden(target, threadClassAllowedToBeCreated, threadNumberAllowedToBeCreated)) {
 					return target != null ? target.toDisplayString() : null;
 				}
 			} catch (SecurityException ignored) {

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationConnectNetworkConstructorAdvice.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationConnectNetworkConstructorAdvice.java
@@ -15,11 +15,11 @@ import net.bytebuddy.asm.Advice;
  */
 public final class JavaInstrumentationConnectNetworkConstructorAdvice {
 	/**
-	 * This method is called when a constructor connecting to networks is
-	 * entered. It performs security checks to determine whether the constructor
-	 * execution is allowed according to network system security policies. If the
-	 * constructor execution is not permitted, a SecurityException is thrown,
-	 * blocking the execution.
+	 * This method is called when a constructor connecting to networks is entered.
+	 * It performs security checks to determine whether the constructor execution is
+	 * allowed according to network system security policies. If the constructor
+	 * execution is not permitted, a SecurityException is thrown, blocking the
+	 * execution.
 	 * <p>
 	 * The checkNetworkSystemInteraction method from
 	 * JavaInstrumentationAdviceNetworkSystemToolbox is called to perform these
@@ -37,4 +37,3 @@ public final class JavaInstrumentationConnectNetworkConstructorAdvice {
 				"<init>", "", new Object[0], parameters, null);
 	}
 }
-

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationConnectNetworkMethodAdvice.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationConnectNetworkMethodAdvice.java
@@ -19,10 +19,9 @@ import net.bytebuddy.asm.Advice;
 public final class JavaInstrumentationConnectNetworkMethodAdvice {
 	/**
 	 * This method is called when a method connecting to networks is entered. It
-	 * performs security checks to determine whether the method execution is
-	 * allowed according to network system security policies. If the method
-	 * execution is not permitted, a SecurityException is thrown, blocking the
-	 * execution.
+	 * performs security checks to determine whether the method execution is allowed
+	 * according to network system security policies. If the method execution is not
+	 * permitted, a SecurityException is thrown, blocking the execution.
 	 * <p>
 	 * The checkNetworkSystemInteraction method from
 	 * JavaInstrumentationAdviceNetworkSystemToolbox is called to perform these
@@ -75,4 +74,3 @@ public final class JavaInstrumentationConnectNetworkMethodAdvice {
 		// </editor-fold>
 	}
 }
-

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationCreatePathConstructorAdvice.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationCreatePathConstructorAdvice.java
@@ -20,8 +20,8 @@ public final class JavaInstrumentationCreatePathConstructorAdvice {
 	 * execution.
 	 * <p>
 	 * The checkFileSystemInteraction method from
-	 * JavaInstrumentationAdviceFileSystemToolbox is called to perform these
-	 * checks, ensuring that the constructor's parameters adhere to the security
+	 * JavaInstrumentationAdviceFileSystemToolbox is called to perform these checks,
+	 * ensuring that the constructor's parameters adhere to the security
 	 * restrictions.
 	 *
 	 * @param declaringTypeName The name of the class that declares the constructor.

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationCreatePathMethodAdvice.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationCreatePathMethodAdvice.java
@@ -6,8 +6,8 @@ import java.lang.reflect.InaccessibleObjectException;
 import net.bytebuddy.asm.Advice;
 
 /**
- * This class provides advice for the execution of methods creating files. It
- * is responsible for verifying whether the method execution is allowed based on
+ * This class provides advice for the execution of methods creating files. It is
+ * responsible for verifying whether the method execution is allowed based on
  * the file system security policies defined within the application.
  * <p>
  * If an execution attempt violates these policies, a SecurityException is
@@ -22,9 +22,9 @@ public final class JavaInstrumentationCreatePathMethodAdvice {
 	 * permitted, a SecurityException is thrown, blocking the execution.
 	 * <p>
 	 * The checkFileSystemInteraction method from
-	 * JavaInstrumentationAdviceFileSystemToolbox is called to perform these
-	 * checks, ensuring that both the method's parameters and the instance fields
-	 * adhere to the security restrictions.
+	 * JavaInstrumentationAdviceFileSystemToolbox is called to perform these checks,
+	 * ensuring that both the method's parameters and the instance fields adhere to
+	 * the security restrictions.
 	 *
 	 * @param declaringTypeName The name of the class that declares the method.
 	 * @param methodName        The name of the method being executed.

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationCreateThreadMethodAdvice.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationCreateThreadMethodAdvice.java
@@ -17,11 +17,10 @@ import net.bytebuddy.asm.Advice;
  */
 public final class JavaInstrumentationCreateThreadMethodAdvice {
 	/**
-	 * This method is called when a method creating threads is entered. It
-	 * performs security checks to determine whether the method execution is
-	 * allowed according to thread system security policies. If the method
-	 * execution is not permitted, a SecurityException is thrown, blocking the
-	 * execution.
+	 * This method is called when a method creating threads is entered. It performs
+	 * security checks to determine whether the method execution is allowed
+	 * according to thread system security policies. If the method execution is not
+	 * permitted, a SecurityException is thrown, blocking the execution.
 	 * <p>
 	 * The checkThreadSystemInteraction method from
 	 * JavaInstrumentationAdviceThreadSystemToolbox is called to perform these

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationDeletePathMethodAdvice.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationDeletePathMethodAdvice.java
@@ -16,11 +16,10 @@ import net.bytebuddy.asm.Advice;
  */
 public final class JavaInstrumentationDeletePathMethodAdvice {
 	/**
-	 * This method is called when a method deleting files is entered. It
-	 * performs security checks to determine whether the method execution is
-	 * allowed according to file system security policies. If the method
-	 * execution is not permitted, a SecurityException is thrown, blocking the
-	 * execution.
+	 * This method is called when a method deleting files is entered. It performs
+	 * security checks to determine whether the method execution is allowed
+	 * according to file system security policies. If the method execution is not
+	 * permitted, a SecurityException is thrown, blocking the execution.
 	 * <p>
 	 * The checkFileSystemInteraction method from
 	 * JavaInstrumentationAdviceFileSystemToolbox is called to perform these checks,

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationReceiveNetworkConstructorAdvice.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationReceiveNetworkConstructorAdvice.java
@@ -15,11 +15,11 @@ import net.bytebuddy.asm.Advice;
  */
 public final class JavaInstrumentationReceiveNetworkConstructorAdvice {
 	/**
-	 * This method is called when a constructor receiving network data is
-	 * entered. It performs security checks to determine whether the constructor
-	 * execution is allowed according to network system security policies. If the
-	 * constructor execution is not permitted, a SecurityException is thrown,
-	 * blocking the execution.
+	 * This method is called when a constructor receiving network data is entered.
+	 * It performs security checks to determine whether the constructor execution is
+	 * allowed according to network system security policies. If the constructor
+	 * execution is not permitted, a SecurityException is thrown, blocking the
+	 * execution.
 	 * <p>
 	 * The checkNetworkSystemInteraction method from
 	 * JavaInstrumentationAdviceNetworkSystemToolbox is called to perform these
@@ -37,4 +37,3 @@ public final class JavaInstrumentationReceiveNetworkConstructorAdvice {
 				"<init>", "", new Object[0], parameters, null);
 	}
 }
-

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationReceiveNetworkMethodAdvice.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationReceiveNetworkMethodAdvice.java
@@ -18,10 +18,9 @@ import net.bytebuddy.asm.Advice;
 public final class JavaInstrumentationReceiveNetworkMethodAdvice {
 	/**
 	 * This method is called when a method receiving network data is entered. It
-	 * performs security checks to determine whether the method execution is
-	 * allowed according to network system security policies. If the method
-	 * execution is not permitted, a SecurityException is thrown, blocking the
-	 * execution.
+	 * performs security checks to determine whether the method execution is allowed
+	 * according to network system security policies. If the method execution is not
+	 * permitted, a SecurityException is thrown, blocking the execution.
 	 * <p>
 	 * The checkNetworkSystemInteraction method from
 	 * JavaInstrumentationAdviceNetworkSystemToolbox is called to perform these
@@ -74,4 +73,3 @@ public final class JavaInstrumentationReceiveNetworkMethodAdvice {
 		// </editor-fold>
 	}
 }
-

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationSendNetworkConstructorAdvice.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationSendNetworkConstructorAdvice.java
@@ -15,11 +15,11 @@ import net.bytebuddy.asm.Advice;
  */
 public final class JavaInstrumentationSendNetworkConstructorAdvice {
 	/**
-	 * This method is called when a constructor sending network data is entered.
-	 * It performs security checks to determine whether the constructor execution
-	 * is allowed according to network system security policies. If the
-	 * constructor execution is not permitted, a SecurityException is thrown,
-	 * blocking the execution.
+	 * This method is called when a constructor sending network data is entered. It
+	 * performs security checks to determine whether the constructor execution is
+	 * allowed according to network system security policies. If the constructor
+	 * execution is not permitted, a SecurityException is thrown, blocking the
+	 * execution.
 	 * <p>
 	 * The checkNetworkSystemInteraction method from
 	 * JavaInstrumentationAdviceNetworkSystemToolbox is called to perform these
@@ -33,8 +33,7 @@ public final class JavaInstrumentationSendNetworkConstructorAdvice {
 	@Advice.OnMethodEnter
 	public static void onEnter(@Advice.Origin("#t") String declaringTypeName,
 			@Advice.AllArguments Object... parameters) {
-		JavaInstrumentationAdviceNetworkSystemToolbox.checkNetworkSystemInteraction("send", declaringTypeName,
-				"<init>", "", new Object[0], parameters, null);
+		JavaInstrumentationAdviceNetworkSystemToolbox.checkNetworkSystemInteraction("send", declaringTypeName, "<init>",
+				"", new Object[0], parameters, null);
 	}
 }
-

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationSendNetworkMethodAdvice.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationSendNetworkMethodAdvice.java
@@ -6,9 +6,9 @@ import java.lang.reflect.InaccessibleObjectException;
 import net.bytebuddy.asm.Advice;
 
 /**
- * This class provides advice for the execution of methods sending network
- * data. It is responsible for verifying whether the method execution is allowed
- * based on the network system security policies defined within the application.
+ * This class provides advice for the execution of methods sending network data.
+ * It is responsible for verifying whether the method execution is allowed based
+ * on the network system security policies defined within the application.
  * <p>
  * If an execution attempt violates these policies, a SecurityException is
  * thrown, preventing unauthorized network send operations. The class interacts
@@ -18,10 +18,9 @@ import net.bytebuddy.asm.Advice;
 public final class JavaInstrumentationSendNetworkMethodAdvice {
 	/**
 	 * This method is called when a method sending network data is entered. It
-	 * performs security checks to determine whether the method execution is
-	 * allowed according to network system security policies. If the method
-	 * execution is not permitted, a SecurityException is thrown, blocking the
-	 * execution.
+	 * performs security checks to determine whether the method execution is allowed
+	 * according to network system security policies. If the method execution is not
+	 * permitted, a SecurityException is thrown, blocking the execution.
 	 * <p>
 	 * The checkNetworkSystemInteraction method from
 	 * JavaInstrumentationAdviceNetworkSystemToolbox is called to perform these
@@ -74,4 +73,3 @@ public final class JavaInstrumentationSendNetworkMethodAdvice {
 		// </editor-fold>
 	}
 }
-

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/NetworkTarget.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/NetworkTarget.java
@@ -29,8 +29,8 @@ public record NetworkTarget(@Nullable String host, int port) {
 	/**
 	 * Returns a human-readable string representation of this network target.
 	 * <p>
-	 * Description: Formats the host and port as {@code host:port}. If the host
-	 * is {@code null} or blank, substitutes the placeholder {@code <unknown>}.
+	 * Description: Formats the host and port as {@code host:port}. If the host is
+	 * {@code null} or blank, substitutes the placeholder {@code <unknown>}.
 	 *
 	 * @return non-null display string in the form {@code host:port}
 	 * @since 2.0.0

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/ThreadTarget.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/ThreadTarget.java
@@ -6,9 +6,9 @@ import javax.annotation.Nullable;
 /**
  * Internal value type representing a resolved thread target.
  * <p>
- * Description: Wraps a nullable class name string. Used throughout the
- * toolbox as the canonical representation of a thread endpoint,
- * regardless of whether it originated from a {@link Runnable}, a
+ * Description: Wraps a nullable class name string. Used throughout the toolbox
+ * as the canonical representation of a thread endpoint, regardless of whether
+ * it originated from a {@link Runnable}, a
  * {@link java.util.concurrent.Callable}, a lambda expression, or another
  * thread-capable object.
  * <p>
@@ -29,8 +29,8 @@ public record ThreadTarget(@Nullable String className) {
 	/**
 	 * Returns a human-readable string representation of this thread target.
 	 * <p>
-	 * Description: Returns the class name, or {@code <unknown>}
-	 * if the class name is {@code null}.
+	 * Description: Returns the class name, or {@code <unknown>} if the class name
+	 * is {@code null}.
 	 *
 	 * @return non-null display string
 	 * @since 2.0.0

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/pointcut/JavaInstrumentationBindingDefinitions.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/pointcut/JavaInstrumentationBindingDefinitions.java
@@ -17,12 +17,12 @@ import de.tum.cit.ase.ares.api.aop.java.JavaAOPTestCaseSettings;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationAdviceAbstractToolbox;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationAdviceFileSystemToolbox;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationAdviceThreadSystemToolbox;
+import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationConnectNetworkConstructorAdvice;
+import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationConnectNetworkMethodAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationCreatePathConstructorAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationCreatePathMethodAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationCreateThreadConstructorAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationCreateThreadMethodAdvice;
-import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationConnectNetworkConstructorAdvice;
-import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationConnectNetworkMethodAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationDeletePathConstructorAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationDeletePathMethodAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationExecuteCommandConstructorAdvice;
@@ -31,10 +31,10 @@ import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentati
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationExecutePathMethodAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationOverwritePathConstructorAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationOverwritePathMethodAdvice;
-import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationReceiveNetworkConstructorAdvice;
-import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationReceiveNetworkMethodAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationReadPathConstructorAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationReadPathMethodAdvice;
+import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationReceiveNetworkConstructorAdvice;
+import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationReceiveNetworkMethodAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationSendNetworkConstructorAdvice;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.advice.JavaInstrumentationSendNetworkMethodAdvice;
 

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/pointcut/JavaInstrumentationPointcutDefinitions.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/pointcut/JavaInstrumentationPointcutDefinitions.java
@@ -84,10 +84,14 @@ public class JavaInstrumentationPointcutDefinitions {
 					.or(ElementMatchers.hasSuperType(ElementMatchers.named(target)));
 		}
 
-		// Exclude internal JVM implementation classes that have different method signatures
-		// than the public API (FileChannel.open dispatches into sun.nio.ch.FileChannelImpl.open
-		// with extra OpenOption arguments). For NIO socket / datagram / async channels the
-		// abstract method is implemented by sun.nio.ch.*ChannelImpl with the SAME signature,
+		// Exclude internal JVM implementation classes that have different method
+		// signatures
+		// than the public API (FileChannel.open dispatches into
+		// sun.nio.ch.FileChannelImpl.open
+		// with extra OpenOption arguments). For NIO socket / datagram / async channels
+		// the
+		// abstract method is implemented by sun.nio.ch.*ChannelImpl with the SAME
+		// signature,
 		// so those impls must remain instrumentable to catch instance-method calls.
 		matcher = matcher.and(ElementMatchers.not(ElementMatchers.nameStartsWith("sun.nio.ch.FileChannelImpl"))
 				.and(ElementMatchers.not(ElementMatchers.nameStartsWith("sun.nio.ch.AsynchronousFileChannelImpl")))
@@ -352,8 +356,7 @@ public class JavaInstrumentationPointcutDefinitions {
 	 */
 	public static final Map<String, List<String>> methodsWhichCanReadFiles = Map.ofEntries(
 			// java.io
-			Map.entry("java.io.Reader", List.of("<init>")),
-			Map.entry("java.io.BufferedInputStream", List.of("<init>")),
+			Map.entry("java.io.Reader", List.of("<init>")), Map.entry("java.io.BufferedInputStream", List.of("<init>")),
 			Map.entry("java.io.FileInputStream", List.of("<init>")),
 			Map.entry("java.io.RandomAccessFile", List.of("<init>")),
 			Map.entry("java.io.DataInput",
@@ -393,9 +396,8 @@ public class JavaInstrumentationPointcutDefinitions {
 			Map.entry("java.util.zip.GZIPInputStream", List.of("<init>")),
 			Map.entry("java.util.jar.JarFile", List.of("<init>", "entries", "getInputStream")),
 			Map.entry("java.util.jar.JarInputStream", List.of("<init>", "getNextJarEntry")),
-            Map.entry("java.util.Properties", List.of("load", "loadFromXML")),
-            Map.entry("java.awt.Desktop",
-                    List.of("open", "edit", "print", "browse", "browseFileDirectory")));
+			Map.entry("java.util.Properties", List.of("load", "loadFromXML")),
+			Map.entry("java.awt.Desktop", List.of("open", "edit", "print", "browse", "browseFileDirectory")));
 	// </editor-fold>
 
 	// <editor-fold desc="Overwrite Path">
@@ -459,8 +461,7 @@ public class JavaInstrumentationPointcutDefinitions {
 			// javax.xml
 			Map.entry("javax.xml.transform.Transformer", List.of("transform")),
 			Map.entry("javax.xml.bind.Marshaller", List.of("marshal")),
-            Map.entry("java.awt.Desktop",
-                    List.of("open", "edit", "print", "browse", "browseFileDirectory")));
+			Map.entry("java.awt.Desktop", List.of("open", "edit", "print", "browse", "browseFileDirectory")));
 	// </editor-fold>
 
 	// <editor-fold desc="Execute Path">
@@ -489,7 +490,8 @@ public class JavaInstrumentationPointcutDefinitions {
 	 */
 	public static final Map<String, List<String>> methodsWhichCanDeleteFiles = Map.ofEntries(
 			// java.awt
-			Map.entry("java.awt.Desktop", List.of("moveToTrash", "open", "edit", "print", "browse", "browseFileDirectory")),
+			Map.entry("java.awt.Desktop",
+					List.of("moveToTrash", "open", "edit", "print", "browse", "browseFileDirectory")),
 			// java.io
 			Map.entry("java.io.File", List.of("delete", "deleteOnExit")),
 			// java.nio

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/ArchitectureMode.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/ArchitectureMode.java
@@ -269,11 +269,8 @@ public enum ArchitectureMode {
 		// forks whose results are entirely served from disk.
 		java.util.function.Supplier<com.ibm.wala.ipa.callgraph.CallGraph> supplier = testCase.getCallGraphSupplier();
 		if (supplier != null) {
-			return new JavaWalaTestCase(
-					(JavaArchitectureTestCaseSupported) testCase.getArchitectureTestCaseSupported(),
-					testCase.getAllowedPackages(),
-					testCase.getJavaClasses(),
-					supplier);
+			return new JavaWalaTestCase((JavaArchitectureTestCaseSupported) testCase.getArchitectureTestCaseSupported(),
+					testCase.getAllowedPackages(), testCase.getJavaClasses(), supplier);
 		}
 		return JavaWalaTestCase.walaBuilder()
 				.javaArchitectureTestCaseSupported(

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCase.java
@@ -42,11 +42,11 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 	// <editor-fold desc="Attributes">
 
 	/**
-	 * Optional lazy supplier of the call graph. When non-null, the WALA
-	 * conversion uses this supplier (deferred construction) instead of the
-	 * eagerly resolved {@link #callGraph} inherited from the parent class. This
-	 * lets the WALA outcome cache short-circuit rule checks before the
-	 * (expensive) call-graph construction ever runs.
+	 * Optional lazy supplier of the call graph. When non-null, the WALA conversion
+	 * uses this supplier (deferred construction) instead of the eagerly resolved
+	 * {@link #callGraph} inherited from the parent class. This lets the WALA
+	 * outcome cache short-circuit rule checks before the (expensive) call-graph
+	 * construction ever runs.
 	 */
 	@Nullable
 	private final Supplier<CallGraph> callGraphSupplier;
@@ -98,8 +98,8 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 	 * @param callGraph                         Eagerly resolved call graph, or
 	 *                                          {@code null} when only the lazy
 	 *                                          supplier is provided
-	 * @param callGraphSupplier                 Lazy supplier of the call graph,
-	 *                                          or {@code null} when an eager
+	 * @param callGraphSupplier                 Lazy supplier of the call graph, or
+	 *                                          {@code null} when an eager
 	 *                                          {@code callGraph} is provided
 	 * @since 2.0.0
 	 */
@@ -209,7 +209,8 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 		@Nonnull
 		String detailLine = messageParts[1].trim();
 
-		// Extract the caller (Method/Constructor) and target (accesses/calls) with fallbacks.
+		// Extract the caller (Method/Constructor) and target (accesses/calls) with
+		// fallbacks.
 		String caller = null;
 		String target = null;
 
@@ -364,13 +365,13 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 			// for callers that already resolved the call graph (legacy code).
 			JavaWalaTestCase tc;
 			if (callGraphSupplier != null) {
-				tc = new JavaWalaTestCase(protectedJavaArchitectureTestCaseSupported,
-						protectedAllowedPackages, protectedJavaClasses, callGraphSupplier);
+				tc = new JavaWalaTestCase(protectedJavaArchitectureTestCaseSupported, protectedAllowedPackages,
+						protectedJavaClasses, callGraphSupplier);
 			} else {
 				tc = JavaWalaTestCase.walaBuilder()
 						.javaArchitectureTestCaseSupported(protectedJavaArchitectureTestCaseSupported)
-						.allowedPackages(protectedAllowedPackages).javaClasses(protectedJavaClasses).callGraph(callGraph)
-						.build();
+						.allowedPackages(protectedAllowedPackages).javaClasses(protectedJavaClasses)
+						.callGraph(callGraph).build();
 			}
 			tc.executeArchitectureTestCase(architectureMode, aopMode);
 		}
@@ -409,8 +410,8 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 		 * Optional lazy supplier for the call graph. When set, the conversion to a
 		 * {@link de.tum.cit.ase.ares.api.architecture.java.wala.JavaWalaTestCase}
 		 * propagates this supplier instead of resolving the call graph eagerly. This
-		 * lets the WALA outcome cache short-circuit rule checks before the
-		 * (expensive) call-graph construction ever runs.
+		 * lets the WALA outcome cache short-circuit rule checks before the (expensive)
+		 * call-graph construction ever runs.
 		 */
 		@Nullable
 		private Supplier<CallGraph> callGraphSupplier;
@@ -465,9 +466,9 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 		}
 
 		/**
-		 * Sets a lazy supplier for the call graph. Required only for WALA mode and
-		 * only when callers want construction deferred until the rule actually needs
-		 * the graph (e.g. cache miss). For ARCHUNIT mode this is irrelevant.
+		 * Sets a lazy supplier for the call graph. Required only for WALA mode and only
+		 * when callers want construction deferred until the rule actually needs the
+		 * graph (e.g. cache miss). For ARCHUNIT mode this is irrelevant.
 		 */
 		@Nonnull
 		public Builder callGraphSupplier(@Nullable Supplier<CallGraph> callGraphSupplier) {
@@ -504,8 +505,8 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 					Preconditions.checkNotNull(javaArchitectureTestCaseSupported,
 							"javaArchitecturalTestCaseSupported must not be null"),
 					Preconditions.checkNotNull(allowedPackages, "allowedPackages must not be null"),
-					Preconditions.checkNotNull(javaClasses, "javaClasses must not be null"),
-					callGraph, callGraphSupplier);
+					Preconditions.checkNotNull(javaClasses, "javaClasses must not be null"), callGraph,
+					callGraphSupplier);
 		}
 	}
 	// </editor-fold>

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/archunit/JavaArchunitTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/archunit/JavaArchunitTestCase.java
@@ -111,9 +111,9 @@ public class JavaArchunitTestCase extends JavaArchitectureTestCase {
 	 * {@code Optional.of(AssertionError)} captured from the first evaluation.
 	 * Subsequent invocations replay the cached outcome instead of re-scanning.
 	 * Keyed on category name plus {@code System.identityHashCode} of the
-	 * {@code JavaClasses}; {@code JavaClasses} is rebuilt at most once per JVM
-	 * fork by {@code ArchitectureMode.getJavaClasses(classPath)}, so the identity
-	 * is stable for the fork's lifetime.
+	 * {@code JavaClasses}; {@code JavaClasses} is rebuilt at most once per JVM fork
+	 * by {@code ArchitectureMode.getJavaClasses(classPath)}, so the identity is
+	 * stable for the fork's lifetime.
 	 */
 	/**
 	 * Cache of per-({@link JavaArchitectureTestCaseSupported}, {@code JavaClasses})
@@ -132,9 +132,7 @@ public class JavaArchunitTestCase extends JavaArchitectureTestCase {
 		JavaArchitectureTestCaseSupported supported = (JavaArchitectureTestCaseSupported) this.architectureTestCaseSupported;
 		java.util.Optional<SecurityException> cached;
 		if (supported == JavaArchitectureTestCaseSupported.PACKAGE_IMPORT) {
-			String allowedSignature = allowedPackages.stream()
-					.map(p -> p.importTheFollowingPackage())
-					.sorted()
+			String allowedSignature = allowedPackages.stream().map(p -> p.importTheFollowingPackage()).sorted()
 					.collect(java.util.stream.Collectors.joining(","));
 			String pkgKey = allowedSignature + "@" + System.identityHashCode(javaClasses);
 			cached = PACKAGE_OUTCOME_CACHE.get(pkgKey);

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/archunit/JavaArchunitTestCaseCollection.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/archunit/JavaArchunitTestCaseCollection.java
@@ -38,8 +38,8 @@ public class JavaArchunitTestCaseCollection {
 	 * Converts Java-style array notation in method signatures to the JNI-style
 	 * format that ArchUnit uses in {@code JavaAccess.getTarget().getFullName()}.
 	 * <p>
-	 * For example: {@code "java.lang.String[]"} becomes {@code "[Ljava.lang.String;"}
-	 * and {@code "byte[]"} becomes {@code "[B"}.
+	 * For example: {@code "java.lang.String[]"} becomes
+	 * {@code "[Ljava.lang.String;"} and {@code "byte[]"} becomes {@code "[B"}.
 	 *
 	 * @param signature the method signature with Java-style array notation
 	 * @return the signature with JNI-style array notation
@@ -68,8 +68,7 @@ public class JavaArchunitTestCaseCollection {
 					@Override
 					public boolean test(JavaAccess<?> javaAccess) {
 						if (forbiddenMethods == null) {
-							forbiddenMethods = FileTools.readMethodsFile(FileTools.readFile(methodsFilePath))
-									.stream()
+							forbiddenMethods = FileTools.readMethodsFile(FileTools.readFile(methodsFilePath)).stream()
 									.map(JavaArchunitTestCaseCollection::convertArrayNotation)
 									.collect(Collectors.toSet());
 						}

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilder.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilder.java
@@ -26,13 +26,13 @@ import com.ibm.wala.ipa.callgraph.CallGraphBuilder;
 import com.ibm.wala.ipa.callgraph.MethodTargetSelector;
 import com.ibm.wala.ipa.callgraph.impl.DefaultEntrypoint;
 import com.ibm.wala.ipa.callgraph.impl.Util;
-import com.ibm.wala.ipa.summaries.MethodSummary;
-import com.ibm.wala.ipa.summaries.SummarizedMethod;
-import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.ipa.cha.ClassHierarchy;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
+import com.ibm.wala.ipa.summaries.MethodSummary;
+import com.ibm.wala.ipa.summaries.SummarizedMethod;
 import com.ibm.wala.types.ClassLoaderReference;
+import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
@@ -55,12 +55,13 @@ public class CustomCallgraphBuilder {
 
 	/** Substrings that disqualify a classpath entry from the analysis scope. */
 	private static final List<String> CLASSPATH_EXCLUDE_SUBSTRINGS = List.of(
-			// Test build outputs (compiled test sources and resources, across JVM languages)
-			"/build/classes/java/test/", "/build/resources/test/",
-			"/build/classes/groovy/test/", "/build/classes/kotlin/test/",
+			// Test build outputs (compiled test sources and resources, across JVM
+			// languages)
+			"/build/classes/java/test/", "/build/resources/test/", "/build/classes/groovy/test/",
+			"/build/classes/kotlin/test/",
 			// JUnit and supporting test-platform libraries
-			"/junit-", "/junit5-", "/junit-jupiter", "/junit-platform", "/junit-vintage",
-			"/opentest4j", "/apiguardian-api", "/junit-pioneer",
+			"/junit-", "/junit5-", "/junit-jupiter", "/junit-platform", "/junit-vintage", "/opentest4j",
+			"/apiguardian-api", "/junit-pioneer",
 			// Mocking and test-double libraries
 			"/mockito-", "/byte-buddy-agent", "/objenesis",
 			// Assertion and property-based testing libraries
@@ -70,8 +71,7 @@ public class CustomCallgraphBuilder {
 			// Gradle test-runner infrastructure
 			"/gradle-worker", "/gradle-test-kit", "/test-kit",
 			// Static analysis, linting and bug-finding tools
-			"/spotbugs", "/spotbugsAnnotations",
-			"/checkstyle", "/pmd-", "/spoon-",
+			"/spotbugs", "/spotbugsAnnotations", "/checkstyle", "/pmd-", "/spoon-",
 			// Auxiliary parsing and graph libraries pulled in by analysis tooling
 			"/javaparser-", "/jgrapht-", "/info.debatty",
 			// Ares itself must never appear in its own analysis scope
@@ -100,19 +100,16 @@ public class CustomCallgraphBuilder {
 	/**
 	 * Drops classpath entries that belong to the test framework, JaCoCo, the Ares
 	 * agent, and the WALA/AspectJ runtime. Student code and any non-test library
-	 * dependencies remain in the scope. Library code is reachable on demand via
-	 * the analysis: only entries actually referenced from student-code entry
-	 * points end up in the call graph.
+	 * dependencies remain in the scope. Library code is reachable on demand via the
+	 * analysis: only entries actually referenced from student-code entry points end
+	 * up in the call graph.
 	 */
 	private static String filterClassPath(String classPath) {
 		String[] entries = classPath.split(File.pathSeparator);
-		LinkedHashSet<String> kept = Arrays.stream(entries)
-				.filter(entry -> !entry.isBlank())
-				.filter(entry -> {
-					String normalized = entry.replace(File.separatorChar, '/');
-					return CLASSPATH_EXCLUDE_SUBSTRINGS.stream().noneMatch(normalized::contains);
-				})
-				.collect(Collectors.toCollection(LinkedHashSet::new));
+		LinkedHashSet<String> kept = Arrays.stream(entries).filter(entry -> !entry.isBlank()).filter(entry -> {
+			String normalized = entry.replace(File.separatorChar, '/');
+			return CLASSPATH_EXCLUDE_SUBSTRINGS.stream().noneMatch(normalized::contains);
+		}).collect(Collectors.toCollection(LinkedHashSet::new));
 
 		// Ares' BuildMode.getClasspath narrows the analysis classpath to a single
 		// package subdirectory (e.g. build/classes/java/main/anonymous/foo/bar) so
@@ -152,16 +149,17 @@ public class CustomCallgraphBuilder {
 			java.nio.file.Files.writeString(java.nio.file.Paths.get("/tmp/wala-filter-trace.txt"),
 					"input=" + classPath + "\nwidened=" + result + "\ncwd=" + System.getProperty("user.dir") + "\n",
 					java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-		} catch (Exception ignored) {}
+		} catch (Exception ignored) {
+		}
 		return result;
 	}
 
 	/**
 	 * Helper subpackages that hold base classes / utilities shared across student
 	 * categories. Listed explicitly (instead of widening the whole build root) so
-	 * WALA's class hierarchy can resolve supertypes without dragging in every
-	 * other category's Runnable / Thread / Executor implementations, which would
-	 * blow up CHA-based dispatch resolution for Thread.start() and friends.
+	 * WALA's class hierarchy can resolve supertypes without dragging in every other
+	 * category's Runnable / Thread / Executor implementations, which would blow up
+	 * CHA-based dispatch resolution for Thread.start() and friends.
 	 */
 	private static final List<String> HELPER_SUBPACKAGES = List.of("anonymous/toolclasses");
 
@@ -216,18 +214,14 @@ public class CustomCallgraphBuilder {
 		if (clazz == null) {
 			return Collections.emptySet();
 		}
-		return classHierarchy.getImmediateSubclasses(clazz).stream().map(IClass::getName)
-				.map(Object::toString)
-				.map(this::tryResolve)
-				.filter(Optional::isPresent)
-				.map(Optional::get)
-				.collect(Collectors.toSet());
+		return classHierarchy.getImmediateSubclasses(clazz).stream().map(IClass::getName).map(Object::toString)
+				.map(this::tryResolve).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toSet());
 	}
 
 	/**
-	 * Builds the call graph for the given classpath, or returns a previously
-	 * built graph cached on the JVM. The cache lives for the lifetime of the
-	 * test JVM: the next Gradle run rebuilds it.
+	 * Builds the call graph for the given classpath, or returns a previously built
+	 * graph cached on the JVM. The cache lives for the lifetime of the test JVM:
+	 * the next Gradle run rebuilds it.
 	 */
 	public CallGraph buildCallGraph(String classPathToAnalyze) {
 		long _profileStart = System.nanoTime();
@@ -239,11 +233,13 @@ public class CustomCallgraphBuilder {
 				java.nio.file.Files.writeString(java.nio.file.Paths.get("/tmp/wala-build-times.log"),
 						System.currentTimeMillis() + "|HIT|" + _hitMs + "|" + cacheKey.hashCode() + "\n",
 						java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-			} catch (Exception ignored) {}
+			} catch (Exception ignored) {
+			}
 			return cached;
 		}
 		try {
-			// Build entry points from the WIDENED classpath so getEntryPointsFromStudentSubmission's
+			// Build entry points from the WIDENED classpath so
+			// getEntryPointsFromStudentSubmission's
 			// internal hierarchy can fully resolve student class supertypes
 			// (anonymous.toolclasses.ProtectedResourceAccess, …); without that step,
 			// the outer student classes are silently dropped and only standalone
@@ -253,23 +249,29 @@ public class CustomCallgraphBuilder {
 			// than spilling into unrelated category classes that share the wider scope.
 			String narrowPackagePrefix = derivePackagePrefix(classPathToAnalyze);
 			List<DefaultEntrypoint> customEntryPoints = ReachabilityChecker
-					.getEntryPointsFromStudentSubmission(filterClassPath(classPathToAnalyze), classHierarchy)
-					.stream()
+					.getEntryPointsFromStudentSubmission(filterClassPath(classPathToAnalyze), classHierarchy).stream()
 					.filter(ep -> narrowPackagePrefix == null
-							|| ep.getMethod().getDeclaringClass().getName().toString()
-									.startsWith(narrowPackagePrefix))
+							|| ep.getMethod().getDeclaringClass().getName().toString().startsWith(narrowPackagePrefix))
 					.collect(Collectors.toCollection(ArrayList::new));
 			AnalysisOptions options = new AnalysisOptions(scope, customEntryPoints);
 			CallGraphBuilder<?> builder = Util.makeZeroOneCFABuilder(Language.JAVA, options, new AnalysisCacheImpl(),
 					classHierarchy);
-			// Util.makeZeroOneCFABuilder installs the default + bypass selectors on options. Wrap
-			// them with a primordial-blackbox selector so WALA stops descending into JDK methods:
-			// the call edge from student code to a JDK method is still recorded (so policy checks
-			// for "calls java.io.FileInputStream.<init>" continue to work), but WALA does not load
-			// or analyse the JDK method's bytecode. The class hierarchy still contains all JDK
-			// types, so Ares' lookup-based policy decisions are unaffected. SSAPropagationCallGraphBuilder
-			// reads options.getMethodTargetSelector() dynamically (see SSAPropagationCallGraphBuilder.java
-			// around line 1577 in WALA 1.6.12), so wrapping after makeZeroOneCFABuilder takes effect.
+			// Util.makeZeroOneCFABuilder installs the default + bypass selectors on
+			// options. Wrap
+			// them with a primordial-blackbox selector so WALA stops descending into JDK
+			// methods:
+			// the call edge from student code to a JDK method is still recorded (so policy
+			// checks
+			// for "calls java.io.FileInputStream.<init>" continue to work), but WALA does
+			// not load
+			// or analyse the JDK method's bytecode. The class hierarchy still contains all
+			// JDK
+			// types, so Ares' lookup-based policy decisions are unaffected.
+			// SSAPropagationCallGraphBuilder
+			// reads options.getMethodTargetSelector() dynamically (see
+			// SSAPropagationCallGraphBuilder.java
+			// around line 1577 in WALA 1.6.12), so wrapping after makeZeroOneCFABuilder
+			// takes effect.
 			options.setSelector(new JdkOpaqueMethodTargetSelector(options.getMethodTargetSelector()));
 			long _mkCgStart = System.nanoTime();
 			CallGraph callGraph = builder.makeCallGraph(options, null);
@@ -277,34 +279,43 @@ public class CustomCallgraphBuilder {
 			long _totalMs = (System.nanoTime() - _profileStart) / 1_000_000L;
 			try {
 				java.nio.file.Files.writeString(java.nio.file.Paths.get("/tmp/wala-build-times.log"),
-						System.currentTimeMillis() + "|MISS|" + _totalMs + "|mkcg=" + _mkCgMs + "|" + cacheKey.hashCode() + "|" + classPathToAnalyze + "\n",
+						System.currentTimeMillis() + "|MISS|" + _totalMs + "|mkcg=" + _mkCgMs + "|"
+								+ cacheKey.hashCode() + "|" + classPathToAnalyze + "\n",
 						java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-			} catch (Exception ignored) {}
+			} catch (Exception ignored) {
+			}
 			CallGraph existing = CALL_GRAPH_CACHE.putIfAbsent(cacheKey, callGraph);
 			if (existing == null) {
 				try {
 					java.util.Set<String> anonClasses = new java.util.TreeSet<>();
 					int totalCgNodes = 0;
-					for (com.ibm.wala.ipa.callgraph.CGNode n : (Iterable<com.ibm.wala.ipa.callgraph.CGNode>) () -> callGraph.iterator()) {
+					for (com.ibm.wala.ipa.callgraph.CGNode n : (Iterable<com.ibm.wala.ipa.callgraph.CGNode>) () -> callGraph
+							.iterator()) {
 						totalCgNodes++;
 						String dn = n.getMethod().getDeclaringClass().getName().toString();
-						if (dn.startsWith("Lanonymous/")) anonClasses.add(dn);
+						if (dn.startsWith("Lanonymous/"))
+							anonClasses.add(dn);
 					}
 					int chCount = 0;
 					java.util.Set<String> chAnon = new java.util.TreeSet<>();
-					for (com.ibm.wala.classLoader.IClass c : (Iterable<com.ibm.wala.classLoader.IClass>) () -> classHierarchy.iterator()) {
+					for (com.ibm.wala.classLoader.IClass c : (Iterable<com.ibm.wala.classLoader.IClass>) () -> classHierarchy
+							.iterator()) {
 						chCount++;
 						String n = c.getName().toString();
-						if (n.startsWith("Lanonymous/")) chAnon.add(n);
+						if (n.startsWith("Lanonymous/"))
+							chAnon.add(n);
 					}
 					StringBuilder sb = new StringBuilder();
 					sb.append("CG totalNodes=").append(totalCgNodes).append("\n");
 					sb.append("CG anon student classes (").append(anonClasses.size()).append("):\n");
-					for (String c : anonClasses) sb.append("  ").append(c).append("\n");
+					for (String c : anonClasses)
+						sb.append("  ").append(c).append("\n");
 					sb.append("Hierarchy total=").append(chCount).append(" anon=").append(chAnon.size()).append("\n");
-					for (String c : chAnon) sb.append("  ").append(c).append("\n");
+					for (String c : chAnon)
+						sb.append("  ").append(c).append("\n");
 					java.nio.file.Files.writeString(java.nio.file.Paths.get("/tmp/wala-cg-stats.txt"), sb.toString());
-				} catch (Exception ignored) {}
+				} catch (Exception ignored) {
+				}
 			}
 			return existing != null ? existing : callGraph;
 		} catch (Exception e) {
@@ -312,25 +323,28 @@ public class CustomCallgraphBuilder {
 		}
 	}
 
-
 	/**
-	 * Convert a classpath entry like {@code build/classes/java/main/anonymous/foo/bar}
-	 * into the WALA TypeName prefix {@code Lanonymous/foo/bar/} so we can keep
-	 * entry points limited to the test's package without re-deriving it from the
-	 * policy. Returns {@code null} if the path doesn't look like a build-output
-	 * package directory (in which case no narrowing is applied).
+	 * Convert a classpath entry like
+	 * {@code build/classes/java/main/anonymous/foo/bar} into the WALA TypeName
+	 * prefix {@code Lanonymous/foo/bar/} so we can keep entry points limited to the
+	 * test's package without re-deriving it from the policy. Returns {@code null}
+	 * if the path doesn't look like a build-output package directory (in which case
+	 * no narrowing is applied).
 	 */
 	private static String derivePackagePrefix(String classPath) {
-		if (classPath == null) return null;
+		if (classPath == null)
+			return null;
 		String first = classPath.split(File.pathSeparator)[0].replace(File.separatorChar, '/');
-		String[] markers = {"/build/classes/java/main/", "build/classes/java/main/",
-				"/target/classes/", "target/classes/"};
+		String[] markers = { "/build/classes/java/main/", "build/classes/java/main/", "/target/classes/",
+				"target/classes/" };
 		for (String marker : markers) {
 			int idx = first.indexOf(marker);
 			if (idx >= 0) {
 				String pkg = first.substring(idx + marker.length());
-				if (pkg.isBlank()) return null;
-				if (!pkg.endsWith("/")) pkg = pkg + "/";
+				if (pkg.isBlank())
+					return null;
+				if (!pkg.endsWith("/"))
+					pkg = pkg + "/";
 				return "L" + pkg;
 			}
 		}
@@ -338,21 +352,23 @@ public class CustomCallgraphBuilder {
 	}
 
 	/**
-	 * Treats every method declared in a primordial class (the JDK) as opaque: returns a
-	 * {@link SummarizedMethod} with an empty {@link MethodSummary} for primordial targets so
-	 * WALA records the call edge and creates a CGNode (preserving the JDK signature for
-	 * downstream forbidden-call predicates such as {@code WalaRule.isForbidden}), but does
-	 * not load or analyse the JDK method's bytecode. Non-primordial calls are forwarded to
-	 * the wrapped selector chain set up by {@link Util#addDefaultSelectors} and
-	 * {@link Util#addDefaultBypassLogic} (LambdaMethodTargetSelector → BypassMethodTargetSelector
-	 * → ClassHierarchyMethodTargetSelector).
-	 *
-	 * <p>An earlier revision returned {@code null} for primordial targets, which removed the
-	 * CGNode entirely. {@link de.tum.cit.ase.ares.api.architecture.java.wala.WalaRule#check}
-	 * relies on those CGNodes to recognise forbidden JDK calls, so {@code null} silently
-	 * disabled blocked-all detection. Returning a SummarizedMethod keeps the node and edge
-	 * but skips body analysis. Summaries are cached by {@link MethodReference} to avoid
-	 * per-call allocation during propagation.
+	 * Treats every method declared in a primordial class (the JDK) as opaque:
+	 * returns a {@link SummarizedMethod} with an empty {@link MethodSummary} for
+	 * primordial targets so WALA records the call edge and creates a CGNode
+	 * (preserving the JDK signature for downstream forbidden-call predicates such
+	 * as {@code WalaRule.isForbidden}), but does not load or analyse the JDK
+	 * method's bytecode. Non-primordial calls are forwarded to the wrapped selector
+	 * chain set up by {@link Util#addDefaultSelectors} and
+	 * {@link Util#addDefaultBypassLogic} (LambdaMethodTargetSelector →
+	 * BypassMethodTargetSelector → ClassHierarchyMethodTargetSelector).
+	 * <p>
+	 * An earlier revision returned {@code null} for primordial targets, which
+	 * removed the CGNode entirely.
+	 * {@link de.tum.cit.ase.ares.api.architecture.java.wala.WalaRule#check} relies
+	 * on those CGNodes to recognise forbidden JDK calls, so {@code null} silently
+	 * disabled blocked-all detection. Returning a SummarizedMethod keeps the node
+	 * and edge but skips body analysis. Summaries are cached by
+	 * {@link MethodReference} to avoid per-call allocation during propagation.
 	 */
 	private static final class JdkOpaqueMethodTargetSelector implements MethodTargetSelector {
 
@@ -369,8 +385,7 @@ public class CustomCallgraphBuilder {
 			if (target == null) {
 				return null;
 			}
-			if (!target.getDeclaringClass().getClassLoader().getReference()
-					.equals(ClassLoaderReference.Primordial)) {
+			if (!target.getDeclaringClass().getClassLoader().getReference().equals(ClassLoaderReference.Primordial)) {
 				return target;
 			}
 			MethodReference ref = target.getReference();
@@ -401,9 +416,9 @@ public class CustomCallgraphBuilder {
 
 		static CachedAnalysis build(String filteredClassPath) {
 			try {
-				AnalysisScope scope = Java9AnalysisScopeReader.instance.makeJavaBinaryAnalysisScope(
-						filteredClassPath, FileTools.readFile(FileTools
-								.resolveFileOnSourceDirectory("templates", "architecture", "java", "exclusions.txt")));
+				AnalysisScope scope = Java9AnalysisScopeReader.instance.makeJavaBinaryAnalysisScope(filteredClassPath,
+						FileTools.readFile(FileTools.resolveFileOnSourceDirectory("templates", "architecture", "java",
+								"exclusions.txt")));
 				ClassHierarchy hierarchy = ClassHierarchyFactory.make(scope);
 				return new CachedAnalysis(scope, hierarchy);
 			} catch (ClassHierarchyException | IOException e) {

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomDFSPathFinder.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomDFSPathFinder.java
@@ -171,8 +171,8 @@ public class CustomDFSPathFinder {
 	 * <p>
 	 * WALA stores successor sets in HashSet-backed collections; their iteration
 	 * order depends on each {@code CGNode}'s identity hashcode, which is seeded
-	 * once per JVM and therefore differs between runs. Sorting by method
-	 * signature gives DFS the same traversal order every time.
+	 * once per JVM and therefore differs between runs. Sorting by method signature
+	 * gives DFS the same traversal order every time.
 	 *
 	 * @since 2.0.0
 	 * @author Markus Paulsen

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/JavaWalaTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/JavaWalaTestCase.java
@@ -10,8 +10,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.HashSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -53,19 +53,20 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 	/**
 	 * In-memory mirror of the disk cache: maps "classpath fingerprint + rule" to
 	 * the cached outcome of running that WALA rule.
-	 *
-	 * <p>WALA call-graph construction dominates the cost of {@code testAllModes}
+	 * <p>
+	 * WALA call-graph construction dominates the cost of {@code testAllModes}
 	 * (~5–7s × #packages × #JVM forks). Gradle launches a separate JVM for each
 	 * sub-task ({@code testUnprotected}, {@code testPermitted},
 	 * {@code testBlockedPartial}, {@code testBlockedAll}), so the in-memory cache
 	 * in {@code JavaCreator.cacheResult} doesn't cross fork boundaries. This
-	 * disk-backed cache survives JVM exits and lets later forks short-circuit
-	 * rule checks for which the outcome was already computed.
+	 * disk-backed cache survives JVM exits and lets later forks short-circuit rule
+	 * checks for which the outcome was already computed.
 	 */
 	/**
-	 * Serializable holder for a cached rule outcome. {@link Optional} is intentionally
-	 * not {@link Serializable} in the JDK, which caused silent persistence failure when
-	 * the map values were {@code Optional<SecurityException>}.
+	 * Serializable holder for a cached rule outcome. {@link Optional} is
+	 * intentionally not {@link Serializable} in the JDK, which caused silent
+	 * persistence failure when the map values were
+	 * {@code Optional<SecurityException>}.
 	 */
 	private static final class CachedOutcome implements Serializable {
 		private static final long serialVersionUID = 1L;
@@ -78,8 +79,7 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 	}
 
 	@Nonnull
-	private static final ConcurrentHashMap<String, CachedOutcome> RULE_OUTCOME_CACHE =
-			new ConcurrentHashMap<>();
+	private static final ConcurrentHashMap<String, CachedOutcome> RULE_OUTCOME_CACHE = new ConcurrentHashMap<>();
 
 	/**
 	 * Persistent cache file location. Lives in the system temp directory so it
@@ -87,13 +87,11 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 	 * Ares-jar rebuild (the jar mtime is folded into the cache key).
 	 */
 	@Nonnull
-	private static final Path CACHE_FILE = Paths.get(System.getProperty("java.io.tmpdir"),
-			"ares-wala-outcomes.bin");
+	private static final Path CACHE_FILE = Paths.get(System.getProperty("java.io.tmpdir"), "ares-wala-outcomes.bin");
 
 	static {
 		loadCacheFromDisk();
-		Runtime.getRuntime().addShutdownHook(new Thread(JavaWalaTestCase::saveCacheToDisk,
-				"ares-wala-outcomes-saver"));
+		Runtime.getRuntime().addShutdownHook(new Thread(JavaWalaTestCase::saveCacheToDisk, "ares-wala-outcomes-saver"));
 	}
 
 	private static void loadCacheFromDisk() {
@@ -135,40 +133,34 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 	}
 
 	/**
-	 * Build a stable cache key combining the analysis classpath, the Ares-jar mtime,
-	 * the rule name, AND the per-package input fingerprint (sorted class names of
-	 * {@code javaClasses} plus the sorted set of {@code allowedPackages}). The
-	 * per-package fingerprint is essential: different student packages produce
-	 * different call graphs and therefore different rule outcomes for the same
-	 * rule name; without it, the first package's outcome would be served to every
-	 * other package.
+	 * Build a stable cache key combining the analysis classpath, the Ares-jar
+	 * mtime, the rule name, AND the per-package input fingerprint (sorted class
+	 * names of {@code javaClasses} plus the sorted set of {@code allowedPackages}).
+	 * The per-package fingerprint is essential: different student packages produce
+	 * different call graphs and therefore different rule outcomes for the same rule
+	 * name; without it, the first package's outcome would be served to every other
+	 * package.
 	 */
 	@Nonnull
 	private String cacheKey() {
 		long aresMtime = 0L;
 		try {
-			Path own = Paths.get(JavaWalaTestCase.class.getProtectionDomain().getCodeSource()
-					.getLocation().toURI());
+			Path own = Paths.get(JavaWalaTestCase.class.getProtectionDomain().getCodeSource().getLocation().toURI());
 			aresMtime = Files.getLastModifiedTime(own).toMillis();
 		} catch (Exception ignored) {
 			// Fall back to the version-string component below.
 		}
 		String classpath = Stream.of(System.getProperty("java.class.path", "").split(java.io.File.pathSeparator))
-				.filter(p -> p.contains("classes") || p.contains("build"))
-				.sorted()
+				.filter(p -> p.contains("classes") || p.contains("build")).sorted()
 				.collect(Collectors.joining(java.io.File.pathSeparator));
-		String classNamesFingerprint = javaClasses.stream()
-				.map(JavaClass::getFullName)
-				.sorted()
+		String classNamesFingerprint = javaClasses.stream().map(JavaClass::getFullName).sorted()
 				.collect(Collectors.joining(","));
-		String allowedPackagesFingerprint = allowedPackages.stream()
-				.map(PackagePermission::importTheFollowingPackage)
-				.sorted()
-				.collect(Collectors.joining(","));
+		String allowedPackagesFingerprint = allowedPackages.stream().map(PackagePermission::importTheFollowingPackage)
+				.sorted().collect(Collectors.joining(","));
 		return classpath + "|" + aresMtime + "|"
-				+ ((JavaArchitectureTestCaseSupported) this.architectureTestCaseSupported).name()
-				+ "|cls=" + Integer.toHexString(classNamesFingerprint.hashCode())
-				+ "|pkg=" + Integer.toHexString(allowedPackagesFingerprint.hashCode());
+				+ ((JavaArchitectureTestCaseSupported) this.architectureTestCaseSupported).name() + "|cls="
+				+ Integer.toHexString(classNamesFingerprint.hashCode()) + "|pkg="
+				+ Integer.toHexString(allowedPackagesFingerprint.hashCode());
 	}
 
 	// </editor-fold>
@@ -177,8 +169,8 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 
 	/**
 	 * Lazy supplier of the WALA call graph used for rule checks.
-	 *
-	 * <p>When constructed via the eager-CallGraph constructor (kept for backward
+	 * <p>
+	 * When constructed via the eager-CallGraph constructor (kept for backward
 	 * compatibility), this is a thunk over the already-resolved instance. When
 	 * constructed via the supplier-based constructor (used by {@code JavaCreator}),
 	 * the call graph is built only on the first cache miss in
@@ -275,19 +267,19 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 
 	/**
 	 * Executes the architecture test case.
-	 *
-	 * <p>Outcomes are cached on disk keyed by classpath + Ares-jar mtime + rule name, so
-	 * subsequent JVM forks (e.g. {@code testPermitted} after {@code testUnprotected})
-	 * skip the expensive call-graph traversal when the same rule was already evaluated
-	 * for the same classpath.
+	 * <p>
+	 * Outcomes are cached on disk keyed by classpath + Ares-jar mtime + rule name,
+	 * so subsequent JVM forks (e.g. {@code testPermitted} after
+	 * {@code testUnprotected}) skip the expensive call-graph traversal when the
+	 * same rule was already evaluated for the same classpath.
 	 */
 	@Override
 	public void executeArchitectureTestCase(@Nonnull String architectureMode, @Nonnull String aopMode) {
-		JavaArchitectureTestCaseSupported supported =
-				(JavaArchitectureTestCaseSupported) this.architectureTestCaseSupported;
+		JavaArchitectureTestCaseSupported supported = (JavaArchitectureTestCaseSupported) this.architectureTestCaseSupported;
 		// Priority rules (NATIVE_CODE, AGENT_ATTACH, ENVIRONMENT_ACCESS, MODULE_SYSTEM,
 		// JNDI_INJECTION) always run in every test mode and delegate to ArchUnit. Their
-		// outcome depends on which resources are permitted in the current test scenario,
+		// outcome depends on which resources are permitted in the current test
+		// scenario,
 		// but the allowedPackages component of the cache key is identical between
 		// testPermitted and testBlockedAll for these rules (permitted agent/env/JNDI
 		// resources do not contribute package imports). Skipping the disk cache for
@@ -320,8 +312,8 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 	}
 
 	/**
-	 * Run the WALA rule for this case and translate the AssertionError outcome
-	 * (if any) into a {@link SecurityException} so it can be cached uniformly.
+	 * Run the WALA rule for this case and translate the AssertionError outcome (if
+	 * any) into a {@link SecurityException} so it can be cached uniformly.
 	 */
 	@Nonnull
 	private Optional<SecurityException> runRuleAndCapture(@Nonnull String architectureMode, @Nonnull String aopMode) {
@@ -355,10 +347,9 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 				// javax.naming, …) live in JDK packages outside the application analysis
 				// scope. ArchUnit's class-level scan does see them — delegate.
 				de.tum.cit.ase.ares.api.architecture.java.archunit.JavaArchunitTestCase.archunitBuilder()
-						.javaArchitectureTestCaseSupported((JavaArchitectureTestCaseSupported) this.architectureTestCaseSupported)
-						.javaClasses(this.javaClasses)
-						.allowedPackages(this.allowedPackages)
-						.build()
+						.javaArchitectureTestCaseSupported(
+								(JavaArchitectureTestCaseSupported) this.architectureTestCaseSupported)
+						.javaClasses(this.javaClasses).allowedPackages(this.allowedPackages).build()
 						.executeArchitectureTestCase(architectureMode, aopMode);
 			default -> throw new SecurityException(
 					Messages.localized("security.common.unsupported.operation", this.architectureTestCaseSupported));
@@ -372,7 +363,8 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 				return Optional.of(parsed);
 			}
 		} catch (SecurityException sec) {
-			// The NATIVE_CODE/etc. branch delegates to ArchUnit which throws SecurityException
+			// The NATIVE_CODE/etc. branch delegates to ArchUnit which throws
+			// SecurityException
 			// directly. Preserve and cache.
 			return Optional.of(sec);
 		}

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/ReachabilityChecker.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/ReachabilityChecker.java
@@ -46,13 +46,16 @@ public class ReachabilityChecker {
 	public static List<CGNode> findReachableMethods(CallGraph callGraph, Iterator<CGNode> startNodes,
 			Predicate<CGNode> targetNodeFilter) {
 		if (callGraph == null) {
-			throw new SecurityException(Messages.localized("security.common.not.null", "CallGraph", "findReachableMethods"));
+			throw new SecurityException(
+					Messages.localized("security.common.not.null", "CallGraph", "findReachableMethods"));
 		}
 		if (startNodes == null) {
-			throw new SecurityException(Messages.localized("security.common.not.null", "startNodes", "findReachableMethods"));
+			throw new SecurityException(
+					Messages.localized("security.common.not.null", "startNodes", "findReachableMethods"));
 		}
 		if (targetNodeFilter == null) {
-			throw new SecurityException(Messages.localized("security.common.not.null", "targetNodeFilter", "findReachableMethods"));
+			throw new SecurityException(
+					Messages.localized("security.common.not.null", "targetNodeFilter", "findReachableMethods"));
 		}
 		return new CustomDFSPathFinder(callGraph, startNodes, targetNodeFilter).find();
 	}
@@ -62,16 +65,17 @@ public class ReachabilityChecker {
 	 * identity, classPath)}. The hierarchy reference is part of the key because
 	 * {@link DefaultEntrypoint} captures it: a different application hierarchy must
 	 * not reuse another's entry points.
-	 *
-	 * <p>The intermediate {@link ClassHierarchy} created by {@link #createClassHierarchy}
-	 * is intentionally NOT cached separately. Each inner hierarchy reloads the full
-	 * JDK primordial scope, so caching ~13 hierarchies per phase exhausts the 512 MB
-	 * Gradle test-worker heap and crashes the JVM (observed empirically: testPermitted
-	 * died with "Could not complete execution for Gradle Test Executor"). Caching the
-	 * entry-point list alone is sufficient: on cache hit the inner-hierarchy build is
-	 * skipped entirely; on miss the hierarchy is built once, used to enumerate methods,
-	 * and then released for GC since {@link DefaultEntrypoint} only retains references
-	 * to {@link com.ibm.wala.types.MethodReference} and the application hierarchy.
+	 * <p>
+	 * The intermediate {@link ClassHierarchy} created by
+	 * {@link #createClassHierarchy} is intentionally NOT cached separately. Each
+	 * inner hierarchy reloads the full JDK primordial scope, so caching ~13
+	 * hierarchies per phase exhausts the 512 MB Gradle test-worker heap and crashes
+	 * the JVM (observed empirically: testPermitted died with "Could not complete
+	 * execution for Gradle Test Executor"). Caching the entry-point list alone is
+	 * sufficient: on cache hit the inner-hierarchy build is skipped entirely; on
+	 * miss the hierarchy is built once, used to enumerate methods, and then
+	 * released for GC since {@link DefaultEntrypoint} only retains references to
+	 * {@link com.ibm.wala.types.MethodReference} and the application hierarchy.
 	 */
 	private static final ConcurrentHashMap<String, List<DefaultEntrypoint>> ENTRYPOINTS_CACHE = new ConcurrentHashMap<>();
 
@@ -89,10 +93,12 @@ public class ReachabilityChecker {
 	public static List<DefaultEntrypoint> getEntryPointsFromStudentSubmission(String classPath,
 			ClassHierarchy applicationClassHierarchy) {
 		if (classPath == null || classPath.trim().isEmpty()) {
-			throw new SecurityException(Messages.localized("security.common.not.null", "classPath", "getEntryPointsFromStudentSubmission"));
+			throw new SecurityException(
+					Messages.localized("security.common.not.null", "classPath", "getEntryPointsFromStudentSubmission"));
 		}
 		if (applicationClassHierarchy == null) {
-			throw new SecurityException(Messages.localized("security.common.not.null", "ClassHierarchy", "getEntryPointsFromStudentSubmission"));
+			throw new SecurityException(Messages.localized("security.common.not.null", "ClassHierarchy",
+					"getEntryPointsFromStudentSubmission"));
 		}
 		String cacheKey = System.identityHashCode(applicationClassHierarchy) + "::" + classPath;
 		List<DefaultEntrypoint> cached = ENTRYPOINTS_CACHE.get(cacheKey);
@@ -100,11 +106,11 @@ public class ReachabilityChecker {
 			return cached;
 		}
 		try {
-			List<DefaultEntrypoint> fresh = new ArrayList<>(io.vavr.collection.Stream.ofAll(createClassHierarchy(classPath)).toJavaStream()
+			List<DefaultEntrypoint> fresh = new ArrayList<>(io.vavr.collection.Stream
+					.ofAll(createClassHierarchy(classPath)).toJavaStream()
 					.filter(iClass -> iClass.getClassLoader().getReference().equals(ClassLoaderReference.Application))
 					.map(IClass::getDeclaredMethods).map(io.vavr.collection.Stream::ofAll)
-					.flatMap(io.vavr.collection.Stream::toJavaStream)
-					.map(IMethod::getReference)
+					.flatMap(io.vavr.collection.Stream::toJavaStream).map(IMethod::getReference)
 					.map(methodReference -> new DefaultEntrypoint(methodReference, applicationClassHierarchy))
 					.toList());
 			List<DefaultEntrypoint> immutable = Collections.unmodifiableList(fresh);

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/WalaPathClassification.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/WalaPathClassification.java
@@ -4,215 +4,216 @@ import java.util.List;
 import java.util.OptionalInt;
 
 import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.debug.UnimplementedError;
-import com.ibm.wala.core.util.strings.Atom;
 
 import de.tum.cit.ase.ares.api.localization.Messages;
 
 /**
  * Package-private utility for classifying WALA call-graph nodes as
  * student-authored or infrastructure (JDK / Ares / test helpers).
- *
- * <p>Used by {@link WalaRule} to attribute security violations to the nearest
- * student frame rather than an intermediate JDK method.</p>
+ * <p>
+ * Used by {@link WalaRule} to attribute security violations to the nearest
+ * student frame rather than an intermediate JDK method.
+ * </p>
  */
 class WalaPathClassification {
 
-    // <editor-fold desc="Constructor">
-    private WalaPathClassification() {
-        throw new SecurityException(
-                Messages.localized("security.general.utility.initialization", "WalaPathClassification"));
-    }
-    // </editor-fold>
+	// <editor-fold desc="Constructor">
+	private WalaPathClassification() {
+		throw new SecurityException(
+				Messages.localized("security.general.utility.initialization", "WalaPathClassification"));
+	}
+	// </editor-fold>
 
-    // <editor-fold desc="Constants">
+	// <editor-fold desc="Constants">
 
-    /**
-     * Package prefixes (with trailing dot) that belong to infrastructure and must
-     * not be attributed as student code. Mirrors the exclusions in AspectJ's
-     * {@code studentScope()} pointcut.
-     *
-     * <p>The two reproducibility-repo helper packages ({@code anonymous.toolclasses.}
-     * and {@code metatest.}) are included here intentionally: they are test-framework
-     * helpers, not student-authored code under test. If a future Ares consumer uses
-     * different helper packages, this list will need to be made configurable.</p>
-     */
-    static final List<String> INFRA_PREFIXES = List.of(
-            "java.", "javax.", "sun.", "jdk.", "com.sun.",
-            "de.tum.cit.ase.ares.",
-            "net.bytebuddy.", "org.aspectj.",
-            "com.ibm.wala.", "com.tngtech.archunit.",
-            "anonymous.toolclasses.", "metatest."
-    );
+	/**
+	 * Package prefixes (with trailing dot) that belong to infrastructure and must
+	 * not be attributed as student code. Mirrors the exclusions in AspectJ's
+	 * {@code studentScope()} pointcut.
+	 * <p>
+	 * The two reproducibility-repo helper packages ({@code anonymous.toolclasses.}
+	 * and {@code metatest.}) are included here intentionally: they are
+	 * test-framework helpers, not student-authored code under test. If a future
+	 * Ares consumer uses different helper packages, this list will need to be made
+	 * configurable.
+	 * </p>
+	 */
+	static final List<String> INFRA_PREFIXES = List.of("java.", "javax.", "sun.", "jdk.", "com.sun.",
+			"de.tum.cit.ase.ares.", "net.bytebuddy.", "org.aspectj.", "com.ibm.wala.", "com.tngtech.archunit.",
+			"anonymous.toolclasses.", "metatest.");
 
-    /**
-     * Subset of {@link #INFRA_PREFIXES} that genuinely indicates a transitive
-     * false-positive path: the student called a permitted JDK or framework API
-     * and the JDK or framework internally invoked a forbidden one. Only JDK,
-     * Ares-internal, AspectJ, ByteBuddy, WALA and ArchUnit packages qualify.
-     *
-     * <p>Project-specific test helpers ({@code anonymous.toolclasses.} and
-     * {@code metatest.}) are deliberately omitted: when student code routes
-     * through such a helper into a forbidden JDK API, the helper exists for the
-     * sole purpose of exercising that API. Treating those paths as false
-     * positives silently disabled BLOCKED_ALL detection for every Network /
-     * FileSystem / Command call placed inside a project test helper.</p>
-     */
-    static final List<String> TRANSITIVE_FALSE_POSITIVE_PREFIXES = List.of(
-            "java.", "javax.", "sun.", "jdk.", "com.sun.",
-            "de.tum.cit.ase.ares.",
-            "net.bytebuddy.", "org.aspectj.",
-            "com.ibm.wala.", "com.tngtech.archunit."
-    );
-    // </editor-fold>
+	/**
+	 * Subset of {@link #INFRA_PREFIXES} that genuinely indicates a transitive
+	 * false-positive path: the student called a permitted JDK or framework API and
+	 * the JDK or framework internally invoked a forbidden one. Only JDK,
+	 * Ares-internal, AspectJ, ByteBuddy, WALA and ArchUnit packages qualify.
+	 * <p>
+	 * Project-specific test helpers ({@code anonymous.toolclasses.} and
+	 * {@code metatest.}) are deliberately omitted: when student code routes through
+	 * such a helper into a forbidden JDK API, the helper exists for the sole
+	 * purpose of exercising that API. Treating those paths as false positives
+	 * silently disabled BLOCKED_ALL detection for every Network / FileSystem /
+	 * Command call placed inside a project test helper.
+	 * </p>
+	 */
+	static final List<String> TRANSITIVE_FALSE_POSITIVE_PREFIXES = List.of("java.", "javax.", "sun.", "jdk.",
+			"com.sun.", "de.tum.cit.ase.ares.", "net.bytebuddy.", "org.aspectj.", "com.ibm.wala.",
+			"com.tngtech.archunit.");
+	// </editor-fold>
 
-    // <editor-fold desc="Public API">
+	// <editor-fold desc="Public API">
 
-    /**
-     * Returns the index (in {@code path}) of the frame closest to the forbidden
-     * sink that belongs to student code (i.e., not in {@link #INFRA_PREFIXES} and
-     * not loaded by a JDK classloader).
-     *
-     * <p>The scan runs from {@code path.size()-1} (the sink) down to {@code 0}
-     * (the entry point). The first non-infra frame found is returned.</p>
-     *
-     * @param path ordered call-graph path, {@code path.get(path.size()-1)} is the
-     *             forbidden node
-     * @return the index of the nearest student frame, or empty if the entire path
-     *         is infrastructure
-     */
-    static OptionalInt nearestStudentFrame(List<CGNode> path) {
-        for (int i = path.size() - 1; i >= 0; i--) {
-            try {
-                if (!isInfraFrame(path.get(i))) {
-                    return OptionalInt.of(i);
-                }
-            } catch (RuntimeException | UnimplementedError ignored) {
-                // skip malformed / synthetic frame
-            }
-        }
-        return OptionalInt.empty();
-    }
+	/**
+	 * Returns the index (in {@code path}) of the frame closest to the forbidden
+	 * sink that belongs to student code (i.e., not in {@link #INFRA_PREFIXES} and
+	 * not loaded by a JDK classloader).
+	 * <p>
+	 * The scan runs from {@code path.size()-1} (the sink) down to {@code 0} (the
+	 * entry point). The first non-infra frame found is returned.
+	 * </p>
+	 *
+	 * @param path ordered call-graph path, {@code path.get(path.size()-1)} is the
+	 *             forbidden node
+	 * @return the index of the nearest student frame, or empty if the entire path
+	 *         is infrastructure
+	 */
+	static OptionalInt nearestStudentFrame(List<CGNode> path) {
+		for (int i = path.size() - 1; i >= 0; i--) {
+			try {
+				if (!isInfraFrame(path.get(i))) {
+					return OptionalInt.of(i);
+				}
+			} catch (RuntimeException | UnimplementedError ignored) {
+				// skip malformed / synthetic frame
+			}
+		}
+		return OptionalInt.empty();
+	}
 
-    /**
-     * Returns {@code true} when the path represents a transitive-JDK false positive:
-     * the student frame at {@code studentIdx} exists but every frame strictly between
-     * it and the forbidden sink is an infrastructure frame.
-     *
-     * <p>This pattern occurs when student code uses a permitted JDK API (e.g.
-     * {@code BufferedReader}, {@code AsynchronousSocketChannel}) whose internal
-     * implementation transitively reaches a forbidden method such as
-     * {@code Class.forName()} or {@code Thread.start()}. The student did not
-     * intentionally call the forbidden API; it was an internal JDK side-effect.</p>
-     *
-     * <p>Direct violations — where the student frame is immediately adjacent to
-     * the forbidden sink (no intermediate frames) — are never suppressed.</p>
-     *
-     * @param path       the call-graph path ({@code path.get(path.size()-1)} is the
-     *                   forbidden sink)
-     * @param studentIdx the index returned by {@link #nearestStudentFrame}
-     * @return {@code true} if the violation is a transitive-JDK false positive
-     */
-    static boolean isFalsePositiveTransitivePath(List<CGNode> path, int studentIdx) {
-        int sinkIdx = path.size() - 1;
-        if (studentIdx >= sinkIdx - 1) {
-            return false;
-        }
-        for (int j = studentIdx + 1; j < sinkIdx; j++) {
-            if (!isTransitiveFalsePositiveFrame(path.get(j))) {
-                return false;
-            }
-        }
-        return true;
-    }
+	/**
+	 * Returns {@code true} when the path represents a transitive-JDK false
+	 * positive: the student frame at {@code studentIdx} exists but every frame
+	 * strictly between it and the forbidden sink is an infrastructure frame.
+	 * <p>
+	 * This pattern occurs when student code uses a permitted JDK API (e.g.
+	 * {@code BufferedReader}, {@code AsynchronousSocketChannel}) whose internal
+	 * implementation transitively reaches a forbidden method such as
+	 * {@code Class.forName()} or {@code Thread.start()}. The student did not
+	 * intentionally call the forbidden API; it was an internal JDK side-effect.
+	 * </p>
+	 * <p>
+	 * Direct violations — where the student frame is immediately adjacent to the
+	 * forbidden sink (no intermediate frames) — are never suppressed.
+	 * </p>
+	 *
+	 * @param path       the call-graph path ({@code path.get(path.size()-1)} is the
+	 *                   forbidden sink)
+	 * @param studentIdx the index returned by {@link #nearestStudentFrame}
+	 * @return {@code true} if the violation is a transitive-JDK false positive
+	 */
+	static boolean isFalsePositiveTransitivePath(List<CGNode> path, int studentIdx) {
+		int sinkIdx = path.size() - 1;
+		if (studentIdx >= sinkIdx - 1) {
+			return false;
+		}
+		for (int j = studentIdx + 1; j < sinkIdx; j++) {
+			if (!isTransitiveFalsePositiveFrame(path.get(j))) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-    /**
-     * Returns {@code true} when the given CGNode belongs to infrastructure:
-     * JDK boot/extension/synthetic classes or any package in {@link #INFRA_PREFIXES}.
-     */
-    static boolean isInfraFrame(CGNode node) {
-        try {
-            IClass cls = node.getMethod().getDeclaringClass();
-            if (cls == null) {
-                return true;
-            }
-            ClassLoaderReference loader = cls.getClassLoader().getReference();
-            if (loader.equals(ClassLoaderReference.Primordial)
-                    || loader.equals(ClassLoaderReference.Extension)) {
-                // Primordial covers JDK boot classes and WALA's synthetic FakeRoot
-                // nodes, which use Primordial loader in WALA 1.6.x.
-                return true;
-            }
-            String pkg = packageNameOf(cls);
-            return INFRA_PREFIXES.stream().anyMatch(pkg::startsWith);
-        } catch (RuntimeException | UnimplementedError ignored) {
-            return true; // malformed frame treated as infrastructure
-        }
-    }
+	/**
+	 * Returns {@code true} when the given CGNode belongs to infrastructure: JDK
+	 * boot/extension/synthetic classes or any package in {@link #INFRA_PREFIXES}.
+	 */
+	static boolean isInfraFrame(CGNode node) {
+		try {
+			IClass cls = node.getMethod().getDeclaringClass();
+			if (cls == null) {
+				return true;
+			}
+			ClassLoaderReference loader = cls.getClassLoader().getReference();
+			if (loader.equals(ClassLoaderReference.Primordial) || loader.equals(ClassLoaderReference.Extension)) {
+				// Primordial covers JDK boot classes and WALA's synthetic FakeRoot
+				// nodes, which use Primordial loader in WALA 1.6.x.
+				return true;
+			}
+			String pkg = packageNameOf(cls);
+			return INFRA_PREFIXES.stream().anyMatch(pkg::startsWith);
+		} catch (RuntimeException | UnimplementedError ignored) {
+			return true; // malformed frame treated as infrastructure
+		}
+	}
 
-    /**
-     * Returns {@code true} when the given CGNode counts as transitive infrastructure
-     * for the purpose of {@link #isFalsePositiveTransitivePath} only. Project test
-     * helpers ({@code anonymous.toolclasses.} / {@code metatest.}) explicitly do
-     * NOT count here, so a student call that routes through such a helper into a
-     * forbidden JDK API is reported as a real violation.
-     */
-    static boolean isTransitiveFalsePositiveFrame(CGNode node) {
-        try {
-            IClass cls = node.getMethod().getDeclaringClass();
-            if (cls == null) {
-                return true;
-            }
-            ClassLoaderReference loader = cls.getClassLoader().getReference();
-            if (loader.equals(ClassLoaderReference.Primordial)
-                    || loader.equals(ClassLoaderReference.Extension)) {
-                return true;
-            }
-            String pkg = packageNameOf(cls);
-            return TRANSITIVE_FALSE_POSITIVE_PREFIXES.stream().anyMatch(pkg::startsWith);
-        } catch (RuntimeException | UnimplementedError ignored) {
-            return true;
-        }
-    }
-    // </editor-fold>
+	/**
+	 * Returns {@code true} when the given CGNode counts as transitive
+	 * infrastructure for the purpose of {@link #isFalsePositiveTransitivePath}
+	 * only. Project test helpers ({@code anonymous.toolclasses.} /
+	 * {@code metatest.}) explicitly do NOT count here, so a student call that
+	 * routes through such a helper into a forbidden JDK API is reported as a real
+	 * violation.
+	 */
+	static boolean isTransitiveFalsePositiveFrame(CGNode node) {
+		try {
+			IClass cls = node.getMethod().getDeclaringClass();
+			if (cls == null) {
+				return true;
+			}
+			ClassLoaderReference loader = cls.getClassLoader().getReference();
+			if (loader.equals(ClassLoaderReference.Primordial) || loader.equals(ClassLoaderReference.Extension)) {
+				return true;
+			}
+			String pkg = packageNameOf(cls);
+			return TRANSITIVE_FALSE_POSITIVE_PREFIXES.stream().anyMatch(pkg::startsWith);
+		} catch (RuntimeException | UnimplementedError ignored) {
+			return true;
+		}
+	}
+	// </editor-fold>
 
-    // <editor-fold desc="Package helpers">
+	// <editor-fold desc="Package helpers">
 
-    /**
-     * Returns the dotted package name of an {@link IClass}, with a trailing dot
-     * (e.g. {@code "java.lang."}). Returns an empty string for primitive types or
-     * classes in the default package.
-     *
-     * <p>Array types are unwrapped to their element type recursively.</p>
-     */
-    static String packageNameOf(IClass cls) {
-        return packageNameOf(cls.getReference());
-    }
+	/**
+	 * Returns the dotted package name of an {@link IClass}, with a trailing dot
+	 * (e.g. {@code "java.lang."}). Returns an empty string for primitive types or
+	 * classes in the default package.
+	 * <p>
+	 * Array types are unwrapped to their element type recursively.
+	 * </p>
+	 */
+	static String packageNameOf(IClass cls) {
+		return packageNameOf(cls.getReference());
+	}
 
-    /**
-     * Returns the dotted package name of a {@link TypeReference}.
-     *
-     * <p>For array types, recurses on the element type.
-     * For reference types, reads {@link com.ibm.wala.types.TypeName#getPackage()} and
-     * converts the slash-separated result to dot notation with a trailing dot.
-     * For primitive types or unknown packages, returns {@code ""}.</p>
-     */
-    static String packageNameOf(TypeReference ref) {
-        if (ref.isArrayType()) {
-            TypeReference element = ref.getArrayElementType();
-            if (element != null && element.isReferenceType()) {
-                return packageNameOf(element);
-            }
-            return ""; // array of primitives: no package
-        }
-        Atom pkg = ref.getName().getPackage();
-        if (pkg == null) {
-            return "";
-        }
-        return pkg.toString().replace('/', '.') + ".";
-    }
-    // </editor-fold>
+	/**
+	 * Returns the dotted package name of a {@link TypeReference}.
+	 * <p>
+	 * For array types, recurses on the element type. For reference types, reads
+	 * {@link com.ibm.wala.types.TypeName#getPackage()} and converts the
+	 * slash-separated result to dot notation with a trailing dot. For primitive
+	 * types or unknown packages, returns {@code ""}.
+	 * </p>
+	 */
+	static String packageNameOf(TypeReference ref) {
+		if (ref.isArrayType()) {
+			TypeReference element = ref.getArrayElementType();
+			if (element != null && element.isReferenceType()) {
+				return packageNameOf(element);
+			}
+			return ""; // array of primitives: no package
+		}
+		Atom pkg = ref.getName().getPackage();
+		if (pkg == null) {
+			return "";
+		}
+		return pkg.toString().replace('/', '.') + ".";
+	}
+	// </editor-fold>
 }

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/WalaRule.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/WalaRule.java
@@ -28,80 +28,84 @@ public class WalaRule {
 		int _pathCount = 0;
 		boolean _violationFound = false;
 		try {
-		Predicate<CGNode> isForbidden = n -> forbiddenMethods.stream()
-				.anyMatch(m -> n.getMethod().getSignature().startsWith(m));
+			Predicate<CGNode> isForbidden = n -> forbiddenMethods.stream()
+					.anyMatch(m -> n.getMethod().getSignature().startsWith(m));
 
-		// Use the DFS finder in a loop: skip paths that are all-infra or transitive-JDK
-		// false positives and keep searching until a genuine student violation is found.
-		// This prevents a long JDK-internal path (found first by alphabetical DFS) from
-		// masking the shorter, direct forbidden-method call in student code.
-		CustomDFSPathFinder finder = new CustomDFSPathFinder(cg, cg.getEntrypointNodes().iterator(), isForbidden);
-		List<CGNode> path;
-		while ((path = finder.find()) != null) {
-			_pathCount++;
-			if (path.isEmpty()) {
-				continue;
+			// Use the DFS finder in a loop: skip paths that are all-infra or transitive-JDK
+			// false positives and keep searching until a genuine student violation is
+			// found.
+			// This prevents a long JDK-internal path (found first by alphabetical DFS) from
+			// masking the shorter, direct forbidden-method call in student code.
+			CustomDFSPathFinder finder = new CustomDFSPathFinder(cg, cg.getEntrypointNodes().iterator(), isForbidden);
+			List<CGNode> path;
+			while ((path = finder.find()) != null) {
+				_pathCount++;
+				if (path.isEmpty()) {
+					continue;
+				}
+
+				OptionalInt studentIdx = WalaPathClassification.nearestStudentFrame(path);
+				if (studentIdx.isEmpty()) {
+					continue;
+				}
+
+				int callerIdx = studentIdx.getAsInt();
+				if (WalaPathClassification.isFalsePositiveTransitivePath(path, callerIdx)) {
+					continue;
+				}
+
+				int size = path.size();
+				CGNode forbiddenNode = path.get(size - 1);
+
+				// In production the forbidden node is always a JDK method (Primordial-loaded),
+				// so isInfraFrame classifies it as infra and nearestStudentFrame never returns
+				// size-1. This branch is defensive against misconfiguration only.
+				// Convert WALA's JVM-descriptor signatures to source-form so the resulting
+				// SecurityException matches the format ArchUnit produces (java.lang.String
+				// instead of Ljava/lang/String;, no return-type suffix). This keeps
+				// expected-exception fixtures consistent across both architecture backends.
+				String callerSignature = formatJvmSignature(
+						(callerIdx == size - 1) ? path.get(0).getMethod().getSignature()
+								: path.get(callerIdx).getMethod().getSignature());
+
+				String forbiddenSignature = formatJvmSignature(forbiddenNode.getMethod().getSignature());
+				String declaringClass = forbiddenNode.getMethod().getDeclaringClass().getName().getClassName()
+						.toString();
+				String entrySignature = formatJvmSignature(path.get(0).getMethod().getSignature());
+
+				try {
+					IMethod.SourcePosition sp = forbiddenNode.getMethod().getSourcePosition(0);
+					int lineNumber = sp != null ? sp.getFirstLine() : -1;
+					_violationFound = true;
+					throw new AssertionError(Messages.localized("security.architecture.method.call.message", ruleName,
+							callerSignature, forbiddenSignature, declaringClass, lineNumber, entrySignature));
+				} catch (InvalidClassFileException e) {
+					throw new SecurityException(Messages.localized("security.architecture.invalid.class.file"));
+				}
 			}
-
-			OptionalInt studentIdx = WalaPathClassification.nearestStudentFrame(path);
-			if (studentIdx.isEmpty()) {
-				continue;
-			}
-
-			int callerIdx = studentIdx.getAsInt();
-			if (WalaPathClassification.isFalsePositiveTransitivePath(path, callerIdx)) {
-				continue;
-			}
-
-			int size = path.size();
-			CGNode forbiddenNode = path.get(size - 1);
-
-			// In production the forbidden node is always a JDK method (Primordial-loaded),
-			// so isInfraFrame classifies it as infra and nearestStudentFrame never returns
-			// size-1. This branch is defensive against misconfiguration only.
-			// Convert WALA's JVM-descriptor signatures to source-form so the resulting
-			// SecurityException matches the format ArchUnit produces (java.lang.String
-			// instead of Ljava/lang/String;, no return-type suffix). This keeps
-			// expected-exception fixtures consistent across both architecture backends.
-			String callerSignature = formatJvmSignature((callerIdx == size - 1)
-					? path.get(0).getMethod().getSignature()
-					: path.get(callerIdx).getMethod().getSignature());
-
-			String forbiddenSignature = formatJvmSignature(forbiddenNode.getMethod().getSignature());
-			String declaringClass = forbiddenNode.getMethod().getDeclaringClass().getName().getClassName().toString();
-			String entrySignature = formatJvmSignature(path.get(0).getMethod().getSignature());
-
-			try {
-				IMethod.SourcePosition sp = forbiddenNode.getMethod().getSourcePosition(0);
-				int lineNumber = sp != null ? sp.getFirstLine() : -1;
-				_violationFound = true;
-				throw new AssertionError(
-						Messages.localized("security.architecture.method.call.message", ruleName,
-								callerSignature, forbiddenSignature, declaringClass, lineNumber, entrySignature));
-			} catch (InvalidClassFileException e) {
-				throw new SecurityException(Messages.localized("security.architecture.invalid.class.file"));
-			}
-		}
 		} finally {
 			long _ms = (System.nanoTime() - _checkStart) / 1_000_000L;
 			try {
 				java.nio.file.Files.writeString(java.nio.file.Paths.get("/tmp/wala-check-times.log"),
-						System.currentTimeMillis() + "|" + _ms + "|paths=" + _pathCount + "|violation=" + _violationFound + "|" + ruleName + "\n",
+						System.currentTimeMillis() + "|" + _ms + "|paths=" + _pathCount + "|violation="
+								+ _violationFound + "|" + ruleName + "\n",
 						java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-			} catch (Exception ignored) {}
+			} catch (Exception ignored) {
+			}
 		}
 	}
 
 	/**
 	 * Convert a WALA {@link IMethod#getSignature()} string from JVM-descriptor form
 	 * to the source-code form that ArchUnit produces.
-	 *
-	 * <p>WALA's signature looks like
-	 * {@code package.Class.method(Lpackage/Param;[I)Lreturn/Type;}. ArchUnit reports
-	 * {@code package.Class.method(package.Param, int[])}. The return-type suffix is
-	 * dropped to match ArchUnit's omission. Constructor names {@code <init>} stay as is.
-	 *
-	 * <p>Returns the original string unchanged when no parenthesised descriptor is
+	 * <p>
+	 * WALA's signature looks like
+	 * {@code package.Class.method(Lpackage/Param;[I)Lreturn/Type;}. ArchUnit
+	 * reports {@code package.Class.method(package.Param, int[])}. The return-type
+	 * suffix is dropped to match ArchUnit's omission. Constructor names
+	 * {@code <init>} stay as is.
+	 * <p>
+	 * Returns the original string unchanged when no parenthesised descriptor is
 	 * found, so callers can pass any signature without first checking the format.
 	 */
 	static String formatJvmSignature(String walaSignature) {
@@ -132,16 +136,17 @@ public class WalaRule {
 
 	/**
 	 * Parse a JVM parameter-descriptor sequence into a list of source-form types.
-	 *
-	 * <p>Examples:
+	 * <p>
+	 * Examples:
 	 * <ul>
-	 *   <li>{@code "Ljava/lang/String;Ljava/io/File;"} → {@code [java.lang.String, java.io.File]}</li>
-	 *   <li>{@code "[I"} → {@code [int[]]}</li>
-	 *   <li>{@code "[[Ljava/lang/String;"} → {@code [java.lang.String[][]]}</li>
+	 * <li>{@code "Ljava/lang/String;Ljava/io/File;"} →
+	 * {@code [java.lang.String, java.io.File]}</li>
+	 * <li>{@code "[I"} → {@code [int[]]}</li>
+	 * <li>{@code "[[Ljava/lang/String;"} → {@code [java.lang.String[][]]}</li>
 	 * </ul>
-	 *
-	 * <p>Malformed descriptors stop the parse early; whatever has been parsed so
-	 * far is returned to keep the surrounding error message useful.
+	 * <p>
+	 * Malformed descriptors stop the parse early; whatever has been parsed so far
+	 * is returned to keep the surrounding error message useful.
 	 */
 	private static List<String> parseParamDescriptors(String descriptor) {
 		List<String> params = new ArrayList<>();
@@ -179,23 +184,23 @@ public class WalaRule {
 
 	/**
 	 * Map a single primitive JVM-descriptor character to its source-form Java name.
-	 *
-	 * <p>{@code V} (void) is included for completeness, even though it never appears
+	 * <p>
+	 * {@code V} (void) is included for completeness, even though it never appears
 	 * inside a parameter list. Unknown characters are echoed back so future JVM
 	 * spec extensions do not silently corrupt the message.
 	 */
 	private static String primitiveDescriptorToName(char descriptorChar) {
 		return switch (descriptorChar) {
-			case 'B' -> "byte";
-			case 'C' -> "char";
-			case 'D' -> "double";
-			case 'F' -> "float";
-			case 'I' -> "int";
-			case 'J' -> "long";
-			case 'S' -> "short";
-			case 'Z' -> "boolean";
-			case 'V' -> "void";
-			default -> String.valueOf(descriptorChar);
+		case 'B' -> "byte";
+		case 'C' -> "char";
+		case 'D' -> "double";
+		case 'F' -> "float";
+		case 'I' -> "int";
+		case 'J' -> "long";
+		case 'S' -> "short";
+		case 'Z' -> "boolean";
+		case 'V' -> "void";
+		default -> String.valueOf(descriptorChar);
 		};
 	}
 }

--- a/src/main/java/de/tum/cit/ase/ares/api/ast/asserting/UnwantedNodesAssert.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/ast/asserting/UnwantedNodesAssert.java
@@ -60,10 +60,11 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	 * @return An unwanted node assertion object (for chaining)
 	 */
 	public static UnwantedNodesAssert assertThatProjectSources() {
-		Path path = ProjectSourcesFinder.findProjectSourcesPath().orElseThrow(() -> new AssertionError("Could not find project sources folder." //$NON-NLS-1$
-				+ " Make sure the build file is configured correctly." //$NON-NLS-1$
-				+ " If it is not located in the execution folder directly," //$NON-NLS-1$
-				+ " set the location using AresConfiguration methods.")); //$NON-NLS-1$
+		Path path = ProjectSourcesFinder.findProjectSourcesPath()
+				.orElseThrow(() -> new AssertionError("Could not find project sources folder." //$NON-NLS-1$
+						+ " Make sure the build file is configured correctly." //$NON-NLS-1$
+						+ " If it is not located in the execution folder directly," //$NON-NLS-1$
+						+ " set the location using AresConfiguration methods.")); //$NON-NLS-1$
 		return new UnwantedNodesAssert(path, null, false);
 	}
 

--- a/src/main/java/de/tum/cit/ase/ares/api/jqwik/JqwikSecurityExtension.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/jqwik/JqwikSecurityExtension.java
@@ -50,12 +50,12 @@ public final class JqwikSecurityExtension implements AroundPropertyHook {
 		// - no @Policy on property → enforce with default policy (null path)
 		// - @Policy(activated=false) → Ares deactivated (no security checks)
 		if (isAresActivated) {
-			Path policyPath = policyOpt.filter(p -> !p.value().isBlank())
-					.map(p -> testAndGetPolicyValue(p)).orElse(null);
-			Path withinPath = policyOpt.filter(p -> !p.withinPath().isBlank())
-					.map(p -> testAndGetPolicyWithinPath(p)).orElse(Path.of(""));
-			SecurityPolicyReaderAndDirector.builder().securityPolicyFilePath(policyPath)
-					.projectFolderPath(withinPath).build().createTestCases().executeTestCases();
+			Path policyPath = policyOpt.filter(p -> !p.value().isBlank()).map(p -> testAndGetPolicyValue(p))
+					.orElse(null);
+			Path withinPath = policyOpt.filter(p -> !p.withinPath().isBlank()).map(p -> testAndGetPolicyWithinPath(p))
+					.orElse(Path.of(""));
+			SecurityPolicyReaderAndDirector.builder().securityPolicyFilePath(policyPath).projectFolderPath(withinPath)
+					.build().createTestCases().executeTestCases();
 		}
 		// REMOVED: Installing of ArtemisSecurityManager
 		PropertyExecutionResult result;

--- a/src/main/java/de/tum/cit/ase/ares/api/jupiter/JupiterSecurityExtension.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/jupiter/JupiterSecurityExtension.java
@@ -19,7 +19,8 @@ import de.tum.cit.ase.ares.api.policy.SecurityPolicyReaderAndDirector;
 //REMOVED: Import of ArtemisSecurityManager
 
 @API(status = Status.INTERNAL)
-public final class JupiterSecurityExtension implements UnifiedInvocationInterceptor, BeforeTestExecutionCallback, AfterTestExecutionCallback {
+public final class JupiterSecurityExtension
+		implements UnifiedInvocationInterceptor, BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
 	// <editor-fold desc="Lifecycle Callbacks">
 
@@ -28,10 +29,10 @@ public final class JupiterSecurityExtension implements UnifiedInvocationIntercep
 	 * <p>
 	 * This callback is used as a reliable alternative to
 	 * {@link InvocationInterceptor#interceptTestTemplateMethod} and
-	 * {@link InvocationInterceptor#interceptTestMethod}, which are not invoked
-	 * when tests are executed via {@code EngineTestKit} (e.g., in meta-tests).
-	 * Lifecycle callbacks like {@link BeforeTestExecutionCallback} are reliably
-	 * called in all execution contexts.
+	 * {@link InvocationInterceptor#interceptTestMethod}, which are not invoked when
+	 * tests are executed via {@code EngineTestKit} (e.g., in meta-tests). Lifecycle
+	 * callbacks like {@link BeforeTestExecutionCallback} are reliably called in all
+	 * execution contexts.
 	 */
 	@Override
 	public void beforeTestExecution(ExtensionContext extensionContext) throws Exception {
@@ -46,16 +47,18 @@ public final class JupiterSecurityExtension implements UnifiedInvocationIntercep
 		boolean hasPolicyAnnotation = policyOpt.isPresent();
 		boolean isAresActivated = policyOpt.map(Policy::activated).orElse(true);
 		boolean isTestMethodPresent = testContext.testMethod().isPresent();
-		System.err.println("[ARES-LIFECYCLE] hasPolicyAnnotation=" + hasPolicyAnnotation + " isAresActivated=" + isAresActivated + " isTestMethodPresent=" + isTestMethodPresent);
+		System.err.println("[ARES-LIFECYCLE] hasPolicyAnnotation=" + hasPolicyAnnotation + " isAresActivated="
+				+ isAresActivated + " isTestMethodPresent=" + isTestMethodPresent);
 
 		if (isAresActivated && (hasPolicyAnnotation || isTestMethodPresent)) {
 			Path policyPath = policyOpt.filter(p -> !p.value().isBlank())
 					.map(JupiterSecurityExtension::testAndGetPolicyValue).orElse(null);
 			Path withinPath = policyOpt.filter(p -> !p.withinPath().isBlank())
 					.map(JupiterSecurityExtension::testAndGetPolicyWithinPath).orElse(Path.of(""));
-			System.err.println("[ARES-LIFECYCLE] executing with policyPath=" + policyPath + " withinPath=" + withinPath);
-			SecurityPolicyReaderAndDirector.builder().securityPolicyFilePath(policyPath)
-					.projectFolderPath(withinPath).build().createTestCases().executeTestCases();
+			System.err
+					.println("[ARES-LIFECYCLE] executing with policyPath=" + policyPath + " withinPath=" + withinPath);
+			SecurityPolicyReaderAndDirector.builder().securityPolicyFilePath(policyPath).projectFolderPath(withinPath)
+					.build().createTestCases().executeTestCases();
 			System.err.println("[ARES-LIFECYCLE] executeTestCases completed");
 		}
 	}
@@ -93,15 +96,16 @@ public final class JupiterSecurityExtension implements UnifiedInvocationIntercep
 		// - @Policy(activated=true) → enforce with custom policy from file
 		// - no @Policy on @Test method → enforce with default policy (null path)
 		// - @Policy(activated=false) → Ares deactivated (no security checks)
-		// Skip enforcement during constructor interception (no test method present yet).
+		// Skip enforcement during constructor interception (no test method present
+		// yet).
 		boolean isTestMethodPresent = testContext.testMethod().isPresent();
 		if (isAresActivated && (hasPolicyAnnotation || isTestMethodPresent)) {
 			Path policyPath = policyOpt.filter(p -> !p.value().isBlank())
 					.map(JupiterSecurityExtension::testAndGetPolicyValue).orElse(null);
 			Path withinPath = policyOpt.filter(p -> !p.withinPath().isBlank())
 					.map(JupiterSecurityExtension::testAndGetPolicyWithinPath).orElse(Path.of(""));
-			SecurityPolicyReaderAndDirector.builder().securityPolicyFilePath(policyPath)
-					.projectFolderPath(withinPath).build().createTestCases().executeTestCases();
+			SecurityPolicyReaderAndDirector.builder().securityPolicyFilePath(policyPath).projectFolderPath(withinPath)
+					.build().createTestCases().executeTestCases();
 		}
 		// REMOVED: Installing of ArtemisSecurityManager
 		Throwable failure = null;

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/SecurityPolicyReaderAndDirector.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/SecurityPolicyReaderAndDirector.java
@@ -6,7 +6,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 
 import de.tum.cit.ase.ares.api.localization.Messages;
@@ -99,7 +98,8 @@ public class SecurityPolicyReaderAndDirector {
 		@Nullable
 		SecurityPolicy securityPolicy = null;
 		if (securityPolicyFilePath != null && !securityPolicyFilePath.toString().isEmpty()) {
-			@Nonnull Path nonNullPolicyPath = securityPolicyFilePath;
+			@Nonnull
+			Path nonNullPolicyPath = securityPolicyFilePath;
 			securityPolicyReader = SecurityPolicyReader.selectSecurityPolicyReader(nonNullPolicyPath);
 			if (securityPolicyReader != null) {
 				securityPolicy = securityPolicyReader.readSecurityPolicyFrom(nonNullPolicyPath);

--- a/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/creator/JavaCreator.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/creator/JavaCreator.java
@@ -94,19 +94,16 @@ public class JavaCreator implements Creator {
 			@Nonnull List<String> testClasses) {
 		return Stream.of(
 				// Essential packages are allowed to do anything
-				essentialPackages.stream()
-						.filter(p -> p != null && !p.isBlank())
-						.map(PackagePermission::new),
+				essentialPackages.stream().filter(p -> p != null && !p.isBlank()).map(PackagePermission::new),
 				// The permitted packages are allowed
 				resourceAccesses.regardingPackageImports().stream(),
 				/*
 				 * The package of the restricted student code is allowed (else the student would
-				 * not be able to use his/her own code).
-				 * SECURITY: Do not derive top-level roots (e.g., com/org/de), as that
-				 * unintentionally allows unrelated package namespaces.
+				 * not be able to use his/her own code). SECURITY: Do not derive top-level roots
+				 * (e.g., com/org/de), as that unintentionally allows unrelated package
+				 * namespaces.
 				 */
-				(packageName != null && !packageName.isBlank())
-						? Stream.of(new PackagePermission(packageName))
+				(packageName != null && !packageName.isBlank()) ? Stream.of(new PackagePermission(packageName))
 						: Stream.<PackagePermission>empty(),
 				/*
 				 * The packages of the test classes are allowed (test infrastructure classes
@@ -157,8 +154,8 @@ public class JavaCreator implements Creator {
 	 */
 	@Nonnull
 	private JavaArchitectureTestCase createArchitectureTestCase(@Nonnull JavaArchitectureTestCaseSupported supported,
-			@Nonnull JavaClasses classes, @Nonnull Supplier<CallGraph> callGraphSupplier, @Nonnull Set<PackagePermission> allowedPackages,
-			@Nonnull Set<ClassPermission> allowedClasses) {
+			@Nonnull JavaClasses classes, @Nonnull Supplier<CallGraph> callGraphSupplier,
+			@Nonnull Set<PackagePermission> allowedPackages, @Nonnull Set<ClassPermission> allowedClasses) {
 		return JavaArchitectureTestCase.builder()
 				// The architecture test case checks for the following aspect
 				.javaArchitectureTestCaseSupported(supported)
@@ -195,8 +192,8 @@ public class JavaCreator implements Creator {
 	@Nonnull
 	private JavaAOPTestCase createAOPTestCase(@Nonnull ResourceAccesses resourceAccesses,
 			@Nonnull List<ArchitectureTestCase> javaArchitectureTestCases, @Nonnull JavaAOPTestCaseSupported supported,
-			@Nonnull JavaClasses classes, @Nonnull Supplier<CallGraph> callGraphSupplier, @Nonnull Set<PackagePermission> allowedPackages,
-			@Nonnull Set<ClassPermission> allowedClasses) {
+			@Nonnull JavaClasses classes, @Nonnull Supplier<CallGraph> callGraphSupplier,
+			@Nonnull Set<PackagePermission> allowedPackages, @Nonnull Set<ClassPermission> allowedClasses) {
 		@Nonnull
 		Supplier<List<?>> resourceAccessSupplier = List
 				.of((Supplier<List<?>>) resourceAccesses::regardingFileSystemInteractions,
@@ -258,8 +255,8 @@ public class JavaCreator implements Creator {
 	 *                                  null
 	 */
 	private void addPriorityTestCases(@Nonnull List<ArchitectureTestCase> javaArchitectureTestCases,
-			@Nonnull JavaClasses classes, @Nonnull Supplier<CallGraph> callGraphSupplier, @Nonnull Set<PackagePermission> allowedPackages,
-			@Nonnull Set<ClassPermission> allowedClasses) {
+			@Nonnull JavaClasses classes, @Nonnull Supplier<CallGraph> callGraphSupplier,
+			@Nonnull Set<PackagePermission> allowedPackages, @Nonnull Set<ClassPermission> allowedClasses) {
 		javaArchitectureTestCases.addAll(JavaArchitectureTestCaseSupported.NATIVE_CODE.getPriority().stream()
 				.map(priorityCase -> createArchitectureTestCase((JavaArchitectureTestCaseSupported) priorityCase,
 						classes, callGraphSupplier, allowedPackages, allowedClasses))
@@ -282,8 +279,8 @@ public class JavaCreator implements Creator {
 	 *                                  null
 	 */
 	private void addFixedTestCases(@Nonnull List<ArchitectureTestCase> javaArchitectureTestCases,
-			@Nonnull JavaClasses classes, @Nonnull Supplier<CallGraph> callGraphSupplier, @Nonnull Set<PackagePermission> allowedPackages,
-			@Nonnull Set<ClassPermission> allowedClasses) {
+			@Nonnull JavaClasses classes, @Nonnull Supplier<CallGraph> callGraphSupplier,
+			@Nonnull Set<PackagePermission> allowedPackages, @Nonnull Set<ClassPermission> allowedClasses) {
 		javaArchitectureTestCases.addAll(JavaArchitectureTestCaseSupported
 				// The choice of using TERMINATE_JVM was taken randomly for getting an instance
 				// of JavaArchitectureTestCaseSupported (otherwise we cannot operate over an
@@ -316,8 +313,9 @@ public class JavaCreator implements Creator {
 	 */
 	private void addVariableTestCases(@Nonnull List<ArchitectureTestCase> javaArchitectureTestCases,
 			@Nonnull List<AOPTestCase> javaAOPTestCases, @Nonnull List<PhobosTestCase> javaPhobosTestCases,
-			@Nonnull JavaClasses classes, @Nonnull Supplier<CallGraph> callGraphSupplier, @Nonnull Set<PackagePermission> allowedPackages,
-			@Nonnull Set<ClassPermission> allowedClasses, @Nonnull ResourceAccesses resourceAccesses) {
+			@Nonnull JavaClasses classes, @Nonnull Supplier<CallGraph> callGraphSupplier,
+			@Nonnull Set<PackagePermission> allowedPackages, @Nonnull Set<ClassPermission> allowedClasses,
+			@Nonnull ResourceAccesses resourceAccesses) {
 		javaAOPTestCases.addAll(JavaAOPTestCaseSupported
 				// The choice of using FILESYSTEM_INTERACTION was taken randomly for getting an
 				// instance of JavaAOPTestCaseSupported (otherwise we cannot operate over an
@@ -381,9 +379,11 @@ public class JavaCreator implements Creator {
 		JavaClasses javaClasses = cacheResult(projectPath + "_" + packageName + "_javaClasses",
 				() -> architectureMode.getJavaClasses(classPath)).get();
 		// Keep the call graph as a Supplier (no eager .get()) so downstream test cases
-		// can defer construction. The disk-backed WALA outcome cache in JavaWalaTestCase
+		// can defer construction. The disk-backed WALA outcome cache in
+		// JavaWalaTestCase
 		// short-circuits rule checks before this supplier is ever invoked when the same
-		// (classpath, rule, per-package fingerprint) was already evaluated by an earlier
+		// (classpath, rule, per-package fingerprint) was already evaluated by an
+		// earlier
 		// JVM fork.
 		@Nonnull
 		Supplier<CallGraph> callGraphSupplier = cacheResult(projectPath + "_" + packageName + "_callGraph",

--- a/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScanner.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScanner.java
@@ -143,8 +143,8 @@ public class JavaProjectScanner implements ProjectScanner {
 	}
 
 	/**
-	 * Finds the test source directory by inspecting the build configuration file
-	 * at the project root.
+	 * Finds the test source directory by inspecting the build configuration file at
+	 * the project root.
 	 *
 	 * @since 2.0.0
 	 * @author Markus Paulsen

--- a/src/main/java/de/tum/cit/ase/ares/api/util/FileTools.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/util/FileTools.java
@@ -293,12 +293,11 @@ public class FileTools {
 		try {
 			String fileContent = Files.readString(sourceFile.toPath(), StandardCharsets.UTF_8);
 			String normalizedContent = fileContent.replace("\r\n", "\n").replace("\r", "\n");
-			// Strip Unicode whitespace, drop blank and comment lines so empty entries do not
+			// Strip Unicode whitespace, drop blank and comment lines so empty entries do
+			// not
 			// match every WALA signature via the prefix matcher.
-			List<String> methods = Arrays.stream(normalizedContent.split("\n"))
-					.map(String::strip)
-					.filter(str -> !str.isEmpty() && !str.startsWith("#"))
-					.toList();
+			List<String> methods = Arrays.stream(normalizedContent.split("\n")).map(String::strip)
+					.filter(str -> !str.isEmpty() && !str.startsWith("#")).toList();
 			return new HashSet<>(methods);
 		} catch (IOException e) {
 			throw new SecurityException(localize("security.file-tools.read.content.failure"), e);

--- a/src/main/java/de/tum/cit/ase/ares/api/util/YamlPlaceholderResolver.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/util/YamlPlaceholderResolver.java
@@ -6,17 +6,18 @@ import javax.annotation.Nonnull;
 
 /**
  * Resolves a fixed set of placeholders inside YAML content before parsing.
- *
- * <p>Description: Provides string-level expansion of four well-defined placeholders
- * ({@code ${PROJECT_ROOT}}, {@code ${java.home}}, {@code ${user.home}},
- * {@code ${java.io.tmpdir}}) so that security-policy YAML files can be authored
- * portably across local, CI, and Docker environments without hard-coding user-
- * or platform-specific paths.
- *
- * <p>Design Rationale: A small fixed set of placeholders keeps the substitution surface
- * predictable and avoids accidental coupling of policy files to arbitrary system
- * properties. Unknown placeholders are left untouched so legitimate text containing
- * {@code ${...}} sequences cannot be silently mangled.
+ * <p>
+ * Description: Provides string-level expansion of four well-defined
+ * placeholders ({@code ${PROJECT_ROOT}}, {@code ${java.home}},
+ * {@code ${user.home}}, {@code ${java.io.tmpdir}}) so that security-policy YAML
+ * files can be authored portably across local, CI, and Docker environments
+ * without hard-coding user- or platform-specific paths.
+ * <p>
+ * Design Rationale: A small fixed set of placeholders keeps the substitution
+ * surface predictable and avoids accidental coupling of policy files to
+ * arbitrary system properties. Unknown placeholders are left untouched so
+ * legitimate text containing {@code ${...}} sequences cannot be silently
+ * mangled.
  *
  * @since 2.0.1
  * @author Markus Paulsen
@@ -25,22 +26,21 @@ import javax.annotation.Nonnull;
 public final class YamlPlaceholderResolver {
 
 	@Nonnull
-	private static final Map<String, String> PLACEHOLDER_PROPERTIES = Map.of(
-			"${PROJECT_ROOT}", "user.dir",
-			"${java.home}", "java.home",
-			"${user.home}", "user.home",
-			"${java.io.tmpdir}", "java.io.tmpdir");
+	private static final Map<String, String> PLACEHOLDER_PROPERTIES = Map.of("${PROJECT_ROOT}", "user.dir",
+			"${java.home}", "java.home", "${user.home}", "user.home", "${java.io.tmpdir}", "java.io.tmpdir");
 
 	private YamlPlaceholderResolver() {
-		throw new UnsupportedOperationException("YamlPlaceholderResolver is a utility class and cannot be instantiated");
+		throw new UnsupportedOperationException(
+				"YamlPlaceholderResolver is a utility class and cannot be instantiated");
 	}
 
 	/**
 	 * Expand the three supported placeholders in the supplied YAML content.
 	 *
 	 * @param content the raw YAML content; may contain placeholder tokens.
-	 * @return the content with every supported placeholder replaced by the corresponding system property value.
-	 *         When a system property is unset, the placeholder is replaced with the empty string. Unknown
+	 * @return the content with every supported placeholder replaced by the
+	 *         corresponding system property value. When a system property is unset,
+	 *         the placeholder is replaced with the empty string. Unknown
 	 *         placeholders remain unchanged.
 	 */
 	@Nonnull

--- a/src/test/java/de/tum/cit/ase/ares/api/aop/java/JavaAOPTestCaseSettingsTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/aop/java/JavaAOPTestCaseSettingsTest.java
@@ -56,11 +56,9 @@ public class JavaAOPTestCaseSettingsTest {
 		InvocationTargetException thrown = Assertions.assertThrows(InvocationTargetException.class,
 				constructor::newInstance, "Invoking private constructor must throw SecurityException");
 		constructor.setAccessible(false);
-        String msg = thrown.getTargetException().getMessage();
-        Assertions.assertNotNull(msg, "Exception message should not be null");
-        Assertions.assertTrue(
-                msg.contains("Ares Security Error") || msg.contains("Ares Sicherheitsfehler")
-        );
+		String msg = thrown.getTargetException().getMessage();
+		Assertions.assertNotNull(msg, "Exception message should not be null");
+		Assertions.assertTrue(msg.contains("Ares Security Error") || msg.contains("Ares Sicherheitsfehler"));
 	}
 
 	/**

--- a/src/test/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceFileSystemToolboxTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceFileSystemToolboxTest.java
@@ -15,6 +15,7 @@ import org.mockito.MockedStatic;
 import de.tum.cit.ase.ares.api.aop.java.JavaAOPTestCase;
 import de.tum.cit.ase.ares.api.aop.java.JavaAOPTestCaseSettings;
 import de.tum.cit.ase.ares.api.aop.java.instrumentation.pointcut.JavaInstrumentationPointcutDefinitions;
+
 import example.student.InstrumentationSecurityProbe;
 
 class JavaInstrumentationAdviceFileSystemToolboxTest {
@@ -27,17 +28,16 @@ class JavaInstrumentationAdviceFileSystemToolboxTest {
 
 	private static void configureInstrumentationMode() {
 		JavaAOPTestCase.setJavaAdviceSettingValue("aopMode", "INSTRUMENTATION", "ARCH", "INSTRUMENTATION");
-		JavaAOPTestCase.setJavaAdviceSettingValue("restrictedPackage", "example.student", "ARCH",
-				"INSTRUMENTATION");
-		JavaAOPTestCase.setJavaAdviceSettingValue("allowedListedClasses", new String[0], "ARCH",
-				"INSTRUMENTATION");
+		JavaAOPTestCase.setJavaAdviceSettingValue("restrictedPackage", "example.student", "ARCH", "INSTRUMENTATION");
+		JavaAOPTestCase.setJavaAdviceSettingValue("allowedListedClasses", new String[0], "ARCH", "INSTRUMENTATION");
 	}
 
 	@Test
 	void testCheckFileSystemInteraction_AllowedInteraction() {
 		try (MockedStatic<JavaInstrumentationAdviceFileSystemToolbox> mockedToolbox = mockStatic(
 				JavaInstrumentationAdviceFileSystemToolbox.class)) {
-			// When the class is mocked statically, checkFileSystemInteraction is intercepted
+			// When the class is mocked statically, checkFileSystemInteraction is
+			// intercepted
 			// and returns null by default — just verify no exception is thrown
 			assertDoesNotThrow(() -> JavaInstrumentationAdviceFileSystemToolbox.checkFileSystemInteraction("read",
 					"de.tum.cit.ase.safe.FileReader", "readFile", "(Ljava/lang/String;)V", null,
@@ -50,10 +50,8 @@ class JavaInstrumentationAdviceFileSystemToolboxTest {
 		try {
 			resetSettings();
 			JavaAOPTestCase.setJavaAdviceSettingValue("aopMode", "INSTRUMENTATION", "ARCH", "INSTRUMENTATION");
-			JavaAOPTestCase.setJavaAdviceSettingValue("restrictedPackage", "de.tum.cit.ase", "ARCH",
-					"INSTRUMENTATION");
-			JavaAOPTestCase.setJavaAdviceSettingValue("allowedListedClasses", new String[0], "ARCH",
-					"INSTRUMENTATION");
+			JavaAOPTestCase.setJavaAdviceSettingValue("restrictedPackage", "de.tum.cit.ase", "ARCH", "INSTRUMENTATION");
+			JavaAOPTestCase.setJavaAdviceSettingValue("allowedListedClasses", new String[0], "ARCH", "INSTRUMENTATION");
 			String allowedPath = tempDir.toString();
 			JavaAOPTestCase.setJavaAdviceSettingValue("pathsAllowedToBeOverwritten", new String[] { allowedPath },
 					"ARCH", "INSTRUMENTATION");
@@ -113,8 +111,8 @@ class JavaInstrumentationAdviceFileSystemToolboxTest {
 			configureInstrumentationMode();
 			Path allowedDir = Files.createDirectory(tempDir.resolve("allowed"));
 			Path forbiddenPath = tempDir.resolve("missing.txt");
-			JavaAOPTestCase.setJavaAdviceSettingValue("pathsAllowedToBeDeleted",
-					new String[] { allowedDir.toString() }, "ARCH", "INSTRUMENTATION");
+			JavaAOPTestCase.setJavaAdviceSettingValue("pathsAllowedToBeDeleted", new String[] { allowedDir.toString() },
+					"ARCH", "INSTRUMENTATION");
 
 			SecurityException exception = assertThrows(SecurityException.class,
 					() -> InstrumentationSecurityProbe.checkDeleteIfExists(forbiddenPath));

--- a/src/test/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolboxTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolboxTest.java
@@ -2,8 +2,8 @@ package de.tum.cit.ase.ares.api.aop.java.instrumentation.advice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FileDescriptor;
@@ -21,7 +21,8 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 
 	@Test
 	void toTarget_extractsHostAndPortFromInetSocketAddress() throws Exception {
-		Method toTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("toTarget", Object.class);
+		Method toTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("toTarget",
+				Object.class);
 		toTarget.setAccessible(true);
 		Object target = toTarget.invoke(null, new InetSocketAddress("example.org", 443));
 		assertNotNull(target);
@@ -33,7 +34,8 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 
 	@Test
 	void toTarget_extractsDefaultPortFromUriScheme() throws Exception {
-		Method toTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("toTarget", Object.class);
+		Method toTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("toTarget",
+				Object.class);
 		toTarget.setAccessible(true);
 		Object target = toTarget.invoke(null, URI.create("https://example.org/path"));
 		assertNotNull(target);
@@ -48,8 +50,8 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 		Method hostMatches = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("hostMatches",
 				String.class, String.class);
 		hostMatches.setAccessible(true);
-		Method portMatches = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("portMatches", int.class,
-				int.class);
+		Method portMatches = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("portMatches",
+				int.class, int.class);
 		portMatches.setAccessible(true);
 
 		boolean hostAllowed = (boolean) hostMatches.invoke(null, "api.example.org", "example.org");
@@ -61,7 +63,8 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 
 	@Test
 	void toTarget_returnsNullForUnresolvedSocketReceiver() throws Exception {
-		Method toTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("toTarget", Object.class);
+		Method toTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("toTarget",
+				Object.class);
 		toTarget.setAccessible(true);
 
 		try (Socket socket = new Socket()) {
@@ -72,7 +75,8 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 
 	@Test
 	void toTarget_extractsHostAndPortFromConnectedSocket() throws Exception {
-		Method toTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("toTarget", Object.class);
+		Method toTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("toTarget",
+				Object.class);
 		toTarget.setAccessible(true);
 
 		try (ServerSocket serverSocket = new ServerSocket(0);
@@ -89,8 +93,8 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 
 	@Test
 	void parametersToTarget_extractsHostAndPortFromSeparateArguments() throws Exception {
-		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod(
-				"parametersToTarget", Object[].class);
+		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class
+				.getDeclaredMethod("parametersToTarget", Object[].class);
 		parametersToTarget.setAccessible(true);
 
 		Object target = parametersToTarget.invoke(null, (Object) new Object[] { "127.0.0.1", 12345 });
@@ -103,12 +107,13 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 
 	@Test
 	void parametersToTarget_skipsLeadingNonHostPortPairsAndConsumesOnlyResolvedIndices() throws Exception {
-		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod(
-				"parametersToTarget", Object[].class, BitSet.class);
+		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class
+				.getDeclaredMethod("parametersToTarget", Object[].class, BitSet.class);
 		parametersToTarget.setAccessible(true);
 
 		BitSet consumed = new BitSet();
-		Object[] params = new Object[] { new FileDescriptor(), InetAddress.getByName("127.0.0.1"), Integer.valueOf(12345) };
+		Object[] params = new Object[] { new FileDescriptor(), InetAddress.getByName("127.0.0.1"),
+				Integer.valueOf(12345) };
 		Object target = parametersToTarget.invoke(null, (Object) params, consumed);
 		assertNotNull(target);
 
@@ -122,13 +127,13 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 
 	@Test
 	void parametersToTarget_consumesAllAdjacentPairsForMultiPairSignatures() throws Exception {
-		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod(
-				"parametersToTarget", Object[].class, BitSet.class);
+		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class
+				.getDeclaredMethod("parametersToTarget", Object[].class, BitSet.class);
 		parametersToTarget.setAccessible(true);
 
 		BitSet consumed = new BitSet();
-		Object[] params = new Object[] { "127.0.0.1", Integer.valueOf(12345),
-				InetAddress.getByName("10.0.0.1"), Integer.valueOf(0) };
+		Object[] params = new Object[] { "127.0.0.1", Integer.valueOf(12345), InetAddress.getByName("10.0.0.1"),
+				Integer.valueOf(0) };
 		Object target = parametersToTarget.invoke(null, (Object) params, consumed);
 		assertNotNull(target);
 
@@ -143,8 +148,8 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 
 	@Test
 	void parametersToTarget_bareInetAddressFallsBackToSinglePortAndConsumesIndex() throws Exception {
-		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod(
-				"parametersToTarget", Object[].class, BitSet.class);
+		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class
+				.getDeclaredMethod("parametersToTarget", Object[].class, BitSet.class);
 		parametersToTarget.setAccessible(true);
 
 		BitSet consumed = new BitSet();
@@ -162,8 +167,8 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 
 	@Test
 	void parametersToTarget_bareUriFallsBackToSinglePortAndConsumesIndex() throws Exception {
-		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod(
-				"parametersToTarget", Object[].class, BitSet.class);
+		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class
+				.getDeclaredMethod("parametersToTarget", Object[].class, BitSet.class);
 		parametersToTarget.setAccessible(true);
 
 		BitSet consumed = new BitSet();
@@ -179,8 +184,8 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 
 	@Test
 	void parametersToTarget_returnsNullForEmptyParameterArray() throws Exception {
-		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod(
-				"parametersToTarget", Object[].class, BitSet.class);
+		Method parametersToTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class
+				.getDeclaredMethod("parametersToTarget", Object[].class, BitSet.class);
 		parametersToTarget.setAccessible(true);
 
 		BitSet consumed = new BitSet();
@@ -189,6 +194,3 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 		assertTrue(consumed.isEmpty());
 	}
 }
-
-
-

--- a/src/test/java/de/tum/cit/ase/ares/api/aop/java/javaAOPModeData/JavaCSVFileLoaderTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/aop/java/javaAOPModeData/JavaCSVFileLoaderTest.java
@@ -75,8 +75,8 @@ public class JavaCSVFileLoaderTest {
 			}
 		};
 
-		Assertions.assertThrows(com.opencsv.exceptions.CsvMalformedLineException.class, () -> loader.loadCopyData(ArchitectureMode.WALA, false),
-				"Expected CsvException for malformed content");
+		Assertions.assertThrows(com.opencsv.exceptions.CsvMalformedLineException.class,
+				() -> loader.loadCopyData(ArchitectureMode.WALA, false), "Expected CsvException for malformed content");
 	}
 
 	@Test
@@ -133,7 +133,7 @@ public class JavaCSVFileLoaderTest {
 			}
 		};
 
-		Assertions.assertThrows(com.opencsv.exceptions.CsvMalformedLineException.class, () -> loader.loadEditData(AOPMode.ASPECTJ),
-				"Expected CsvException for malformed content");
+		Assertions.assertThrows(com.opencsv.exceptions.CsvMalformedLineException.class,
+				() -> loader.loadEditData(AOPMode.ASPECTJ), "Expected CsvException for malformed content");
 	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/FileHandlerConstantsTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/FileHandlerConstantsTest.java
@@ -13,7 +13,8 @@ public class FileHandlerConstantsTest {
 
 	@Test
 	void testClassCannotBeInstantiated() throws Exception {
-		// Constructor is private and throws SecurityException; reflection wraps it in InvocationTargetException
+		// Constructor is private and throws SecurityException; reflection wraps it in
+		// InvocationTargetException
 		var ctor = FileHandlerConstants.class.getDeclaredConstructor();
 		ctor.setAccessible(true);
 		try {
@@ -22,7 +23,8 @@ public class FileHandlerConstantsTest {
 					ctor.newInstance();
 				} catch (java.lang.reflect.InvocationTargetException e) {
 					Throwable cause = e.getCause();
-					if (cause instanceof SecurityException se) throw se;
+					if (cause instanceof SecurityException se)
+						throw se;
 					throw new RuntimeException(cause);
 				}
 			});

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/ReachabilityCheckerTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/ReachabilityCheckerTest.java
@@ -26,8 +26,7 @@ public class ReachabilityCheckerTest {
 		Predicate<com.ibm.wala.ipa.callgraph.CGNode> dummyFilter = node -> true;
 		SecurityException ex = assertThrows(SecurityException.class,
 				() -> ReachabilityChecker.findReachableMethods(null, dummyNodes, dummyFilter));
-		assertTrue(ex.getMessage().contains("CallGraph"),
-				"Expected message to mention CallGraph");
+		assertTrue(ex.getMessage().contains("CallGraph"), "Expected message to mention CallGraph");
 	}
 
 	/**
@@ -39,8 +38,7 @@ public class ReachabilityCheckerTest {
 		Predicate<com.ibm.wala.ipa.callgraph.CGNode> dummyFilter = node -> true;
 		SecurityException ex = assertThrows(SecurityException.class,
 				() -> ReachabilityChecker.findReachableMethods(dummyGraph, null, dummyFilter));
-		assertTrue(ex.getMessage().contains("startNodes"),
-				"Expected message to mention startNodes");
+		assertTrue(ex.getMessage().contains("startNodes"), "Expected message to mention startNodes");
 	}
 
 	/**
@@ -52,8 +50,7 @@ public class ReachabilityCheckerTest {
 		Iterator<com.ibm.wala.ipa.callgraph.CGNode> dummyNodes = Collections.emptyIterator();
 		SecurityException ex = assertThrows(SecurityException.class,
 				() -> ReachabilityChecker.findReachableMethods(dummyGraph, dummyNodes, null));
-		assertTrue(ex.getMessage().contains("targetNodeFilter"),
-				"Expected message to mention targetNodeFilter");
+		assertTrue(ex.getMessage().contains("targetNodeFilter"), "Expected message to mention targetNodeFilter");
 	}
 
 	/**
@@ -64,8 +61,7 @@ public class ReachabilityCheckerTest {
 		ClassHierarchy dummyHierarchy = mock(ClassHierarchy.class);
 		SecurityException ex = assertThrows(SecurityException.class,
 				() -> ReachabilityChecker.getEntryPointsFromStudentSubmission("   ", dummyHierarchy));
-		assertTrue(ex.getMessage().contains("classPath"),
-				"Expected message to mention classPath");
+		assertTrue(ex.getMessage().contains("classPath"), "Expected message to mention classPath");
 	}
 
 	/**
@@ -75,7 +71,6 @@ public class ReachabilityCheckerTest {
 	void getEntryPointsFromStudentSubmission_NullHierarchy_ThrowsSecurityException() {
 		SecurityException ex = assertThrows(SecurityException.class,
 				() -> ReachabilityChecker.getEntryPointsFromStudentSubmission("some/path", null));
-		assertTrue(ex.getMessage().contains("ClassHierarchy"),
-				"Expected message to mention ClassHierarchy");
+		assertTrue(ex.getMessage().contains("ClassHierarchy"), "Expected message to mention ClassHierarchy");
 	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/WalaPathClassificationTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/WalaPathClassificationTest.java
@@ -19,198 +19,191 @@ import com.ibm.wala.types.TypeReference;
 
 class WalaPathClassificationTest {
 
-    // ----------------------------------------------------------------
-    // Mock helpers
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Mock helpers
+	// ----------------------------------------------------------------
 
-    private static CGNode mockNode(ClassLoaderReference loaderRef, TypeReference typeRef) {
-        CGNode node = mock(CGNode.class);
-        IMethod method = mock(IMethod.class);
-        IClass cls = mock(IClass.class);
-        IClassLoader loader = mock(IClassLoader.class);
-        when(node.getMethod()).thenReturn(method);
-        when(method.getDeclaringClass()).thenReturn(cls);
-        when(cls.getClassLoader()).thenReturn(loader);
-        when(loader.getReference()).thenReturn(loaderRef);
-        when(cls.getReference()).thenReturn(typeRef);
-        return node;
-    }
+	private static CGNode mockNode(ClassLoaderReference loaderRef, TypeReference typeRef) {
+		CGNode node = mock(CGNode.class);
+		IMethod method = mock(IMethod.class);
+		IClass cls = mock(IClass.class);
+		IClassLoader loader = mock(IClassLoader.class);
+		when(node.getMethod()).thenReturn(method);
+		when(method.getDeclaringClass()).thenReturn(cls);
+		when(cls.getClassLoader()).thenReturn(loader);
+		when(loader.getReference()).thenReturn(loaderRef);
+		when(cls.getReference()).thenReturn(typeRef);
+		return node;
+	}
 
-    private static TypeReference ref(ClassLoaderReference clr, String descriptor) {
-        return TypeReference.findOrCreate(clr, TypeName.findOrCreate(descriptor));
-    }
+	private static TypeReference ref(ClassLoaderReference clr, String descriptor) {
+		return TypeReference.findOrCreate(clr, TypeName.findOrCreate(descriptor));
+	}
 
-    private static CGNode primordialNode(String descriptor) {
-        return mockNode(ClassLoaderReference.Primordial,
-                ref(ClassLoaderReference.Primordial, descriptor));
-    }
+	private static CGNode primordialNode(String descriptor) {
+		return mockNode(ClassLoaderReference.Primordial, ref(ClassLoaderReference.Primordial, descriptor));
+	}
 
-    private static CGNode applicationNode(String descriptor) {
-        return mockNode(ClassLoaderReference.Application,
-                ref(ClassLoaderReference.Application, descriptor));
-    }
+	private static CGNode applicationNode(String descriptor) {
+		return mockNode(ClassLoaderReference.Application, ref(ClassLoaderReference.Application, descriptor));
+	}
 
-    // ----------------------------------------------------------------
-    // isInfraFrame — cases 1-5
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// isInfraFrame — cases 1-5
+	// ----------------------------------------------------------------
 
-    @Test
-    void primordialJdkClassIsInfra() {
-        assertThat(WalaPathClassification.isInfraFrame(primordialNode("Ljava/lang/String;"))).isTrue();
-    }
+	@Test
+	void primordialJdkClassIsInfra() {
+		assertThat(WalaPathClassification.isInfraFrame(primordialNode("Ljava/lang/String;"))).isTrue();
+	}
 
-    @Test
-    void applicationStudentClassIsNotInfra() {
-        assertThat(WalaPathClassification.isInfraFrame(
-                applicationNode("Lanonymous/classloadingsystem/ClassLoadingAccess;"))).isFalse();
-    }
+	@Test
+	void applicationStudentClassIsNotInfra() {
+		assertThat(WalaPathClassification
+				.isInfraFrame(applicationNode("Lanonymous/classloadingsystem/ClassLoadingAccess;"))).isFalse();
+	}
 
-    @Test
-    void applicationToolclassIsInfra() {
-        assertThat(WalaPathClassification.isInfraFrame(
-                applicationNode("Lanonymous/toolclasses/Helper;"))).isTrue();
-    }
+	@Test
+	void applicationToolclassIsInfra() {
+		assertThat(WalaPathClassification.isInfraFrame(applicationNode("Lanonymous/toolclasses/Helper;"))).isTrue();
+	}
 
-    @Test
-    void applicationAresClassIsInfra() {
-        assertThat(WalaPathClassification.isInfraFrame(
-                applicationNode("Lde/tum/cit/ase/ares/api/SomeClass;"))).isTrue();
-    }
+	@Test
+	void applicationAresClassIsInfra() {
+		assertThat(WalaPathClassification.isInfraFrame(applicationNode("Lde/tum/cit/ase/ares/api/SomeClass;")))
+				.isTrue();
+	}
 
-    @Test
-    void applicationArrayOfStudentClassIsNotInfra() {
-        CGNode node = mockNode(ClassLoaderReference.Application,
-                ref(ClassLoaderReference.Application, "[Lanonymous/Student;"));
-        assertThat(WalaPathClassification.isInfraFrame(node)).isFalse();
-    }
+	@Test
+	void applicationArrayOfStudentClassIsNotInfra() {
+		CGNode node = mockNode(ClassLoaderReference.Application,
+				ref(ClassLoaderReference.Application, "[Lanonymous/Student;"));
+		assertThat(WalaPathClassification.isInfraFrame(node)).isFalse();
+	}
 
-    // ----------------------------------------------------------------
-    // nearestStudentFrame — cases 6-12
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// nearestStudentFrame — cases 6-12
+	// ----------------------------------------------------------------
 
-    @Test
-    void emptyPathReturnsEmpty() {
-        assertThat(WalaPathClassification.nearestStudentFrame(List.of()).isEmpty()).isTrue();
-    }
+	@Test
+	void emptyPathReturnsEmpty() {
+		assertThat(WalaPathClassification.nearestStudentFrame(List.of()).isEmpty()).isTrue();
+	}
 
-    @Test
-    void singleStudentNodeReturnsZero() {
-        CGNode student = applicationNode("Lanonymous/Student;");
-        assertThat(WalaPathClassification.nearestStudentFrame(List.of(student)))
-                .isEqualTo(OptionalInt.of(0));
-    }
+	@Test
+	void singleStudentNodeReturnsZero() {
+		CGNode student = applicationNode("Lanonymous/Student;");
+		assertThat(WalaPathClassification.nearestStudentFrame(List.of(student))).isEqualTo(OptionalInt.of(0));
+	}
 
-    @Test
-    void singleInfraNodeReturnsEmpty() {
-        CGNode infra = primordialNode("Ljava/lang/String;");
-        assertThat(WalaPathClassification.nearestStudentFrame(List.of(infra)).isEmpty()).isTrue();
-    }
+	@Test
+	void singleInfraNodeReturnsEmpty() {
+		CGNode infra = primordialNode("Ljava/lang/String;");
+		assertThat(WalaPathClassification.nearestStudentFrame(List.of(infra)).isEmpty()).isTrue();
+	}
 
-    @Test
-    void studentThenInfraSinkReturnsZero() {
-        CGNode student = applicationNode("Lanonymous/Student;");
-        CGNode sink = primordialNode("Ljava/lang/Class;");
-        assertThat(WalaPathClassification.nearestStudentFrame(List.of(student, sink)))
-                .isEqualTo(OptionalInt.of(0));
-    }
+	@Test
+	void studentThenInfraSinkReturnsZero() {
+		CGNode student = applicationNode("Lanonymous/Student;");
+		CGNode sink = primordialNode("Ljava/lang/Class;");
+		assertThat(WalaPathClassification.nearestStudentFrame(List.of(student, sink))).isEqualTo(OptionalInt.of(0));
+	}
 
-    @Test
-    void studentThenMultipleInfraSinksReturnsZero() {
-        CGNode student = applicationNode("Lanonymous/Student;");
-        CGNode infra1 = primordialNode("Lsun/nio/ch/DatagramChannelImpl;");
-        CGNode infra2 = primordialNode("Lsun/nio/ch/DatagramChannelImpl;");
-        CGNode sink = primordialNode("Ljava/net/InetAddress;");
-        assertThat(WalaPathClassification.nearestStudentFrame(
-                List.of(student, infra1, infra2, sink))).isEqualTo(OptionalInt.of(0));
-    }
+	@Test
+	void studentThenMultipleInfraSinksReturnsZero() {
+		CGNode student = applicationNode("Lanonymous/Student;");
+		CGNode infra1 = primordialNode("Lsun/nio/ch/DatagramChannelImpl;");
+		CGNode infra2 = primordialNode("Lsun/nio/ch/DatagramChannelImpl;");
+		CGNode sink = primordialNode("Ljava/net/InetAddress;");
+		assertThat(WalaPathClassification.nearestStudentFrame(List.of(student, infra1, infra2, sink)))
+				.isEqualTo(OptionalInt.of(0));
+	}
 
-    @Test
-    void nearestStudentIsReturnedWhenMultipleStudentFrames() {
-        CGNode studentA = applicationNode("Lanonymous/A;");
-        CGNode infra = primordialNode("Lsun/nio/ch/SomeImpl;");
-        CGNode studentB = applicationNode("Lanonymous/B;");
-        CGNode sink = primordialNode("Ljava/lang/Thread;");
-        assertThat(WalaPathClassification.nearestStudentFrame(
-                List.of(studentA, infra, studentB, sink))).isEqualTo(OptionalInt.of(2));
-    }
+	@Test
+	void nearestStudentIsReturnedWhenMultipleStudentFrames() {
+		CGNode studentA = applicationNode("Lanonymous/A;");
+		CGNode infra = primordialNode("Lsun/nio/ch/SomeImpl;");
+		CGNode studentB = applicationNode("Lanonymous/B;");
+		CGNode sink = primordialNode("Ljava/lang/Thread;");
+		assertThat(WalaPathClassification.nearestStudentFrame(List.of(studentA, infra, studentB, sink)))
+				.isEqualTo(OptionalInt.of(2));
+	}
 
-    @Test
-    void toolclassHelperTreatedAsInfraNotStudent() {
-        CGNode studentA = applicationNode("Lanonymous/A;");
-        CGNode toolclass = applicationNode("Lanonymous/toolclasses/Helper;");
-        CGNode studentB = applicationNode("Lanonymous/B;");
-        CGNode sink = primordialNode("Ljava/lang/Thread;");
-        assertThat(WalaPathClassification.nearestStudentFrame(
-                List.of(studentA, toolclass, studentB, sink))).isEqualTo(OptionalInt.of(2));
-    }
+	@Test
+	void toolclassHelperTreatedAsInfraNotStudent() {
+		CGNode studentA = applicationNode("Lanonymous/A;");
+		CGNode toolclass = applicationNode("Lanonymous/toolclasses/Helper;");
+		CGNode studentB = applicationNode("Lanonymous/B;");
+		CGNode sink = primordialNode("Ljava/lang/Thread;");
+		assertThat(WalaPathClassification.nearestStudentFrame(List.of(studentA, toolclass, studentB, sink)))
+				.isEqualTo(OptionalInt.of(2));
+	}
 
-    // ----------------------------------------------------------------
-    // packageNameOf — cases 13-16
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// packageNameOf — cases 13-16
+	// ----------------------------------------------------------------
 
-    @Test
-    void packageNameOfJavaLangString() {
-        IClass cls = mock(IClass.class);
-        when(cls.getReference()).thenReturn(TypeReference.JavaLangString);
-        assertThat(WalaPathClassification.packageNameOf(cls)).isEqualTo("java.lang.");
-    }
+	@Test
+	void packageNameOfJavaLangString() {
+		IClass cls = mock(IClass.class);
+		when(cls.getReference()).thenReturn(TypeReference.JavaLangString);
+		assertThat(WalaPathClassification.packageNameOf(cls)).isEqualTo("java.lang.");
+	}
 
-    @Test
-    void packageNameOfStringArray() {
-        IClass cls = mock(IClass.class);
-        when(cls.getReference()).thenReturn(
-                ref(ClassLoaderReference.Primordial, "[Ljava/lang/String;"));
-        assertThat(WalaPathClassification.packageNameOf(cls)).isEqualTo("java.lang.");
-    }
+	@Test
+	void packageNameOfStringArray() {
+		IClass cls = mock(IClass.class);
+		when(cls.getReference()).thenReturn(ref(ClassLoaderReference.Primordial, "[Ljava/lang/String;"));
+		assertThat(WalaPathClassification.packageNameOf(cls)).isEqualTo("java.lang.");
+	}
 
-    @Test
-    void packageNameOfTwoDimensionalStudentArray() {
-        IClass cls = mock(IClass.class);
-        when(cls.getReference()).thenReturn(
-                ref(ClassLoaderReference.Application, "[[Lanonymous/Student;"));
-        assertThat(WalaPathClassification.packageNameOf(cls)).isEqualTo("anonymous.");
-    }
+	@Test
+	void packageNameOfTwoDimensionalStudentArray() {
+		IClass cls = mock(IClass.class);
+		when(cls.getReference()).thenReturn(ref(ClassLoaderReference.Application, "[[Lanonymous/Student;"));
+		assertThat(WalaPathClassification.packageNameOf(cls)).isEqualTo("anonymous.");
+	}
 
-    @Test
-    void packageNameOfPrimitiveIntArray() {
-        IClass cls = mock(IClass.class);
-        when(cls.getReference()).thenReturn(TypeReference.IntArray);
-        assertThat(WalaPathClassification.packageNameOf(cls)).isEqualTo("");
-    }
+	@Test
+	void packageNameOfPrimitiveIntArray() {
+		IClass cls = mock(IClass.class);
+		when(cls.getReference()).thenReturn(TypeReference.IntArray);
+		assertThat(WalaPathClassification.packageNameOf(cls)).isEqualTo("");
+	}
 
-    // ----------------------------------------------------------------
-    // isInfraFrame edge cases — cases 17-18
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// isInfraFrame edge cases — cases 17-18
+	// ----------------------------------------------------------------
 
-    @Test
-    void extensionClassLoaderIsInfra() {
-        // ClassLoaderReference.Synthetic does not exist in WALA 1.6.x.
-        // Extension loader (platform/endorsed) is the correct secondary infra signal.
-        CGNode node = mockNode(ClassLoaderReference.Extension,
-                ref(ClassLoaderReference.Primordial, "Ljava/lang/String;"));
-        assertThat(WalaPathClassification.isInfraFrame(node)).isTrue();
-    }
+	@Test
+	void extensionClassLoaderIsInfra() {
+		// ClassLoaderReference.Synthetic does not exist in WALA 1.6.x.
+		// Extension loader (platform/endorsed) is the correct secondary infra signal.
+		CGNode node = mockNode(ClassLoaderReference.Extension,
+				ref(ClassLoaderReference.Primordial, "Ljava/lang/String;"));
+		assertThat(WalaPathClassification.isInfraFrame(node)).isTrue();
+	}
 
-    @Test
-    void declaringClassThrowsIsInfra() {
-        CGNode node = mock(CGNode.class);
-        IMethod method = mock(IMethod.class);
-        when(node.getMethod()).thenReturn(method);
-        when(method.getDeclaringClass()).thenThrow(new RuntimeException("simulated WALA error"));
-        assertThat(WalaPathClassification.isInfraFrame(node)).isTrue();
-    }
+	@Test
+	void declaringClassThrowsIsInfra() {
+		CGNode node = mock(CGNode.class);
+		IMethod method = mock(IMethod.class);
+		when(node.getMethod()).thenReturn(method);
+		when(method.getDeclaringClass()).thenThrow(new RuntimeException("simulated WALA error"));
+		assertThat(WalaPathClassification.isInfraFrame(node)).isTrue();
+	}
 
-    // ----------------------------------------------------------------
-    // Generic all-infra invariant — case 19
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Generic all-infra invariant — case 19
+	// ----------------------------------------------------------------
 
-    @Test
-    void allInfraPathWithMixedLoadersReturnsEmpty() {
-        // Primordial (JDK) + Application (Ares infra) — both infra, different classloaders.
-        // Asserts the no-student-frame contract independent of forbidden-API family.
-        CGNode primordial = primordialNode("Ljava/lang/String;");
-        CGNode ares = applicationNode("Lde/tum/cit/ase/ares/api/SomeHelper;");
-        assertThat(WalaPathClassification.nearestStudentFrame(
-                List.of(primordial, ares)).isEmpty()).isTrue();
-    }
+	@Test
+	void allInfraPathWithMixedLoadersReturnsEmpty() {
+		// Primordial (JDK) + Application (Ares infra) — both infra, different
+		// classloaders.
+		// Asserts the no-student-frame contract independent of forbidden-API family.
+		CGNode primordial = primordialNode("Ljava/lang/String;");
+		CGNode ares = applicationNode("Lde/tum/cit/ase/ares/api/SomeHelper;");
+		assertThat(WalaPathClassification.nearestStudentFrame(List.of(primordial, ares)).isEmpty()).isTrue();
+	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/WalaRuleTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/WalaRuleTest.java
@@ -20,412 +20,387 @@ import org.mockito.Mockito;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.classLoader.IMethod;
+import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
-import com.ibm.wala.core.util.strings.Atom;
 
 import de.tum.cit.ase.ares.api.architecture.java.JavaArchitectureTestCase;
 
 class WalaRuleTest {
 
-    private static Locale originalDefault;
-    private static Locale originalDisplay;
+	private static Locale originalDefault;
+	private static Locale originalDisplay;
 
-    @BeforeAll
-    static void pinEnglishLocale() {
-        originalDefault = Locale.getDefault();
-        originalDisplay = Locale.getDefault(Locale.Category.DISPLAY);
-        Locale.setDefault(Locale.ENGLISH);
-        Locale.setDefault(Locale.Category.DISPLAY, Locale.ENGLISH);
-    }
+	@BeforeAll
+	static void pinEnglishLocale() {
+		originalDefault = Locale.getDefault();
+		originalDisplay = Locale.getDefault(Locale.Category.DISPLAY);
+		Locale.setDefault(Locale.ENGLISH);
+		Locale.setDefault(Locale.Category.DISPLAY, Locale.ENGLISH);
+	}
 
-    @AfterAll
-    static void restoreLocale() {
-        Locale.setDefault(originalDefault);
-        Locale.setDefault(Locale.Category.DISPLAY, originalDisplay);
-    }
+	@AfterAll
+	static void restoreLocale() {
+		Locale.setDefault(originalDefault);
+		Locale.setDefault(Locale.Category.DISPLAY, originalDisplay);
+	}
 
-    // ----------------------------------------------------------------
-    // Mock helpers
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Mock helpers
+	// ----------------------------------------------------------------
 
-    /**
-     * Creates a student-code CGNode classified as Application-loaded in the
-     * anonymous.Student class. isInfraFrame returns false for this node.
-     */
-    private static CGNode studentNode(String signature) {
-        CGNode node = mock(CGNode.class);
-        IMethod method = mock(IMethod.class);
-        IClass cls = mock(IClass.class);
-        IClassLoader loader = mock(IClassLoader.class);
-        when(node.getMethod()).thenReturn(method);
-        when(method.getSignature()).thenReturn(signature);
-        when(method.getDeclaringClass()).thenReturn(cls);
-        when(cls.getClassLoader()).thenReturn(loader);
-        when(loader.getReference()).thenReturn(ClassLoaderReference.Application);
-        when(cls.getReference()).thenReturn(
-                TypeReference.findOrCreate(ClassLoaderReference.Application,
-                        TypeName.findOrCreate("Lanonymous/Student;")));
-        return node;
-    }
+	/**
+	 * Creates a student-code CGNode classified as Application-loaded in the
+	 * anonymous.Student class. isInfraFrame returns false for this node.
+	 */
+	private static CGNode studentNode(String signature) {
+		CGNode node = mock(CGNode.class);
+		IMethod method = mock(IMethod.class);
+		IClass cls = mock(IClass.class);
+		IClassLoader loader = mock(IClassLoader.class);
+		when(node.getMethod()).thenReturn(method);
+		when(method.getSignature()).thenReturn(signature);
+		when(method.getDeclaringClass()).thenReturn(cls);
+		when(cls.getClassLoader()).thenReturn(loader);
+		when(loader.getReference()).thenReturn(ClassLoaderReference.Application);
+		when(cls.getReference()).thenReturn(TypeReference.findOrCreate(ClassLoaderReference.Application,
+				TypeName.findOrCreate("Lanonymous/Student;")));
+		return node;
+	}
 
-    /**
-     * Creates a JDK (Primordial-loaded) CGNode suitable as the forbidden sink.
-     * Provides enough mocking for both isInfraFrame and WalaRule.check's
-     * declaringClass/lineNumber extraction.
-     */
-    private static CGNode jdkForbiddenNode(String signature, String simpleClassName) {
-        CGNode node = mock(CGNode.class);
-        IMethod method = mock(IMethod.class);
-        IClass cls = mock(IClass.class);
-        IClassLoader loader = mock(IClassLoader.class);
-        com.ibm.wala.types.TypeName typeName = mock(com.ibm.wala.types.TypeName.class);
-        Atom classAtom = Atom.findOrCreateAsciiAtom(simpleClassName);
-        when(node.getMethod()).thenReturn(method);
-        when(method.getSignature()).thenReturn(signature);
-        when(method.getDeclaringClass()).thenReturn(cls);
-        try {
-            Mockito.doReturn(null).when(method).getSourcePosition(0);
-        } catch (com.ibm.wala.shrike.shrikeCT.InvalidClassFileException ignored) {
-            // never thrown by a mock; satisfies compiler
-        }
-        when(cls.getClassLoader()).thenReturn(loader);
-        when(loader.getReference()).thenReturn(ClassLoaderReference.Primordial);
-        when(cls.getName()).thenReturn(typeName);
-        when(typeName.getClassName()).thenReturn(classAtom);
-        return node;
-    }
+	/**
+	 * Creates a JDK (Primordial-loaded) CGNode suitable as the forbidden sink.
+	 * Provides enough mocking for both isInfraFrame and WalaRule.check's
+	 * declaringClass/lineNumber extraction.
+	 */
+	private static CGNode jdkForbiddenNode(String signature, String simpleClassName) {
+		CGNode node = mock(CGNode.class);
+		IMethod method = mock(IMethod.class);
+		IClass cls = mock(IClass.class);
+		IClassLoader loader = mock(IClassLoader.class);
+		com.ibm.wala.types.TypeName typeName = mock(com.ibm.wala.types.TypeName.class);
+		Atom classAtom = Atom.findOrCreateAsciiAtom(simpleClassName);
+		when(node.getMethod()).thenReturn(method);
+		when(method.getSignature()).thenReturn(signature);
+		when(method.getDeclaringClass()).thenReturn(cls);
+		try {
+			Mockito.doReturn(null).when(method).getSourcePosition(0);
+		} catch (com.ibm.wala.shrike.shrikeCT.InvalidClassFileException ignored) {
+			// never thrown by a mock; satisfies compiler
+		}
+		when(cls.getClassLoader()).thenReturn(loader);
+		when(loader.getReference()).thenReturn(ClassLoaderReference.Primordial);
+		when(cls.getName()).thenReturn(typeName);
+		when(typeName.getClassName()).thenReturn(classAtom);
+		return node;
+	}
 
-    /**
-     * Creates an Ares-infra CGNode (Application-loaded but in de.tum.cit.ase.ares
-     * package). isInfraFrame returns true via INFRA_PREFIXES check.
-     */
-    private static CGNode aresInfraNode(String signature) {
-        CGNode node = mock(CGNode.class);
-        IMethod method = mock(IMethod.class);
-        IClass cls = mock(IClass.class);
-        IClassLoader loader = mock(IClassLoader.class);
-        when(node.getMethod()).thenReturn(method);
-        when(method.getSignature()).thenReturn(signature);
-        when(method.getDeclaringClass()).thenReturn(cls);
-        when(cls.getClassLoader()).thenReturn(loader);
-        when(loader.getReference()).thenReturn(ClassLoaderReference.Application);
-        when(cls.getReference()).thenReturn(
-                TypeReference.findOrCreate(ClassLoaderReference.Application,
-                        TypeName.findOrCreate("Lde/tum/cit/ase/ares/api/Helper;")));
-        return node;
-    }
+	/**
+	 * Creates an Ares-infra CGNode (Application-loaded but in de.tum.cit.ase.ares
+	 * package). isInfraFrame returns true via INFRA_PREFIXES check.
+	 */
+	private static CGNode aresInfraNode(String signature) {
+		CGNode node = mock(CGNode.class);
+		IMethod method = mock(IMethod.class);
+		IClass cls = mock(IClass.class);
+		IClassLoader loader = mock(IClassLoader.class);
+		when(node.getMethod()).thenReturn(method);
+		when(method.getSignature()).thenReturn(signature);
+		when(method.getDeclaringClass()).thenReturn(cls);
+		when(cls.getClassLoader()).thenReturn(loader);
+		when(loader.getReference()).thenReturn(ClassLoaderReference.Application);
+		when(cls.getReference()).thenReturn(TypeReference.findOrCreate(ClassLoaderReference.Application,
+				TypeName.findOrCreate("Lde/tum/cit/ase/ares/api/Helper;")));
+		return node;
+	}
 
-    private static CallGraph buildMockCg(List<CGNode> path) {
-        CallGraph cg = mock(CallGraph.class);
-        if (path.isEmpty()) {
-            when(cg.getEntrypointNodes()).thenReturn(java.util.Collections.emptyList());
-            return cg;
-        }
-        when(cg.getEntrypointNodes()).thenReturn(java.util.Collections.singletonList(path.get(0)));
-        when(cg.getSuccNodes(any())).thenAnswer(inv -> java.util.Collections.emptyIterator());
-        for (int i = 0; i < path.size() - 1; i++) {
-            final CGNode child = path.get(i + 1);
-            when(cg.getSuccNodes(path.get(i))).thenAnswer(inv ->
-                    java.util.Collections.singletonList(child).iterator());
-        }
-        return cg;
-    }
+	private static CallGraph buildMockCg(List<CGNode> path) {
+		CallGraph cg = mock(CallGraph.class);
+		if (path.isEmpty()) {
+			when(cg.getEntrypointNodes()).thenReturn(java.util.Collections.emptyList());
+			return cg;
+		}
+		when(cg.getEntrypointNodes()).thenReturn(java.util.Collections.singletonList(path.get(0)));
+		when(cg.getSuccNodes(any())).thenAnswer(inv -> java.util.Collections.emptyIterator());
+		for (int i = 0; i < path.size() - 1; i++) {
+			final CGNode child = path.get(i + 1);
+			when(cg.getSuccNodes(path.get(i))).thenAnswer(inv -> java.util.Collections.singletonList(child).iterator());
+		}
+		return cg;
+	}
 
-    private static AssertionError runAndExpectError(List<CGNode> path, WalaRule rule) {
-        AssertionError thrown = null;
-        try {
-            rule.check(buildMockCg(path));
-        } catch (AssertionError ae) {
-            thrown = ae;
-        }
-        return thrown;
-    }
+	private static AssertionError runAndExpectError(List<CGNode> path, WalaRule rule) {
+		AssertionError thrown = null;
+		try {
+			rule.check(buildMockCg(path));
+		} catch (AssertionError ae) {
+			thrown = ae;
+		}
+		return thrown;
+	}
 
-    private static void runAndExpectNoError(List<CGNode> path, WalaRule rule) {
-        rule.check(buildMockCg(path));
-    }
+	private static void runAndExpectNoError(List<CGNode> path, WalaRule rule) {
+		rule.check(buildMockCg(path));
+	}
 
-    /**
-     * Realistic full WALA method signatures for every formerly-suppressed API.
-     * Each value begins with the corresponding ALLOWED_HELPER_APIS prefix literal.
-     */
-    private static final Map<String, String[]> REALISTIC_SIGNATURES = Map.ofEntries(
-            Map.entry("java.lang.Thread.<init>",
-                    new String[]{"java.lang.Thread.<init>(Ljava/lang/Runnable;)V", "Thread"}),
-            Map.entry("java.lang.Thread.interrupt",
-                    new String[]{"java.lang.Thread.interrupt()V", "Thread"}),
-            Map.entry("java.lang.ClassLoader.getSystemClassLoader",
-                    new String[]{"java.lang.ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;", "ClassLoader"}),
-            Map.entry("java.lang.ClassLoader.loadLibrary",
-                    new String[]{"java.lang.ClassLoader.loadLibrary(Ljava/lang/String;)V", "ClassLoader"}),
-            Map.entry("java.lang.Runtime.load",
-                    new String[]{"java.lang.Runtime.load(Ljava/lang/String;)V", "Runtime"}),
-            Map.entry("java.lang.Runtime.loadLibrary",
-                    new String[]{"java.lang.Runtime.loadLibrary(Ljava/lang/String;)V", "Runtime"}),
-            Map.entry("java.io.File.getName",
-                    new String[]{"java.io.File.getName()Ljava/lang/String;", "File"}),
-            Map.entry("java.lang.Class.forName",
-                    new String[]{"java.lang.Class.forName(Ljava/lang/String;)Ljava/lang/Class;", "Class"}),
-            Map.entry("java.net.InetAddress.getAllByName",
-                    new String[]{"java.net.InetAddress.getAllByName(Ljava/lang/String;)[Ljava/net/InetAddress;", "InetAddress"}),
-            Map.entry("java.lang.Thread.contextClassLoader",
-                    new String[]{"java.lang.Thread.contextClassLoader()Ljava/lang/ClassLoader;", "Thread"}),
-            Map.entry("java.lang.Class.getDeclaredField",
-                    new String[]{"java.lang.Class.getDeclaredField(Ljava/lang/String;)Ljava/lang/reflect/Field;", "Class"}),
-            Map.entry("java.lang.reflect.Method.invoke",
-                    new String[]{"java.lang.reflect.Method.invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;", "Method"}),
-            Map.entry("java.lang.Class.checkMemberAccess",
-                    new String[]{"java.lang.Class.checkMemberAccess(Ljava/lang/Class;I)V", "Class"}),
-            Map.entry("java.lang.Thread.getContextClassLoader",
-                    new String[]{"java.lang.Thread.getContextClassLoader()Ljava/lang/ClassLoader;", "Thread"}),
-            Map.entry("java.lang.Thread.getStackTrace",
-                    new String[]{"java.lang.Thread.getStackTrace()[Ljava/lang/StackTraceElement;", "Thread"}),
-            Map.entry("java.io.File.<init>",
-                    new String[]{"java.io.File.<init>(Ljava/lang/String;)V", "File"}),
-            Map.entry("java.lang.Class.getClassLoader",
-                    new String[]{"java.lang.Class.getClassLoader()Ljava/lang/ClassLoader;", "Class"})
-    );
+	/**
+	 * Realistic full WALA method signatures for every formerly-suppressed API. Each
+	 * value begins with the corresponding ALLOWED_HELPER_APIS prefix literal.
+	 */
+	private static final Map<String, String[]> REALISTIC_SIGNATURES = Map.ofEntries(
+			Map.entry("java.lang.Thread.<init>",
+					new String[] { "java.lang.Thread.<init>(Ljava/lang/Runnable;)V", "Thread" }),
+			Map.entry("java.lang.Thread.interrupt", new String[] { "java.lang.Thread.interrupt()V", "Thread" }),
+			Map.entry("java.lang.ClassLoader.getSystemClassLoader",
+					new String[] { "java.lang.ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;",
+							"ClassLoader" }),
+			Map.entry("java.lang.ClassLoader.loadLibrary",
+					new String[] { "java.lang.ClassLoader.loadLibrary(Ljava/lang/String;)V", "ClassLoader" }),
+			Map.entry("java.lang.Runtime.load",
+					new String[] { "java.lang.Runtime.load(Ljava/lang/String;)V", "Runtime" }),
+			Map.entry("java.lang.Runtime.loadLibrary",
+					new String[] { "java.lang.Runtime.loadLibrary(Ljava/lang/String;)V", "Runtime" }),
+			Map.entry("java.io.File.getName", new String[] { "java.io.File.getName()Ljava/lang/String;", "File" }),
+			Map.entry("java.lang.Class.forName",
+					new String[] { "java.lang.Class.forName(Ljava/lang/String;)Ljava/lang/Class;", "Class" }),
+			Map.entry("java.net.InetAddress.getAllByName",
+					new String[] { "java.net.InetAddress.getAllByName(Ljava/lang/String;)[Ljava/net/InetAddress;",
+							"InetAddress" }),
+			Map.entry("java.lang.Thread.contextClassLoader",
+					new String[] { "java.lang.Thread.contextClassLoader()Ljava/lang/ClassLoader;", "Thread" }),
+			Map.entry("java.lang.Class.getDeclaredField",
+					new String[] { "java.lang.Class.getDeclaredField(Ljava/lang/String;)Ljava/lang/reflect/Field;",
+							"Class" }),
+			Map.entry("java.lang.reflect.Method.invoke",
+					new String[] {
+							"java.lang.reflect.Method.invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;",
+							"Method" }),
+			Map.entry("java.lang.Class.checkMemberAccess",
+					new String[] { "java.lang.Class.checkMemberAccess(Ljava/lang/Class;I)V", "Class" }),
+			Map.entry("java.lang.Thread.getContextClassLoader",
+					new String[] { "java.lang.Thread.getContextClassLoader()Ljava/lang/ClassLoader;", "Thread" }),
+			Map.entry("java.lang.Thread.getStackTrace",
+					new String[] { "java.lang.Thread.getStackTrace()[Ljava/lang/StackTraceElement;", "Thread" }),
+			Map.entry("java.io.File.<init>", new String[] { "java.io.File.<init>(Ljava/lang/String;)V", "File" }),
+			Map.entry("java.lang.Class.getClassLoader",
+					new String[] { "java.lang.Class.getClassLoader()Ljava/lang/ClassLoader;", "Class" }));
 
-    // ----------------------------------------------------------------
-    // Test 1: all-infra path does not fire
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Test 1: all-infra path does not fire
+	// ----------------------------------------------------------------
 
-    @Test
-    void allInfraPathDoesNotThrow() {
-        CGNode jdk1 = jdkForbiddenNode("java.io.RandomAccessFile.read([BII)I", "RandomAccessFile");
-        CGNode jdk2 = jdkForbiddenNode("java.io.FileInputStream.read([BII)I", "FileInputStream");
-        runAndExpectNoError(List.of(jdk1, jdk2),
-                new WalaRule("Accesses file system", Set.of("java.io.RandomAccessFile.read")));
-    }
+	@Test
+	void allInfraPathDoesNotThrow() {
+		CGNode jdk1 = jdkForbiddenNode("java.io.RandomAccessFile.read([BII)I", "RandomAccessFile");
+		CGNode jdk2 = jdkForbiddenNode("java.io.FileInputStream.read([BII)I", "FileInputStream");
+		runAndExpectNoError(List.of(jdk1, jdk2),
+				new WalaRule("Accesses file system", Set.of("java.io.RandomAccessFile.read")));
+	}
 
-    // ----------------------------------------------------------------
-    // Test 2: student-rooted shallow path reports student caller
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Test 2: student-rooted shallow path reports student caller
+	// ----------------------------------------------------------------
 
-    @Test
-    void studentRootedShallowPathThrowsWithStudentCaller() {
-        CGNode student = studentNode("anonymous.Student.callForbidden()V");
-        CGNode forbidden = jdkForbiddenNode(
-                "java.lang.Class.forName(Ljava/lang/String;)Ljava/lang/Class;", "Class");
-        AssertionError err = runAndExpectError(List.of(student, forbidden),
-                new WalaRule("Manipulates class loading",
-                        Set.of("java.lang.Class.forName(Ljava/lang/String;)")));
-        assertThat(err).isNotNull();
-        assertThat(err.getMessage()).contains("Method <anonymous.Student.callForbidden()V>");
-    }
+	@Test
+	void studentRootedShallowPathThrowsWithStudentCaller() {
+		CGNode student = studentNode("anonymous.Student.callForbidden()V");
+		CGNode forbidden = jdkForbiddenNode("java.lang.Class.forName(Ljava/lang/String;)Ljava/lang/Class;", "Class");
+		AssertionError err = runAndExpectError(List.of(student, forbidden),
+				new WalaRule("Manipulates class loading", Set.of("java.lang.Class.forName(Ljava/lang/String;)")));
+		assertThat(err).isNotNull();
+		assertThat(err.getMessage()).contains("Method <anonymous.Student.callForbidden()V>");
+	}
 
-    // ----------------------------------------------------------------
-    // Test 3: when two student frames are in the path, the one nearest to the
-    // forbidden sink is reported (not the outer caller).
-    // A student → JDK-intermediate → forbidden path is suppressed by
-    // isFalsePositiveTransitivePath; to exercise nearestStudentFrame we use two
-    // student nodes so the inner one is adjacent to the sink.
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Test 3: when two student frames are in the path, the one nearest to the
+	// forbidden sink is reported (not the outer caller).
+	// A student → JDK-intermediate → forbidden path is suppressed by
+	// isFalsePositiveTransitivePath; to exercise nearestStudentFrame we use two
+	// student nodes so the inner one is adjacent to the sink.
+	// ----------------------------------------------------------------
 
-    @Test
-    void deepPathReportsNearestStudentFrameToForbiddenSink() {
-        CGNode studentOuter = studentNode("anonymous.Student.outerCall()V");
-        CGNode studentInner = studentNode("anonymous.Student.innerCall()V");
-        CGNode forbidden = jdkForbiddenNode(
-                "sun.nio.ch.DatagramChannelImpl.connect(Ljava/net/SocketAddress;Z)Ljava/nio/channels/DatagramChannel;",
-                "DatagramChannelImpl");
-        AssertionError err = runAndExpectError(List.of(studentOuter, studentInner, forbidden),
-                new WalaRule("Accesses network",
-                        Set.of("sun.nio.ch.DatagramChannelImpl.connect(Ljava/net/SocketAddress;Z)")));
-        assertThat(err).isNotNull();
-        // innerCall is the nearest student frame and must appear as the Method <caller>
-        assertThat(err.getMessage())
-                .contains("Method <anonymous.Student.innerCall()V>");
-    }
+	@Test
+	void deepPathReportsNearestStudentFrameToForbiddenSink() {
+		CGNode studentOuter = studentNode("anonymous.Student.outerCall()V");
+		CGNode studentInner = studentNode("anonymous.Student.innerCall()V");
+		CGNode forbidden = jdkForbiddenNode(
+				"sun.nio.ch.DatagramChannelImpl.connect(Ljava/net/SocketAddress;Z)Ljava/nio/channels/DatagramChannel;",
+				"DatagramChannelImpl");
+		AssertionError err = runAndExpectError(List.of(studentOuter, studentInner, forbidden), new WalaRule(
+				"Accesses network", Set.of("sun.nio.ch.DatagramChannelImpl.connect(Ljava/net/SocketAddress;Z)")));
+		assertThat(err).isNotNull();
+		// innerCall is the nearest student frame and must appear as the Method <caller>
+		assertThat(err.getMessage()).contains("Method <anonymous.Student.innerCall()V>");
+	}
 
-    // ----------------------------------------------------------------
-    // Test 4: student → infra-classified intermediate → forbidden JDK
-    // isFalsePositiveTransitivePath suppresses this path: the toolclasses helper
-    // is in INFRA_PREFIXES, so all frames between student and sink are infra.
-    // The rule therefore does NOT fire — this is the expected false-positive
-    // suppression behaviour.
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Test 4: student → infra-classified intermediate → forbidden JDK
+	// isFalsePositiveTransitivePath suppresses this path: the toolclasses helper
+	// is in INFRA_PREFIXES, so all frames between student and sink are infra.
+	// The rule therefore does NOT fire — this is the expected false-positive
+	// suppression behaviour.
+	// ----------------------------------------------------------------
 
-    @Test
-    void transitiveInfraPathToForbiddenIsSuppressed() {
-        CGNode studentA = studentNode("anonymous.Student.runTask()V");
-        CGNode toolHelper = mock(CGNode.class);
-        IMethod toolMethod = mock(IMethod.class);
-        IClass toolCls = mock(IClass.class);
-        IClassLoader toolLoader = mock(IClassLoader.class);
-        when(toolHelper.getMethod()).thenReturn(toolMethod);
-        when(toolMethod.getSignature()).thenReturn("anonymous.toolclasses.TaskHelper.run()V");
-        when(toolMethod.getDeclaringClass()).thenReturn(toolCls);
-        when(toolCls.getClassLoader()).thenReturn(toolLoader);
-        when(toolLoader.getReference()).thenReturn(ClassLoaderReference.Application);
-        when(toolCls.getReference()).thenReturn(
-                TypeReference.findOrCreate(ClassLoaderReference.Application,
-                        TypeName.findOrCreate("Lanonymous/toolclasses/TaskHelper;")));
-        CGNode forbidden = jdkForbiddenNode("java.lang.Thread.<init>(Ljava/lang/Runnable;)V", "Thread");
+	@Test
+	void transitiveInfraPathToForbiddenIsSuppressed() {
+		CGNode studentA = studentNode("anonymous.Student.runTask()V");
+		CGNode toolHelper = mock(CGNode.class);
+		IMethod toolMethod = mock(IMethod.class);
+		IClass toolCls = mock(IClass.class);
+		IClassLoader toolLoader = mock(IClassLoader.class);
+		when(toolHelper.getMethod()).thenReturn(toolMethod);
+		when(toolMethod.getSignature()).thenReturn("anonymous.toolclasses.TaskHelper.run()V");
+		when(toolMethod.getDeclaringClass()).thenReturn(toolCls);
+		when(toolCls.getClassLoader()).thenReturn(toolLoader);
+		when(toolLoader.getReference()).thenReturn(ClassLoaderReference.Application);
+		when(toolCls.getReference()).thenReturn(TypeReference.findOrCreate(ClassLoaderReference.Application,
+				TypeName.findOrCreate("Lanonymous/toolclasses/TaskHelper;")));
+		CGNode forbidden = jdkForbiddenNode("java.lang.Thread.<init>(Ljava/lang/Runnable;)V", "Thread");
 
-        runAndExpectNoError(List.of(studentA, toolHelper, forbidden),
-                new WalaRule("Manipulates threads",
-                        Set.of("java.lang.Thread.<init>(Ljava/lang/Runnable;)")));
-    }
+		runAndExpectNoError(List.of(studentA, toolHelper, forbidden),
+				new WalaRule("Manipulates threads", Set.of("java.lang.Thread.<init>(Ljava/lang/Runnable;)")));
+	}
 
-    // ----------------------------------------------------------------
-    // Test 5: size==1 student-self path (callerIdx == size-1 fallback)
-    // This pins the defensive branch: when the student frame IS the forbidden node,
-    // we fall back to path[0] (entry == the same frame here), and the rule still fires.
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Test 5: size==1 student-self path (callerIdx == size-1 fallback)
+	// This pins the defensive branch: when the student frame IS the forbidden node,
+	// we fall back to path[0] (entry == the same frame here), and the rule still
+	// fires.
+	// ----------------------------------------------------------------
 
-    @Test
-    void sizeOneSelfForbiddenStudentPathThrows() {
-        // A student method is itself listed as forbidden. This is a theoretical edge case
-        // (production forbidden methods are always JDK), but we must pin the behaviour.
-        CGNode selfForbidden = studentNode("anonymous.Student.selfForbidden()V");
-        // Override the mock to also supply getName() for WalaRule.check's declaringClass line
-        IMethod selfMethod = selfForbidden.getMethod();
-        IClass cls = selfMethod.getDeclaringClass();
-        com.ibm.wala.types.TypeName typeName = mock(com.ibm.wala.types.TypeName.class);
-        try {
-            Mockito.doReturn(null).when(selfMethod).getSourcePosition(0);
-        } catch (com.ibm.wala.shrike.shrikeCT.InvalidClassFileException ignored) {
-            // never thrown by a mock; satisfies compiler
-        }
-        when(cls.getName()).thenReturn(typeName);
-        when(typeName.getClassName()).thenReturn(Atom.findOrCreateAsciiAtom("Student"));
+	@Test
+	void sizeOneSelfForbiddenStudentPathThrows() {
+		// A student method is itself listed as forbidden. This is a theoretical edge
+		// case
+		// (production forbidden methods are always JDK), but we must pin the behaviour.
+		CGNode selfForbidden = studentNode("anonymous.Student.selfForbidden()V");
+		// Override the mock to also supply getName() for WalaRule.check's
+		// declaringClass line
+		IMethod selfMethod = selfForbidden.getMethod();
+		IClass cls = selfMethod.getDeclaringClass();
+		com.ibm.wala.types.TypeName typeName = mock(com.ibm.wala.types.TypeName.class);
+		try {
+			Mockito.doReturn(null).when(selfMethod).getSourcePosition(0);
+		} catch (com.ibm.wala.shrike.shrikeCT.InvalidClassFileException ignored) {
+			// never thrown by a mock; satisfies compiler
+		}
+		when(cls.getName()).thenReturn(typeName);
+		when(typeName.getClassName()).thenReturn(Atom.findOrCreateAsciiAtom("Student"));
 
-        AssertionError err = runAndExpectError(List.of(selfForbidden),
-                new WalaRule("Test rule", Set.of("anonymous.Student.selfForbidden")));
-        assertThat(err).as("size==1 student-self must fire AssertionError").isNotNull();
-        // callerIdx == 0 == size-1: fallback uses path.get(0) which is the same frame.
-        assertThat(err.getMessage()).contains("anonymous.Student.selfForbidden");
+		AssertionError err = runAndExpectError(List.of(selfForbidden),
+				new WalaRule("Test rule", Set.of("anonymous.Student.selfForbidden")));
+		assertThat(err).as("size==1 student-self must fire AssertionError").isNotNull();
+		// callerIdx == 0 == size-1: fallback uses path.get(0) which is the same frame.
+		assertThat(err.getMessage()).contains("anonymous.Student.selfForbidden");
 
-        SecurityException parsed = null;
-        try {
-            JavaArchitectureTestCase.parseErrorMessage(err);
-        } catch (SecurityException se) {
-            parsed = se;
-        }
-        assertThat(parsed).as("parseErrorMessage must produce a SecurityException").isNotNull();
-    }
+		SecurityException parsed = null;
+		try {
+			JavaArchitectureTestCase.parseErrorMessage(err);
+		} catch (SecurityException se) {
+			parsed = se;
+		}
+		assertThat(parsed).as("parseErrorMessage must produce a SecurityException").isNotNull();
+	}
 
-    // ----------------------------------------------------------------
-    // Test 6: size==1 JDK-only path does not fire
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Test 6: size==1 JDK-only path does not fire
+	// ----------------------------------------------------------------
 
-    @Test
-    void sizeOneJdkOnlyPathDoesNotThrow() {
-        CGNode jdkNode = jdkForbiddenNode(
-                "java.lang.Thread.<init>(Ljava/lang/Runnable;)V", "Thread");
-        runAndExpectNoError(List.of(jdkNode),
-                new WalaRule("Manipulates threads",
-                        Set.of("java.lang.Thread.<init>(Ljava/lang/Runnable;)")));
-    }
+	@Test
+	void sizeOneJdkOnlyPathDoesNotThrow() {
+		CGNode jdkNode = jdkForbiddenNode("java.lang.Thread.<init>(Ljava/lang/Runnable;)V", "Thread");
+		runAndExpectNoError(List.of(jdkNode),
+				new WalaRule("Manipulates threads", Set.of("java.lang.Thread.<init>(Ljava/lang/Runnable;)")));
+	}
 
-    // ----------------------------------------------------------------
-    // Test 7: student → JDK intermediate → Thread.<init>
-    // isFalsePositiveTransitivePath suppresses this: Executors is Primordial
-    // (infra), so every frame between student and Thread.<init> is infra.
-    // In production, Executors itself would also be in the forbidden set, making
-    // the 2-node [student, Executors] path fire directly without suppression.
-    // This test pins the suppression behaviour for the 3-node path.
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Test 7: student → JDK intermediate → Thread.<init>
+	// isFalsePositiveTransitivePath suppresses this: Executors is Primordial
+	// (infra), so every frame between student and Thread.<init> is infra.
+	// In production, Executors itself would also be in the forbidden set, making
+	// the 2-node [student, Executors] path fire directly without suppression.
+	// This test pins the suppression behaviour for the 3-node path.
+	// ----------------------------------------------------------------
 
-    @Test
-    void transitiveJdkExecutorToThreadIsSuppressed() {
-        CGNode student = studentNode("anonymous.Student.callForbidden()V");
-        CGNode executors = jdkForbiddenNode(
-                "java.util.concurrent.Executors.newCachedThreadPool()Ljava/util/concurrent/ExecutorService;",
-                "Executors");
-        CGNode thread = jdkForbiddenNode("java.lang.Thread.<init>(Ljava/lang/Runnable;)V", "Thread");
-        runAndExpectNoError(List.of(student, executors, thread),
-                new WalaRule("Manipulates threads",
-                        Set.of("java.lang.Thread.<init>(Ljava/lang/Runnable;)")));
-    }
+	@Test
+	void transitiveJdkExecutorToThreadIsSuppressed() {
+		CGNode student = studentNode("anonymous.Student.callForbidden()V");
+		CGNode executors = jdkForbiddenNode(
+				"java.util.concurrent.Executors.newCachedThreadPool()Ljava/util/concurrent/ExecutorService;",
+				"Executors");
+		CGNode thread = jdkForbiddenNode("java.lang.Thread.<init>(Ljava/lang/Runnable;)V", "Thread");
+		runAndExpectNoError(List.of(student, executors, thread),
+				new WalaRule("Manipulates threads", Set.of("java.lang.Thread.<init>(Ljava/lang/Runnable;)")));
+	}
 
-    // ----------------------------------------------------------------
-    // Test 8: parameterised over all 17 formerly-suppressed APIs
-    // Each variant uses a realistic full WALA signature beginning with the literal.
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Test 8: parameterised over all 17 formerly-suppressed APIs
+	// Each variant uses a realistic full WALA signature beginning with the literal.
+	// ----------------------------------------------------------------
 
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "java.lang.Thread.<init>",
-            "java.lang.Thread.interrupt",
-            "java.lang.ClassLoader.getSystemClassLoader",
-            "java.lang.ClassLoader.loadLibrary",
-            "java.lang.Runtime.load",
-            "java.lang.Runtime.loadLibrary",
-            "java.io.File.getName",
-            "java.lang.Class.forName",
-            "java.net.InetAddress.getAllByName",
-            "java.lang.Thread.contextClassLoader",
-            "java.lang.Class.getDeclaredField",
-            "java.lang.reflect.Method.invoke",
-            "java.lang.Class.checkMemberAccess",
-            "java.lang.Thread.getContextClassLoader",
-            "java.lang.Thread.getStackTrace",
-            "java.io.File.<init>",
-            "java.lang.Class.getClassLoader"
-    })
-    void formerlyAllowedApiFromStudentCodeThrows(String apiPrefix) {
-        String[] sigAndClass = REALISTIC_SIGNATURES.get(apiPrefix);
-        String fullSig = sigAndClass[0];
-        String simpleClass = sigAndClass[1];
+	@ParameterizedTest
+	@ValueSource(strings = { "java.lang.Thread.<init>", "java.lang.Thread.interrupt",
+			"java.lang.ClassLoader.getSystemClassLoader", "java.lang.ClassLoader.loadLibrary", "java.lang.Runtime.load",
+			"java.lang.Runtime.loadLibrary", "java.io.File.getName", "java.lang.Class.forName",
+			"java.net.InetAddress.getAllByName", "java.lang.Thread.contextClassLoader",
+			"java.lang.Class.getDeclaredField", "java.lang.reflect.Method.invoke", "java.lang.Class.checkMemberAccess",
+			"java.lang.Thread.getContextClassLoader", "java.lang.Thread.getStackTrace", "java.io.File.<init>",
+			"java.lang.Class.getClassLoader" })
+	void formerlyAllowedApiFromStudentCodeThrows(String apiPrefix) {
+		String[] sigAndClass = REALISTIC_SIGNATURES.get(apiPrefix);
+		String fullSig = sigAndClass[0];
+		String simpleClass = sigAndClass[1];
 
-        CGNode student = studentNode("anonymous.Student.callApi()V");
-        CGNode forbidden = jdkForbiddenNode(fullSig, simpleClass);
+		CGNode student = studentNode("anonymous.Student.callApi()V");
+		CGNode forbidden = jdkForbiddenNode(fullSig, simpleClass);
 
-        AssertionError err = runAndExpectError(List.of(student, forbidden),
-                new WalaRule("Test rule", Set.of(apiPrefix)));
-        assertThat(err).as("formerly-suppressed API '%s' from student code must now fire", apiPrefix)
-                .isNotNull();
-        assertThat(err.getMessage())
-                .contains("Method <anonymous.Student.callApi()V>")
-                .contains("calls method <" + fullSig + ">");
-    }
+		AssertionError err = runAndExpectError(List.of(student, forbidden),
+				new WalaRule("Test rule", Set.of(apiPrefix)));
+		assertThat(err).as("formerly-suppressed API '%s' from student code must now fire", apiPrefix).isNotNull();
+		assertThat(err.getMessage()).contains("Method <anonymous.Student.callApi()V>")
+				.contains("calls method <" + fullSig + ">");
+	}
 
-    // ----------------------------------------------------------------
-    // Test 9: infra-only path to a formerly-suppressed API must NOT fire
-    // Codifies that the new infra-frame filter replaces wrapIgnoringJdkHelpers.
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Test 9: infra-only path to a formerly-suppressed API must NOT fire
+	// Codifies that the new infra-frame filter replaces wrapIgnoringJdkHelpers.
+	// ----------------------------------------------------------------
 
-    @Test
-    void infraOnlyPathToFormerlyAllowedApiDoesNotThrow() {
-        CGNode aresHelper = aresInfraNode(
-                "de.tum.cit.ase.ares.api.SomeHelper.checkClass(Ljava/lang/Class;)V");
-        CGNode forbidden = jdkForbiddenNode(
-                "java.lang.Class.forName(Ljava/lang/String;)Ljava/lang/Class;", "Class");
-        runAndExpectNoError(List.of(aresHelper, forbidden),
-                new WalaRule("Manipulates class loading",
-                        Set.of("java.lang.Class.forName")));
-    }
+	@Test
+	void infraOnlyPathToFormerlyAllowedApiDoesNotThrow() {
+		CGNode aresHelper = aresInfraNode("de.tum.cit.ase.ares.api.SomeHelper.checkClass(Ljava/lang/Class;)V");
+		CGNode forbidden = jdkForbiddenNode("java.lang.Class.forName(Ljava/lang/String;)Ljava/lang/Class;", "Class");
+		runAndExpectNoError(List.of(aresHelper, forbidden),
+				new WalaRule("Manipulates class loading", Set.of("java.lang.Class.forName")));
+	}
 
-    // ----------------------------------------------------------------
-    // Test 10: callerIdx == size-1 fallback — student IS the forbidden node
-    // ----------------------------------------------------------------
+	// ----------------------------------------------------------------
+	// Test 10: callerIdx == size-1 fallback — student IS the forbidden node
+	// ----------------------------------------------------------------
 
-    @Test
-    void callerIdxEqualsSizeMinus1FallbackTest() {
-        // When nearestStudentFrame returns size-1 (student is the forbidden node),
-        // WalaRule falls back to path[0] as callerSignature. For size==1 this is the
-        // same frame, so callerSig == forbiddenSig == studentSig.
-        CGNode selfForbidden = studentNode("anonymous.Student.selfForbidden()V");
-        IMethod selfMethod2 = selfForbidden.getMethod();
-        IClass cls2 = selfMethod2.getDeclaringClass();
-        com.ibm.wala.types.TypeName typeName2 = mock(com.ibm.wala.types.TypeName.class);
-        try {
-            Mockito.doReturn(null).when(selfMethod2).getSourcePosition(0);
-        } catch (com.ibm.wala.shrike.shrikeCT.InvalidClassFileException ignored) {
-            // never thrown by a mock; satisfies compiler
-        }
-        when(cls2.getName()).thenReturn(typeName2);
-        when(typeName2.getClassName()).thenReturn(Atom.findOrCreateAsciiAtom("Student"));
+	@Test
+	void callerIdxEqualsSizeMinus1FallbackTest() {
+		// When nearestStudentFrame returns size-1 (student is the forbidden node),
+		// WalaRule falls back to path[0] as callerSignature. For size==1 this is the
+		// same frame, so callerSig == forbiddenSig == studentSig.
+		CGNode selfForbidden = studentNode("anonymous.Student.selfForbidden()V");
+		IMethod selfMethod2 = selfForbidden.getMethod();
+		IClass cls2 = selfMethod2.getDeclaringClass();
+		com.ibm.wala.types.TypeName typeName2 = mock(com.ibm.wala.types.TypeName.class);
+		try {
+			Mockito.doReturn(null).when(selfMethod2).getSourcePosition(0);
+		} catch (com.ibm.wala.shrike.shrikeCT.InvalidClassFileException ignored) {
+			// never thrown by a mock; satisfies compiler
+		}
+		when(cls2.getName()).thenReturn(typeName2);
+		when(typeName2.getClassName()).thenReturn(Atom.findOrCreateAsciiAtom("Student"));
 
-        AssertionError err = runAndExpectError(List.of(selfForbidden),
-                new WalaRule("Test rule", Set.of("anonymous.Student.selfForbidden")));
-        assertThat(err).isNotNull();
-        assertThat(err.getMessage()).contains("anonymous.Student.selfForbidden");
-    }
+		AssertionError err = runAndExpectError(List.of(selfForbidden),
+				new WalaRule("Test rule", Set.of("anonymous.Student.selfForbidden")));
+		assertThat(err).isNotNull();
+		assertThat(err.getMessage()).contains("anonymous.Student.selfForbidden");
+	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/api/internal/sanitization/ThrowableUtilsTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/internal/sanitization/ThrowableUtilsTest.java
@@ -56,7 +56,8 @@ class ThrowableUtilsTest {
 			var preferredConstructor = findPreferredConstructor(type);
 			return !validate(type, preferredConstructor);
 		}).sorted(Comparator.comparing(Object::toString)).collect(Collectors.toList());
-		// Use string-based assertion to avoid assertj IntrospectionError when displaying failing types
+		// Use string-based assertion to avoid assertj IntrospectionError when
+		// displaying failing types
 		assertThat(duplicationFailures.stream().map(Class::getName).collect(Collectors.toList()))
 				.as("the default Throwable duplication works for all SAFE_TYPE classes that are not specially handeled")
 				.isEmpty();

--- a/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/creator/JavaCreatorTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/creator/JavaCreatorTest.java
@@ -106,7 +106,8 @@ public class JavaCreatorTest {
 			Supplier<String> mockSupplier = mock(Supplier.class);
 			when(mockSupplier.get()).thenReturn(null);
 
-			// Act - use a unique key to avoid interference with other tests using the static cache
+			// Act - use a unique key to avoid interference with other tests using the
+			// static cache
 			Supplier<String> cachedSupplier = JavaCreator.cacheResult("null_test_unique_key_abc123", mockSupplier);
 			String result = cachedSupplier.get();
 

--- a/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/essentialModel/yaml/EssentialDataYAMLReaderTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/essentialModel/yaml/EssentialDataYAMLReaderTest.java
@@ -214,10 +214,10 @@ public class EssentialDataYAMLReaderTest {
 		@DisplayName("Should read and process both packages and classes successfully")
 		void shouldReadAndProcessBothPackagesAndClassesSuccessfully() {
 			// Arrange
-			Path packagesPath = Paths
-					.get("src/main/resources/de/tum/cit/ase/ares/api/configuration/essentialFiles/java/EssentialPackages.yaml");
-			Path classesPath = Paths
-					.get("src/main/resources/de/tum/cit/ase/ares/api/configuration/essentialFiles/java/EssentialClasses.yaml");
+			Path packagesPath = Paths.get(
+					"src/main/resources/de/tum/cit/ase/ares/api/configuration/essentialFiles/java/EssentialPackages.yaml");
+			Path classesPath = Paths.get(
+					"src/main/resources/de/tum/cit/ase/ares/api/configuration/essentialFiles/java/EssentialClasses.yaml");
 
 			// Act
 			EssentialPackages packages = reader.readEssentialPackagesFrom(packagesPath);

--- a/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/writer/JavaWriterTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/writer/JavaWriterTest.java
@@ -72,7 +72,7 @@ public class JavaWriterTest {
 		@DisplayName("Should write test cases and return file paths")
 		void shouldWriteTestCasesAndReturnFilePaths() {
 			try (MockedStatic<FileTools> mockedFileTools = mockStatic(FileTools.class);
-				 MockedStatic<Phobos> mockedPhobos = mockStatic(Phobos.class)) {
+					MockedStatic<Phobos> mockedPhobos = mockStatic(Phobos.class)) {
 				// Arrange
 				// Mock ArchitectureMode
 				when(architectureMode.fsFilesToCopy()).thenReturn(List.of());
@@ -120,9 +120,11 @@ public class JavaWriterTest {
 				// Mock Phobos
 				mockedPhobos.when(() -> Phobos.filesToCopy()).thenReturn(List.of());
 				mockedPhobos.when(() -> Phobos.targetsToCopyTo(any())).thenReturn(List.of());
-				mockedPhobos.when(() -> Phobos.threePartedFileHeader()).thenReturn(tempDir.resolve("phobos-header.java"));
+				mockedPhobos.when(() -> Phobos.threePartedFileHeader())
+						.thenReturn(tempDir.resolve("phobos-header.java"));
 				mockedPhobos.when(() -> Phobos.threePartedFileBody(any())).thenReturn("phobos-body");
-				mockedPhobos.when(() -> Phobos.threePartedFileFooter()).thenReturn(tempDir.resolve("phobos-footer.java"));
+				mockedPhobos.when(() -> Phobos.threePartedFileFooter())
+						.thenReturn(tempDir.resolve("phobos-footer.java"));
 				mockedPhobos.when(() -> Phobos.targetToCopyTo(any())).thenReturn(tempDir.resolve("phobos-target.java"));
 				mockedPhobos.when(() -> Phobos.fileValue(any())).thenReturn(new String[] { "value" });
 
@@ -170,7 +172,7 @@ public class JavaWriterTest {
 		@DisplayName("Should handle empty lists")
 		void shouldHandleEmptyLists() {
 			try (MockedStatic<FileTools> mockedFileTools = mockStatic(FileTools.class);
-				 MockedStatic<Phobos> mockedPhobos = mockStatic(Phobos.class)) {
+					MockedStatic<Phobos> mockedPhobos = mockStatic(Phobos.class)) {
 				// Arrange
 				List<String> emptyPackages = List.of();
 				List<String> emptyClasses = List.of();
@@ -220,9 +222,11 @@ public class JavaWriterTest {
 				// Mock Phobos
 				mockedPhobos.when(() -> Phobos.filesToCopy()).thenReturn(List.of());
 				mockedPhobos.when(() -> Phobos.targetsToCopyTo(any())).thenReturn(List.of());
-				mockedPhobos.when(() -> Phobos.threePartedFileHeader()).thenReturn(tempDir.resolve("phobos-header.java"));
+				mockedPhobos.when(() -> Phobos.threePartedFileHeader())
+						.thenReturn(tempDir.resolve("phobos-header.java"));
 				mockedPhobos.when(() -> Phobos.threePartedFileBody(any())).thenReturn("phobos-body");
-				mockedPhobos.when(() -> Phobos.threePartedFileFooter()).thenReturn(tempDir.resolve("phobos-footer.java"));
+				mockedPhobos.when(() -> Phobos.threePartedFileFooter())
+						.thenReturn(tempDir.resolve("phobos-footer.java"));
 				mockedPhobos.when(() -> Phobos.targetToCopyTo(any())).thenReturn(tempDir.resolve("phobos-target.java"));
 				mockedPhobos.when(() -> Phobos.fileValue(any())).thenReturn(new String[] { "value" });
 
@@ -243,7 +247,7 @@ public class JavaWriterTest {
 		@DisplayName("Should merge essential classes and test classes correctly")
 		void shouldMergeEssentialClassesAndTestClassesCorrectly() {
 			try (MockedStatic<FileTools> mockedFileTools = mockStatic(FileTools.class);
-				 MockedStatic<Phobos> mockedPhobos = mockStatic(Phobos.class)) {
+					MockedStatic<Phobos> mockedPhobos = mockStatic(Phobos.class)) {
 				// Arrange
 				when(architectureMode.fsFilesToCopy()).thenReturn(List.of());
 				when(architectureMode.nonFSFilesToCopy()).thenReturn(List.of());
@@ -287,9 +291,11 @@ public class JavaWriterTest {
 				// Mock Phobos
 				mockedPhobos.when(() -> Phobos.filesToCopy()).thenReturn(List.of());
 				mockedPhobos.when(() -> Phobos.targetsToCopyTo(any())).thenReturn(List.of());
-				mockedPhobos.when(() -> Phobos.threePartedFileHeader()).thenReturn(tempDir.resolve("phobos-header.java"));
+				mockedPhobos.when(() -> Phobos.threePartedFileHeader())
+						.thenReturn(tempDir.resolve("phobos-header.java"));
 				mockedPhobos.when(() -> Phobos.threePartedFileBody(any())).thenReturn("phobos-body");
-				mockedPhobos.when(() -> Phobos.threePartedFileFooter()).thenReturn(tempDir.resolve("phobos-footer.java"));
+				mockedPhobos.when(() -> Phobos.threePartedFileFooter())
+						.thenReturn(tempDir.resolve("phobos-footer.java"));
 				mockedPhobos.when(() -> Phobos.targetToCopyTo(any())).thenReturn(tempDir.resolve("phobos-target.java"));
 				mockedPhobos.when(() -> Phobos.fileValue(any())).thenReturn(new String[] { "value" });
 
@@ -311,7 +317,7 @@ public class JavaWriterTest {
 		@DisplayName("Should handle different build modes")
 		void shouldHandleDifferentBuildModes() {
 			try (MockedStatic<FileTools> mockedFileTools = mockStatic(FileTools.class);
-				 MockedStatic<Phobos> mockedPhobos = mockStatic(Phobos.class)) {
+					MockedStatic<Phobos> mockedPhobos = mockStatic(Phobos.class)) {
 				// Arrange
 				when(architectureMode.fsFilesToCopy()).thenReturn(List.of());
 				when(architectureMode.nonFSFilesToCopy()).thenReturn(List.of());
@@ -355,9 +361,11 @@ public class JavaWriterTest {
 				// Mock Phobos
 				mockedPhobos.when(() -> Phobos.filesToCopy()).thenReturn(List.of());
 				mockedPhobos.when(() -> Phobos.targetsToCopyTo(any())).thenReturn(List.of());
-				mockedPhobos.when(() -> Phobos.threePartedFileHeader()).thenReturn(tempDir.resolve("phobos-header.java"));
+				mockedPhobos.when(() -> Phobos.threePartedFileHeader())
+						.thenReturn(tempDir.resolve("phobos-header.java"));
 				mockedPhobos.when(() -> Phobos.threePartedFileBody(any())).thenReturn("phobos-body");
-				mockedPhobos.when(() -> Phobos.threePartedFileFooter()).thenReturn(tempDir.resolve("phobos-footer.java"));
+				mockedPhobos.when(() -> Phobos.threePartedFileFooter())
+						.thenReturn(tempDir.resolve("phobos-footer.java"));
 				mockedPhobos.when(() -> Phobos.targetToCopyTo(any())).thenReturn(tempDir.resolve("phobos-target.java"));
 				mockedPhobos.when(() -> Phobos.fileValue(any())).thenReturn(new String[] { "value" });
 

--- a/src/test/java/de/tum/cit/ase/ares/api/util/FileToolsReadMethodsFileTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/util/FileToolsReadMethodsFileTest.java
@@ -16,26 +16,19 @@ class FileToolsReadMethodsFileTest {
 
 	@Test
 	void stripsAndFiltersBlanksCommentsWhitespaceLines(@TempDir Path tmp) throws IOException {
-		// EM SPACE (U+2003) is Character.isWhitespace -> true -> stripped to empty -> filtered.
-		// Mixed line endings, leading/trailing whitespace, comment with leading spaces, tabs.
-		String content = String.join("\n",
-				"# pure comment",
-				"   # comment with leading spaces",
-				"",
-				"   ",
-				"\t\t",
-				" ",
-				"  java.lang.String.length()  ",
-				"java.lang.String.isEmpty()",
-				"") + "\r\n# trailing comment after CRLF\r\n";
+		// EM SPACE (U+2003) is Character.isWhitespace -> true -> stripped to empty ->
+		// filtered.
+		// Mixed line endings, leading/trailing whitespace, comment with leading spaces,
+		// tabs.
+		String content = String.join("\n", "# pure comment", "   # comment with leading spaces", "", "   ", "\t\t", " ",
+				"  java.lang.String.length()  ", "java.lang.String.isEmpty()", "")
+				+ "\r\n# trailing comment after CRLF\r\n";
 		File file = tmp.resolve("methods.txt").toFile();
 		Files.writeString(file.toPath(), content, StandardCharsets.UTF_8);
 
 		Set<String> methods = FileTools.readMethodsFile(file);
 
-		assertThat(methods).containsExactlyInAnyOrder(
-				"java.lang.String.length()",
-				"java.lang.String.isEmpty()");
+		assertThat(methods).containsExactlyInAnyOrder("java.lang.String.length()", "java.lang.String.isEmpty()");
 	}
 
 	@Test
@@ -45,8 +38,7 @@ class FileToolsReadMethodsFileTest {
 		Files.writeString(file.toPath(), content, StandardCharsets.UTF_8);
 
 		assertThat(FileTools.readMethodsFile(file)).containsExactlyInAnyOrder(
-				"java.io.FileInputStream.<init>(java.io.File)",
-				"java.lang.Class.forName(java.lang.String)");
+				"java.io.FileInputStream.<init>(java.io.File)", "java.lang.Class.forName(java.lang.String)");
 	}
 
 	@Test

--- a/src/test/java/de/tum/cit/ase/ares/api/util/YamlPlaceholderResolverTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/util/YamlPlaceholderResolverTest.java
@@ -40,10 +40,9 @@ class YamlPlaceholderResolverTest {
 		String javaHome = System.getProperty("java.home");
 		String userHome = System.getProperty("user.home");
 		String tmpDir = System.getProperty("java.io.tmpdir");
-		String resolved = YamlPlaceholderResolver.expand(
-				"p: ${PROJECT_ROOT}\nj: ${java.home}\nu: ${user.home}\nt: ${java.io.tmpdir}");
-		assertThat(resolved).isEqualTo(
-				"p: " + userDir + "\nj: " + javaHome + "\nu: " + userHome + "\nt: " + tmpDir);
+		String resolved = YamlPlaceholderResolver
+				.expand("p: ${PROJECT_ROOT}\nj: ${java.home}\nu: ${user.home}\nt: ${java.io.tmpdir}");
+		assertThat(resolved).isEqualTo("p: " + userDir + "\nj: " + javaHome + "\nu: " + userHome + "\nt: " + tmpDir);
 	}
 
 	@Test

--- a/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/FileSystemAccessOverwriteTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/FileSystemAccessOverwriteTest.java
@@ -37,8 +37,8 @@ class FileSystemAccessOverwriteTest extends SystemAccessTest {
 	private static final String FILES_WITHIN_PATH = "test-classes/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/overwrite/files";
 	private static final String BUFFERED_WRITER_WITHIN_PATH = "test-classes/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/overwrite/writer/bufferedWriter";
 	private static final String THIRD_PARTY_PACKAGE_WITHIN_PATH = "test-classes/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/overwrite/thirdPartyPackage";
-	private static final Path THIRD_PARTY_NOT_TRUSTED_PATH = Paths.get("src", "test", "java", "de", "tum", "cit",
-			"ase", "ares", "integration", "aop", "forbidden", "subject", "nottrusted.txt");
+	private static final Path THIRD_PARTY_NOT_TRUSTED_PATH = Paths.get("src", "test", "java", "de", "tum", "cit", "ase",
+			"ares", "integration", "aop", "forbidden", "subject", "nottrusted.txt");
 	private static final String PRINT_WRITER_WITHIN_PATH = "test-classes/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/overwrite/printWriter";
 	private static final String RANDOM_ACCESS_FILE_WITHIN_PATH = "test-classes/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/overwrite/randomAccessFile";
 	private static final String PRINT_STREAM_WITHIN_PATH = "test-classes/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/overwrite/outputStream/printStream";

--- a/src/test/java/de/tum/cit/ase/ares/integration/testuser/HelloWorldUser.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/testuser/HelloWorldUser.java
@@ -13,11 +13,11 @@ import de.tum.cit.ase.ares.api.jupiter.Public;
 import de.tum.cit.ase.ares.api.localization.UseLocale;
 
 /**
- * Hello-World-style user test class that verifies @Policy behaviour.
- * Covers AspectJ modes (ArchUnit and WALA) and deactivated policy.
- * Instrumentation modes are intentionally excluded: when run via @UserBased,
- * the Java agent is not available in the nested test JVM, causing
- * JavaAOPTestCaseSettings to be unloadable from the bootstrap class loader.
+ * Hello-World-style user test class that verifies @Policy behaviour. Covers
+ * AspectJ modes (ArchUnit and WALA) and deactivated policy. Instrumentation
+ * modes are intentionally excluded: when run via @UserBased, the Java agent is
+ * not available in the nested test JVM, causing JavaAOPTestCaseSettings to be
+ * unloadable from the bootstrap class loader.
  */
 @Public
 @UseLocale("en")
@@ -31,10 +31,7 @@ public class HelloWorldUser {
 	// -----------------------------------------------------------------------
 
 	@Test
-	@Policy(
-		value = "src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyHelloWorld.yaml",
-		withinPath = "test-classes/de/tum/cit/ase/ares/integration/testuser/subject/helloWorld"
-	)
+	@Policy(value = "src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyHelloWorld.yaml", withinPath = "test-classes/de/tum/cit/ase/ares/integration/testuser/subject/helloWorld")
 	void helloWorld_mavenArchunitAspectJ() {
 		assertEquals("Hello, World!", "Hello, World!");
 	}
@@ -44,10 +41,7 @@ public class HelloWorldUser {
 	// -----------------------------------------------------------------------
 
 	@Test
-	@Policy(
-		value = "src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyHelloWorld.yaml",
-		withinPath = "test-classes/de/tum/cit/ase/ares/integration/testuser/subject/helloWorld"
-	)
+	@Policy(value = "src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyHelloWorld.yaml", withinPath = "test-classes/de/tum/cit/ase/ares/integration/testuser/subject/helloWorld")
 	void helloWorld_mavenWalaAspectJ() {
 		assertEquals("Hello, World!", "Hello, World!");
 	}


### PR DESCRIPTION
## Summary

Review and improvements of the current markdown documentation in ./docs for code coherence, spelling, grammar and readability.

## Changes

### `BlockFileSystemAccessAOP.md`

- [x] Spelling: `Attribuet` → `Attribute` in TOC entry, anchor, and section heading (4.2)
- [x] Spelling: `Disabeled` → `Disabled` in TOC entry, anchor, and section heading (5.1)
- [x] Grammar: `as an UML` → `as a UML` (section 1.1 body)
- [x] Grammar: `Summarising this` → `In summary` (section 1.5 body)
- [x] Terminology: `in the allowed list` → `in the allowlist` (TL;DR example, step 2)

### `BlockFileSystemAccessArchitecture.md`

- [x] Heading: `How Does The UML Activity Diagram look like?` → `What Does the UML Activity Diagram Look Like?` (heading 1.1, TOC entry, and anchor)
- [x] Grammar: `as an UML` → `as a UML` (section 1.1 body)
- [x] Grammar: `Summarising this` → `In summary` (section 1.5 body)

### `BlockThreadSystemAccessArchitecture.md`

- [x] Spelling: `Archunit` → `ArchUnit` (section 1.1, ArchUnit description line)

### `SecurityPolicyReaderAndDirectorManual.md`

- [x] Heading style: Section 2 `Purpose, What Problem Does This Solve?` → `Purpose — What Problem Does This Solve?` (heading + TOC)
- [x] Heading style: Section 5 `Reading the Policy, The reader Package` → `Reading the Policy — The reader Package` (heading + TOC)
- [x] Heading style: Section 6 `Directing Test-Case Creation, The director Package` → `Directing Test-Case Creation — The director Package` (heading + TOC)
- [x] Heading style: Section 7 `Orchestration, SecurityPolicyReaderAndDirector` → `Orchestration — SecurityPolicyReaderAndDirector` (heading + TOC)
- [x] Intro: Added short introductory paragraph before section 5.1 explaining the reader role
- [x] Intro: Added short introductory paragraph before section 6.1 explaining the director role and reader/director relationship

### `SecurityPolicyManual.md`

- [x] Transition: Added a `> What's next:` callout between the Quick Start (section 5.3) and the detailed configuration section (section 6) to bridge the two parts

### `HowToMakeAProjectAnAresProject.md`

- [x] Scope note: Added a `> Note:` callout after the existing frontmatter clarifying that this is a setup guide and pointing readers to the Security Policy Manual for policy configuration

## Changes applied (second pass)

- [x] `BlockCommandSystemAccessAOP.md` — Sentence overload: split long run-on at section 2 closing paragraph (one compound sentence → two); split section 5.1 Purpose into two paragraphs; split section 5.2.2 Purpose into two paragraphs.
- [x] `TestCaseFactoryAndBuilderManual.md` — Bridging/lead-ins: added transitional sentence at end of section 2 before the section 3 divider; added lead-in before the step list in section 6.2 (`JavaCreator`); added connector sentence before the step list in section 9.2 (`JavaExecuter`).
- [x] `BlockThreadSystemAccessArchitecture.md` — Thread terminology sweep: TOC entry, heading 1.3, and two body references updated from `thread creation` → `thread manipulation`.
- [x] `HowToMakeAProjectAnAresProject.md` — Required/optional overview: added introductory paragraph at top of section 3 listing the three required steps and noting that blockquoted tips are optional.

## Rationale

Some of the contents of the docs were hard to understand for newcomers and contained spelling and grammar issues. Some adjustments were necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the setup guide with a concise three-step overview for repository setup, adding the dependency, and attaching the agent to the test JVM; linked to security policy guidance.
  * Improved wording, headings, and consistency across AOP and architecture security guides.
  * Added brief overviews of test generation and execution lifecycles.
  * Fixed typos and refined formatting for readability and navigation.

* **Chores**
  * Updated CI Java distribution and enabled Maven caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Ares2/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->