### PR TITLE
Clarify file-execute denial reason when the command is allow-listed

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJCommandSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJCommandSystemAdviceDefinitions.aj
@@ -686,12 +686,15 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 						COMMAND_SYSTEM_IGNORE_PARAMETERS_EXCEPT.getOrDefault(
 								extractMethodNameWithoutModifiers(fullMethodSignature), IgnoreValues.NONE));
 		if (pathIllegallyExecutedThroughParameter != null) {
-			boolean noFileAllowRuleConfigured = pathsAllowedToBeExecuted == null || pathsAllowedToBeExecuted.length == 0;
+			// Reaching this check means the command-name check on the same variables already
+			// passed, i.e. the command IS allow-listed; only its executable file path is not
+			// in the execute allow-list. Report that precisely instead of the misleading
+			// generic "no allow rule configured" reason.
 			throw new SecurityException(JavaAspectJAbstractAdviceDefinitions.localize(
 					"security.advice.illegal.file.execution", commandSystemMethodToCheck, action,
 					pathIllegallyExecutedThroughParameter,
 					fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
-							+ " | " + buildDenialReason(noFileAllowRuleConfigured)));
+							+ " | " + localize("security.advice.denial.reason.command.executable.path.not.allowed")));
 		}
 		// </editor-fold>
 		// <editor-fold desc="Check attributes">
@@ -713,12 +716,15 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 						COMMAND_SYSTEM_IGNORE_ATTRIBUTES_EXCEPT.getOrDefault(
 								extractMethodNameWithoutModifiers(fullMethodSignature), IgnoreValues.NONE));
 		if (pathIllegallyExecutedThroughAttribute != null) {
-			boolean noFileAllowRuleConfigured = pathsAllowedToBeExecuted == null || pathsAllowedToBeExecuted.length == 0;
+			// Reaching this check means the command-name check on the same attributes already
+			// passed, i.e. the command IS allow-listed; only its executable file path is not
+			// in the execute allow-list. Report that precisely instead of the misleading
+			// generic "no allow rule configured" reason.
 			throw new SecurityException(JavaAspectJAbstractAdviceDefinitions.localize(
 					"security.advice.illegal.file.execution", commandSystemMethodToCheck, action,
 					pathIllegallyExecutedThroughAttribute,
 					fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
-							+ " | " + buildDenialReason(noFileAllowRuleConfigured)));
+							+ " | " + localize("security.advice.denial.reason.command.executable.path.not.allowed")));
 		}
 		// </editor-fold>
 	}

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceCommandSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceCommandSystemToolbox.java
@@ -651,14 +651,17 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 						COMMAND_SYSTEM_IGNORE_PARAMETERS_EXCEPT.getOrDefault(declaringTypeName + "." + methodName,
 								IgnoreValues.NONE));
 		if (pathIllegallyExecutedThroughParameter != null) {
-			boolean noFileAllowRuleConfigured = pathsAllowedToBeExecuted == null
-					|| pathsAllowedToBeExecuted.length == 0;
+			// Reaching this check means the command-name check on the same variables already
+			// passed, i.e. the command IS allow-listed; only its executable file path is not
+			// in the execute allow-list. Report that precisely instead of the misleading
+			// generic "no allow rule configured" reason.
 			throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox.localize(
 					"security.advice.illegal.file.execution", commandSystemMethodToCheck, action,
 					pathIllegallyExecutedThroughParameter,
 					fullMethodSignature
 							+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")") + " | "
-							+ JavaInstrumentationAdviceAbstractToolbox.buildDenialReason(noFileAllowRuleConfigured)));
+							+ JavaInstrumentationAdviceAbstractToolbox
+									.localize("security.advice.denial.reason.command.executable.path.not.allowed")));
 		}
 		// </editor-fold>
 		// <editor-fold desc="Check attributes">
@@ -681,14 +684,17 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 						COMMAND_SYSTEM_IGNORE_ATTRIBUTES_EXCEPT.getOrDefault(declaringTypeName + "." + methodName,
 								IgnoreValues.NONE));
 		if (pathIllegallyExecutedThroughAttribute != null) {
-			boolean noFileAllowRuleConfigured = pathsAllowedToBeExecuted == null
-					|| pathsAllowedToBeExecuted.length == 0;
+			// Reaching this check means the command-name check on the same attributes already
+			// passed, i.e. the command IS allow-listed; only its executable file path is not
+			// in the execute allow-list. Report that precisely instead of the misleading
+			// generic "no allow rule configured" reason.
 			throw new SecurityException(JavaInstrumentationAdviceAbstractToolbox.localize(
 					"security.advice.illegal.file.execution", commandSystemMethodToCheck, action,
 					pathIllegallyExecutedThroughAttribute,
 					fullMethodSignature
 							+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")") + " | "
-							+ JavaInstrumentationAdviceAbstractToolbox.buildDenialReason(noFileAllowRuleConfigured)));
+							+ JavaInstrumentationAdviceAbstractToolbox
+									.localize("security.advice.denial.reason.command.executable.path.not.allowed")));
 		}
 		// </editor-fold>
 	}

