### PR TITLE
fix(security): suppress hidden test details from student-visible feedback

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/internal/ReportingUtils.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/internal/ReportingUtils.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
 import org.slf4j.*;
 
 import de.tum.cit.ase.ares.api.context.TestContext;
+import de.tum.cit.ase.ares.api.context.TestType;
 import de.tum.cit.ase.ares.api.internal.sanitization.*;
 //REMOVED: Import of ArtemisSecurityManager
 
@@ -40,6 +41,9 @@ public final class ReportingUtils {
 	}
 
 	public static Throwable processThrowable(Throwable t, TestContext context) {
+		if (context.findTestType().orElse(null) == TestType.HIDDEN) {
+			return new AssertionError(localized("test_guard.hidden_test_failed"));
+		}
 		Optional<String> nonprivilegedFailureMessage = ConfigurationUtils.getNonprivilegedFailureMessage(context);
 		if (nonprivilegedFailureMessage.isPresent())
 			return processThrowablePrivilegedOnly(t, nonprivilegedFailureMessage.get());

--- a/src/main/resources/de/tum/cit/ase/ares/api/localization/messages.properties
+++ b/src/main/resources/de/tum/cit/ase/ares/api/localization/messages.properties
@@ -182,6 +182,7 @@ security.policy.within.path.invalid=The following path is invalid for withinPath
 # test guard and deadline handling
 test_guard.extended_deadline_zero_or_negative=deadline extension must not be ZERO or negative: %s
 test_guard.hidden_test_before_deadline_message=hidden tests will be executed after the deadline.
+test_guard.hidden_test_failed=Hidden test failed.
 test_guard.hidden_test_missing_deadline=cannot find a deadline for hidden test %s
 test_guard.invalid_deadline_format=invalid deadline string: %s
 test_guard.invalid_extended_deadline_format=invalid deadline extension format: %s

--- a/src/main/resources/de/tum/cit/ase/ares/api/localization/messages_de.properties
+++ b/src/main/resources/de/tum/cit/ase/ares/api/localization/messages_de.properties
@@ -175,6 +175,7 @@ security.policy.within.path.invalid=Der folgende Pfad ist f\u0308r withinPath un
 # test guard and deadline handling
 test_guard.extended_deadline_zero_or_negative=Deadline Verl\u00e4ngerung muss positiv sein: %s
 test_guard.hidden_test_before_deadline_message=Versteckte Tests werden nach der Deadline ausgef\u0308hrt.
+test_guard.hidden_test_failed=Versteckter Test fehlgeschlagen.
 test_guard.hidden_test_missing_deadline=F\u0308r den versteckten Test %s konnte keine Deadline gefunden werden
 test_guard.invalid_deadline_format=Ung\u0308ltiges ExtendedDeadline Format: %s
 test_guard.invalid_extended_deadline_format=Ung\u0308ltiges ExtendedDeadline Format: %s


### PR DESCRIPTION
## Summary

- When a test is annotated with `@HiddenTest`, all exception details (test names, assertion messages, exception messages, stack traces) are now replaced with a generic `"Hidden test failed."` message before being surfaced to Artemis.
- This prevents leakage of hidden test logic through the student-visible results page.
- New localization keys `test_guard.hidden_test_failed` added (EN + DE).

## Related Issues
Fixes: hidden test information exposed in Artemis student-visible feedback (Issues #1, #4 from the security audit).

## Test plan
- [x] Create a `@HiddenTest` that throws `new RuntimeException("SECRET_HIDDEN_CASE_42")`
- [x] Submit to Artemis and verify student results page shows only "Hidden test failed." — no exception message, no stack trace
- [x] Verify `@PublicTest` failures still show the full assertion message

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when hidden tests fail with localized support.
  * Enhanced error handling to provide clearer feedback.

* **Localization**
  * Added German translations for test-related messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Ares2/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->