--- a/src/main/resources/de/tum/cit/ase/ares/api/localization/messages.properties
+++ b/src/main/resources/de/tum/cit/ase/ares/api/localization/messages.properties
@@ -87,6 +87,7 @@ security.advice.illegal.method.execution=Ares Security Error (Reason: Student-Co
 security.advice.illegal.file.execution=Ares Security Error (Reason: Student-Code; Stage: Execution): %s tried to illegally %s File %s via %s but was blocked by Ares.
 security.advice.denial.reason.no.allowlist=Reason: No allow rule configured for this resource type.
 security.advice.denial.reason.not.in.allowlist=Reason: No configured allow rule permits this access.
+security.advice.denial.reason.command.executable.path.not.allowed=Reason: The command is allow-listed, but its executable file path is not in the execute allow-list.
 security.advice.illegal.command.execution=Ares Security Error (Reason: Student-Code; Stage: Execution): %s tried to illegally %s Command %s via %s but was blocked by Ares.
 security.advice.illegal.thread.execution=Ares Security Error (Reason: Student-Code; Stage: Execution): %s tried to illegally %s Thread %s via %s but was blocked by Ares.
 security.archunit.illegal.execution=Ares Security Error (Reason: Student-Code; Stage: Execution): %s

--- a/src/main/resources/de/tum/cit/ase/ares/api/localization/messages_de.properties
+++ b/src/main/resources/de/tum/cit/ase/ares/api/localization/messages_de.properties
@@ -3,6 +3,7 @@ active_localization=de_DE
 security.advice.command.allowed.size=Ares Sicherheitsfehler (Grund: Ares-Code; Phase: Ausf�hrung): Die Anzahl der Elemente in argumentsAllowedToBePassed (derzeit '%s') muss gleich der Anzahl der Elemente in commandsAllowedToBeExecuted (derzeit '%s') sein.
 security.advice.denial.reason.no.allowlist=Grund: Keine Erlaubnisregel für diesen Ressourcentyp konfiguriert.
 security.advice.denial.reason.not.in.allowlist=Grund: Keine konfigurierte Erlaubnisregel gestattet diesen Zugriff.
+security.advice.denial.reason.command.executable.path.not.allowed=Grund: Der Befehl ist freigegeben, aber sein ausführbarer Dateipfad ist nicht in der Ausführungs-Erlaubnisliste enthalten.
 security.advice.illegal.file.execution=Ares Sicherheitsfehler (Grund: Student-Code; Phase: Ausf�hrung): %s hat versucht, illegal %s Datei %s �ber %s auszuf�hren, wurde jedoch von Ares blockiert.
 security.advice.illegal.command.execution=Ares Sicherheitsfehler (Grund: Student-Code; Phase: Ausf�hrung): %s hat versucht, illegal %s Kommando %s �ber %s auszuf�hren, wurde jedoch von Ares blockiert.
 security.advice.illegal.thread.execution=Ares Sicherheitsfehler (Grund: Student-Code; Phase: Ausf�hrung): %s hat versucht, illegal %s Thread %s �ber %s auszuf�hren, wurde jedoch von Ares blockiert.


### PR DESCRIPTION
## Problem
When student code executes a command by absolute path, the command advice runs a command-name check and then a file-execute check. The file-execute check is only reached *after* the command-name check on the same variables has passed — i.e. the command IS allow-listed and only its executable file path is not in the execute allow-list. The denial nevertheless reported **"No allow rule configured for this resource type"**, which is misleading because the command *is* configured. This sent downstream policy authors looking for a non-existent command-permit problem.

## Change (message-only, no enforcement change)
Introduce a dedicated denial reason (EN + DE) and use it at the four command file-execute throw sites — the instrumentation toolbox and its AspectJ mirror — leaving the shared filesystem advice untouched:

> Reason: The command is allow-listed, but its executable file path is not in the execute allow-list.

The reason is accurate at all four sites because reaching them implies the command-name check (same `IgnoreValues` filtering, runs first) already passed.

## Verification
- `forbidden/FileSystemAccessExecuteTest` 36/36, `DenialReasonAccessTest` 14/14, `allowed/CommandSystemAccessTest` 28/28, `forbidden/CommandSystemAccessTest` 20/20, command toolbox unit test 2/2 — all green.
- No test asserts the old NO_ALLOWLIST reason for command file-execution.
- The 20 pre-existing `allowed/FileSystemAccessExecuteTest` failures are `java.awt.Desktop` environmental failures, confirmed identical on baseline.