### PR TITLE
Reduce dependency surface and add report-only static analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,24 +48,19 @@
 			architecture rules, which do not depend on JVM strong encapsulation. -->
 		<jvm.module.access.args>--add-exports java.base/java.lang=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.nio.channels=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-opens java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED</jvm.module.access.args>
 		<!-- 4. AST: 4.1 JavaParser -->
-		<java-parser-version>3.27.0</java-parser-version>
-		<!-- 5. Formats: 5.1 JSON -->
-		<json-version>20250517</json-version>
-		<!-- 5. Formats: 5.2 YAML and XML-->
-		<yaml-version>2.18.2</yaml-version>
+		<java-parser-version>3.28.2</java-parser-version>
+		<!-- 5. Formats: YAML and XML (JSON handled via Jackson) -->
+		<yaml-version>2.22.0</yaml-version>
 		<!-- 6. Large Tooling Libraries -->
-		<guava-version>33.5.0-jre</guava-version>
-		<commons-io-version>2.20.0</commons-io-version>
-		<vavr-version>0.10.7</vavr-version>
+		<commons-io-version>2.22.0</commons-io-version>
 		<!-- 7. Small Tooling Libraries -->
-		<java-string-similarity-version>2.0.0</java-string-similarity-version>
-		<jgrapht-core-version>1.5.2</jgrapht-core-version>
+		<jgrapht-core-version>1.5.3</jgrapht-core-version>
 		<!-- 8. Logging  -->
-		<logback-version>1.5.18</logback-version>
+		<logback-version>1.5.34</logback-version>
 		<!-- 8. API  -->
 		<apiguardian-api-version>1.1.2</apiguardian-api-version>
 		<!-- Others -->
-		<spotless.version>3.0.0</spotless.version>
+		<spotless.version>3.7.0</spotless.version>
 		<!-- if JaCoCo is not executed -->
 		<argLine></argLine>
 		<!-- full certificate fingerprint: 23E62BB282A473EE4DDA2F8763EFD39363D21A8D -->
@@ -73,16 +68,15 @@
 	</properties>
 	<dependencyManagement>
 		<dependencies>
-			<!-- Override transitive vulnerable dependencies -->
-			<dependency>
-				<groupId>commons-beanutils</groupId>
-				<artifactId>commons-beanutils</artifactId>
-				<version>1.9.4</version>
-			</dependency>
+			<!-- Pin opencsv's transitive commons-lang3 to a current version. opencsv's
+				bean-mapping transitives (commons-beanutils, commons-text) are excluded on
+				the opencsv dependency itself since Ares only uses opencsv's raw CSV reader,
+				not its bean features. commons-lang3 cannot be excluded: opencsv's
+				CSVReader/CSVParser call it at construction time. -->
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.17.0</version>
+				<version>3.20.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -244,44 +238,40 @@
 			<version>${java-parser-version}</version>
 		</dependency>
 		-->
-		<!-- 5. Formats: 5.1 JSON -->
-		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>${json-version}</version>
-		</dependency>
-		<!-- 5. Formats: 5.2 YAML and XML -->
+		<!-- 5. Formats: YAML, XML and JSON (all via Jackson) -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
 			<version>${yaml-version}</version>
 		</dependency>
 		<!-- 6. Large Tooling Libraries -->
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava-version}</version>
-		</dependency>
+		<!-- commons-io is NOT used by Ares itself; it is only a security-interception
+			target so the AspectJ pointcut and instrumentation policy can reference
+			org.apache.commons.io.FileUtils.forceDelete (a way students could delete
+			files). It is scoped 'provided' so it stays on the compile/weave/test
+			classpath (keeping that interception resolvable) without leaking into the
+			runtime/transitive footprint of Ares consumers. -->
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>${commons-io-version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.vavr</groupId>
-			<artifactId>vavr</artifactId>
-			<version>${vavr-version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<!-- 7. Small Tooling Libraries -->
 		<dependency>
 			<groupId>com.opencsv</groupId>
 			<artifactId>opencsv</artifactId>
-			<version>5.9</version>
-		</dependency>
-		<dependency>
-			<groupId>info.debatty</groupId>
-			<artifactId>java-string-similarity</artifactId>
-			<version>${java-string-similarity-version}</version>
+			<version>5.12.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-beanutils</groupId>
+					<artifactId>commons-beanutils</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.jgrapht</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,28 +12,40 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<!-- 1. Testing: 1.1 JUnit -->
-		<junit-jupiter-version>6.0.0</junit-jupiter-version>
-		<junit-platform-version>6.0.0</junit-platform-version>
+		<junit-jupiter-version>6.1.0</junit-jupiter-version>
+		<junit-platform-version>6.1.0</junit-platform-version>
 		<junit-pioneer-version>2.3.0</junit-pioneer-version>
 		<!-- 1. Testing: 1.2 jqwik -->
+		<!-- Pinned to 1.9.3 (newest 1.9.x): the jqwik 1.10.x engine is not stable under
+			Ares here. Running the full suite, its lifecycle store hits a concurrent
+			modification (ArrayIndexOutOfBoundsException in StoreRepository.streamAllStores)
+			when Ares executes thread-spawning jqwik properties, failing JqwickTest
+			deterministically; 1.9.3 is green. The 1.10.x line also moved to
+			junit-platform 1.14 while this project builds on junit-platform 6.x, which
+			likely contributes. Revisit once jqwik ships a JUnit 6 compatible release. -->
 		<jqwik-version>1.9.3</jqwik-version>
 		<!-- 1. Testing: 1.3 AssertJ -->
 		<assertj-version>3.27.6</assertj-version>
 		<!-- 1. Testing: 1.4 Mockito -->
-		<mockito-version>5.2.0</mockito-version>
+		<mockito-version>5.23.0</mockito-version>
 		<!-- 1. Testing: 1.5 Hamcrest -->
 		<hamcrest-version>3.0</hamcrest-version>
 		<!-- 2. Architecture: 2.1 Archunit -->
-		<archunit-version>1.4.1</archunit-version>
+		<archunit-version>1.4.2</archunit-version>
 		<!-- 2. Architecture: 2.2 Wala -->
-		<wala-version>1.6.12</wala-version>
+		<wala-version>1.7.2</wala-version>
 		<!-- 3. AOP: 3.1 AspectJ -->
+		<!-- Pinned to 1.9.24: aspectjtools (ajc) 1.9.25 / 1.9.25.1 bundle an Eclipse JDT
+			compiler that throws an internal NullPointerException
+			("variableDeclaration is null", SourceTypeBinding.resolveTypeFor) while weaving
+			JavaInstrumentationDeletePathMethodAdviceTest. Bump again only once that ajc
+			regression is fixed upstream. -->
 		<aspectj-version>1.9.24</aspectj-version>
 		<aspectj-path>
 			${user.home}${file.separator}.m2${file.separator}repository${file.separator}org${file.separator}aspectj${file.separator}aspectjrt${file.separator}${aspectj-version}${file.separator}aspectjrt-${aspectj-version}.jar
 		</aspectj-path>
 		<!-- 3. AOP: 3.2 Byte Buddy -->
-		<byte-buddy-version>1.17.7</byte-buddy-version>
+		<byte-buddy-version>1.18.10</byte-buddy-version>
 		<byte-buddy-path>
 			${project.build.directory}${file.separator}${project.artifactId}-${project.version}-agent.jar
 		</byte-buddy-path>
@@ -100,14 +112,18 @@
 				src/test/java/de/tum/cit/ase/ares/testutilities/UserBased.java
 			-->
 		</dependency>
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<version>${junit-jupiter-version}</version>
-			<!-- 2 Cases:
+		<!-- JUnit 4 API only (no vintage engine): there are no JUnit 4 tests to run, but
+			the throwable sanitization compiles against junit.framework.* and
+			org.junit.* (JUnit 4) types so it can duplicate/sanitize legacy assertion
+			errors. junit-vintage-engine was removed; this supplies just the API.
+			2 Cases:
 				src/main/java/de/tum/cit/ase/ares/api/internal/sanitization/SafeTypeThrowableSanitizer.java
 				src/main/java/de/tum/cit/ase/ares/api/internal/sanitization/ThrowableSets.java
-			-->
+		-->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
@@ -147,9 +163,11 @@
 			<!-- Multiple Cases -->
 		</dependency>
 		<!-- 1. Testing: 1.3 Mockito -->
+		<!-- mockito-inline was discontinued after 5.2.0; its inline mock-maker is the
+			default in mockito-core since 5.x, so we depend on mockito-core directly. -->
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-inline</artifactId>
+			<artifactId>mockito-core</artifactId>
 			<version>${mockito-version}</version>
 			<!-- Multiple Cases -->
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -347,13 +347,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-clean-plugin</artifactId>
-				<version>3.3.2</version>
+				<version>3.5.0</version>
 			</plugin>
 			<!-- 2. Validate -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.4.1</version>
+				<version>3.6.3</version>
 				<executions>
 					<execution>
 						<id>enforce-versions</id>
@@ -416,12 +416,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.12.1</version>
+				<version>3.15.0</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.3.1</version>
+				<version>3.5.0</version>
 			</plugin>
 			<plugin>
 				<groupId>dev.aspectj</groupId>
@@ -430,8 +430,10 @@
 				<dependencies>
 					<dependency>
 						<groupId>org.aspectj</groupId>
+						<!-- Kept in sync with the aspectjrt runtime via the shared property;
+							see the aspectj-version note for why this is pinned to 1.9.24. -->
 						<artifactId>aspectjtools</artifactId>
-						<version>1.9.24</version>
+						<version>${aspectj-version}</version>
 					</dependency>
 				</dependencies>
 				<configuration>
@@ -462,7 +464,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.5.6</version>
 				<configuration>
 					<forkCount>1</forkCount>
 					<!-- Kill (and report) a hung forked JVM rather than letting CI run until
@@ -476,7 +478,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.5.0</version>
 				<executions>
 					<execution>
 						<id>default-jar</id>
@@ -518,7 +520,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.6.3</version>
+				<version>3.12.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -572,7 +574,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.4.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -585,7 +587,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-install-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>3.1.4</version>
 				<executions>
 					<execution>
 						<id>install-main-jar</id>
@@ -653,7 +655,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.6.2</version>
 				<executions>
 					<!-- Create agent jar before tests so surefire -javaagent path exists -->
 					<execution>
@@ -724,19 +726,19 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.12.1</version>
+				<version>3.22.0</version>
 			</plugin>
 			<!-- 9. Deploy -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>3.1.4</version>
 			</plugin>
 			<!-- Manual execution -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>versions-maven-plugin</artifactId>
-				<version>2.15.0</version>
+				<version>2.21.0</version>
 			</plugin>
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>
@@ -770,6 +772,39 @@
 							</file>
 						</eclipse>
 					</java>
+				</configuration>
+			</plugin>
+			<!-- Static analysis (manual execution, report-only): these are NOT bound to
+				the build lifecycle and are configured never to fail the build. Run them
+				on demand, e.g. `mvn checkstyle:check`, `mvn pmd:check`, `mvn pmd:cpd-check`
+				or `mvn spotbugs:check`; or generate reports via `mvn checkstyle:checkstyle`,
+				`mvn pmd:pmd`, `mvn spotbugs:spotbugs`. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.6.0</version>
+				<configuration>
+					<configLocation>google_checks.xml</configLocation>
+					<failOnViolation>false</failOnViolation>
+					<failsOnError>false</failsOnError>
+					<consoleOutput>true</consoleOutput>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>3.28.0</version>
+				<configuration>
+					<failOnViolation>false</failOnViolation>
+					<printFailingErrors>true</printFailingErrors>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>4.10.2.0</version>
+				<configuration>
+					<failOnError>false</failOnError>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -861,7 +896,7 @@
 					<plugin>
 						<groupId>org.jacoco</groupId>
 						<artifactId>jacoco-maven-plugin</artifactId>
-						<version>0.8.11</version>
+						<version>0.8.15</version>
 						<executions>
 							<execution>
 								<goals>
@@ -904,7 +939,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>3.3.0</version>
+						<version>3.5.6</version>
 						<configuration>
 							<forkCount>1</forkCount>
 							<forkedProcessTimeoutInSeconds>2400</forkedProcessTimeoutInSeconds>
@@ -923,7 +958,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.7</version>
+						<version>3.2.8</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -947,7 +982,7 @@
 					<plugin>
 						<groupId>org.sonatype.central</groupId>
 						<artifactId>central-publishing-maven-plugin</artifactId>
-						<version>0.8.0</version>
+						<version>0.11.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/AOPTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/AOPTestCase.java
@@ -1,8 +1,8 @@
 package de.tum.cit.ase.ares.api.aop;
 
-import javax.annotation.Nonnull;
+import java.util.Objects;
 
-import com.google.common.base.Preconditions;
+import javax.annotation.Nonnull;
 
 import de.tum.cit.ase.ares.api.aop.commandSystem.CommandSystemExtractor;
 import de.tum.cit.ase.ares.api.aop.fileSystem.FileSystemExtractor;
@@ -68,15 +68,14 @@ public abstract class AOPTestCase {
 			@Nonnull NetworkSystemExtractor networkConnectionExtractor,
 			@Nonnull CommandSystemExtractor commandExecutionExtractor,
 			@Nonnull ThreadSystemExtractor threadCreationExtractor) {
-		this.aopTestCaseSupported = Preconditions.checkNotNull(aopTestCaseSupported,
+		this.aopTestCaseSupported = Objects.requireNonNull(aopTestCaseSupported,
 				"aopTestCaseSupported must not be null");
-		this.fileSystemExtractor = Preconditions.checkNotNull(fileSystemExtractor,
-				"fileSystemExtractor must not be null");
-		this.networkConnectionExtractor = Preconditions.checkNotNull(networkConnectionExtractor,
+		this.fileSystemExtractor = Objects.requireNonNull(fileSystemExtractor, "fileSystemExtractor must not be null");
+		this.networkConnectionExtractor = Objects.requireNonNull(networkConnectionExtractor,
 				"networkConnectionExtractor must not be null");
-		this.commandExecutionExtractor = Preconditions.checkNotNull(commandExecutionExtractor,
+		this.commandExecutionExtractor = Objects.requireNonNull(commandExecutionExtractor,
 				"commandExecutionExtractor must not be null");
-		this.threadCreationExtractor = Preconditions.checkNotNull(threadCreationExtractor,
+		this.threadCreationExtractor = Objects.requireNonNull(threadCreationExtractor,
 				"threadCreationExtractor must not be null");
 	}
 	// </editor-fold>

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceAbstractToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceAbstractToolbox.java
@@ -481,11 +481,20 @@ public abstract class JavaInstrumentationAdviceAbstractToolbox {
 				// First restricted, non-allowed frame is the violation.
 				if (violation == null && inRestricted) {
 					boolean allowed = false;
-					for (@Nonnull
-					String allowedClass : allowedClasses) {
-						if (className.startsWith(allowedClass)) {
-							allowed = true;
-							break;
+					// allowedClasses may be null when the per-test settings are only
+					// partially armed: the volatile fields in JavaAOPTestCaseSettings are
+					// written one-by-one, so a class woven on another thread can observe
+					// aopMode/restrictedPackage already set while allowedListedClasses is
+					// still null. Treat null as "nothing allow-listed" (identical to an
+					// empty array), mirroring the null-tolerant allowedPaths handling in
+					// JavaInstrumentationAdviceFileSystemToolbox#checkFileSystemInteractionForAction.
+					if (allowedClasses != null) {
+						for (@Nonnull
+						String allowedClass : allowedClasses) {
+							if (className.startsWith(allowedClass)) {
+								allowed = true;
+								break;
+							}
 						}
 					}
 					if (!allowed) {

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/ArchitectureTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/ArchitectureTestCase.java
@@ -1,11 +1,11 @@
 package de.tum.cit.ase.ares.api.architecture;
 
+import java.util.Objects;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.google.common.base.Preconditions;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.tngtech.archunit.core.domain.JavaClasses;
 
@@ -88,10 +88,10 @@ public abstract class ArchitectureTestCase {
 	protected ArchitectureTestCase(@Nonnull ArchitectureTestCaseSupported architectureTestCaseSupported,
 			@Nonnull Set<PackagePermission> allowedPackages, @Nonnull JavaClasses javaClasses,
 			@Nullable CallGraph callGraph) {
-		this.architectureTestCaseSupported = Preconditions.checkNotNull(architectureTestCaseSupported,
+		this.architectureTestCaseSupported = Objects.requireNonNull(architectureTestCaseSupported,
 				"architecturalTestCaseSupported must not be null");
-		this.allowedPackages = Preconditions.checkNotNull(allowedPackages, "allowedPackages must not be null");
-		this.javaClasses = Preconditions.checkNotNull(javaClasses, "javaClasses must not be null");
+		this.allowedPackages = Objects.requireNonNull(allowedPackages, "allowedPackages must not be null");
+		this.javaClasses = Objects.requireNonNull(javaClasses, "javaClasses must not be null");
 		this.callGraph = callGraph;
 	}
 	// </editor-fold>

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCase.java
@@ -1,12 +1,12 @@
 package de.tum.cit.ase.ares.api.architecture.java;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.google.common.base.Preconditions;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.tngtech.archunit.core.domain.JavaClasses;
 
@@ -166,13 +166,13 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 	 *                           security violation
 	 */
 	public static void parseErrorMessage(@Nonnull AssertionError e) {
-		Preconditions.checkNotNull(e, "error must not be null");
+		Objects.requireNonNull(e, "error must not be null");
 		@Nullable
 		String message = e.getMessage();
-		Preconditions.checkNotNull(message, "message must not be null");
+		Objects.requireNonNull(message, "message must not be null");
 		@Nullable
 		String[] messageParts = e.getMessage().split("\n");
-		Preconditions.checkNotNull(messageParts, "messageParts must not be null");
+		Objects.requireNonNull(messageParts, "messageParts must not be null");
 		if (messageParts.length < 2) {
 			throw new SecurityException(Messages.localized("security.archunit.illegal.execution", e.getMessage()));
 		}
@@ -385,14 +385,16 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 	 */
 	@Override
 	public void executeArchitectureTestCase(@Nonnull String architectureMode, @Nonnull String aopMode) {
-		ArchitectureTestCaseSupported protectedArchitectureTestCaseSupported = Preconditions
-				.checkNotNull(architectureTestCaseSupported, "javaArchitecturalTestCaseSupported must not be null");
-		Preconditions.checkArgument(architectureTestCaseSupported instanceof JavaArchitectureTestCaseSupported,
-				"javaArchitecturalTestCaseSupported must be an instance of JavaArchitectureTestCaseSupported");
+		ArchitectureTestCaseSupported protectedArchitectureTestCaseSupported = Objects
+				.requireNonNull(architectureTestCaseSupported, "javaArchitecturalTestCaseSupported must not be null");
+		if (!(architectureTestCaseSupported instanceof JavaArchitectureTestCaseSupported)) {
+			throw new IllegalArgumentException(
+					"javaArchitecturalTestCaseSupported must be an instance of JavaArchitectureTestCaseSupported");
+		}
 		JavaArchitectureTestCaseSupported protectedJavaArchitectureTestCaseSupported = (JavaArchitectureTestCaseSupported) protectedArchitectureTestCaseSupported;
-		Set<PackagePermission> protectedAllowedPackages = Preconditions.checkNotNull(allowedPackages,
+		Set<PackagePermission> protectedAllowedPackages = Objects.requireNonNull(allowedPackages,
 				"allowedPackages must not be null");
-		JavaClasses protectedJavaClasses = Preconditions.checkNotNull(javaClasses, "javaClasses must not be null");
+		JavaClasses protectedJavaClasses = Objects.requireNonNull(javaClasses, "javaClasses must not be null");
 
 		switch (architectureMode) {
 		case "ARCHUNIT" -> JavaArchunitTestCase.archunitBuilder()
@@ -473,7 +475,7 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 		@Nonnull
 		public Builder javaArchitectureTestCaseSupported(
 				@Nonnull JavaArchitectureTestCaseSupported javaArchitectureTestCaseSupported) {
-			this.javaArchitectureTestCaseSupported = Preconditions.checkNotNull(javaArchitectureTestCaseSupported,
+			this.javaArchitectureTestCaseSupported = Objects.requireNonNull(javaArchitectureTestCaseSupported,
 					"javaArchitecturalTestCaseSupported must not be null");
 			return this;
 		}
@@ -488,7 +490,7 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 		 */
 		@Nonnull
 		public Builder javaClasses(@Nonnull JavaClasses javaClasses) {
-			this.javaClasses = Preconditions.checkNotNull(javaClasses, "javaClasses must not be null");
+			this.javaClasses = Objects.requireNonNull(javaClasses, "javaClasses must not be null");
 			return this;
 		}
 
@@ -528,7 +530,7 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 		 */
 		@Nonnull
 		public Builder allowedPackages(@Nonnull Set<PackagePermission> allowedPackages) {
-			this.allowedPackages = Preconditions.checkNotNull(allowedPackages, "allowedPackages must not be null");
+			this.allowedPackages = Objects.requireNonNull(allowedPackages, "allowedPackages must not be null");
 			return this;
 		}
 
@@ -543,7 +545,7 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 		 */
 		@Nonnull
 		public Builder allowedClasses(@Nonnull Set<ClassPermission> allowedClasses) {
-			this.allowedClasses = Preconditions.checkNotNull(allowedClasses, "allowedClasses must not be null");
+			this.allowedClasses = Objects.requireNonNull(allowedClasses, "allowedClasses must not be null");
 			return this;
 		}
 
@@ -559,11 +561,11 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 		@Nonnull
 		public JavaArchitectureTestCase build() {
 			return new JavaArchitectureTestCase(
-					Preconditions.checkNotNull(javaArchitectureTestCaseSupported,
+					Objects.requireNonNull(javaArchitectureTestCaseSupported,
 							"javaArchitecturalTestCaseSupported must not be null"),
-					Preconditions.checkNotNull(allowedPackages, "allowedPackages must not be null"),
-					Preconditions.checkNotNull(javaClasses, "javaClasses must not be null"), callGraph,
-					callGraphSupplier, allowedClasses);
+					Objects.requireNonNull(allowedPackages, "allowedPackages must not be null"),
+					Objects.requireNonNull(javaClasses, "javaClasses must not be null"), callGraph, callGraphSupplier,
+					allowedClasses);
 		}
 	}
 	// </editor-fold>

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/archunit/JavaArchunitTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/archunit/JavaArchunitTestCase.java
@@ -4,13 +4,13 @@ package de.tum.cit.ase.ares.api.architecture.java.archunit;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.google.common.base.Preconditions;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 
@@ -242,7 +242,7 @@ public class JavaArchunitTestCase extends JavaArchitectureTestCase {
 		@Nonnull
 		public JavaArchunitTestCase.Builder javaArchitectureTestCaseSupported(
 				@Nonnull JavaArchitectureTestCaseSupported javaArchitectureTestCaseSupported) {
-			this.javaArchitectureTestCaseSupported = Preconditions.checkNotNull(javaArchitectureTestCaseSupported,
+			this.javaArchitectureTestCaseSupported = Objects.requireNonNull(javaArchitectureTestCaseSupported,
 					"javaArchitecturalTestCaseSupported must not be null");
 			return this;
 		}
@@ -257,7 +257,7 @@ public class JavaArchunitTestCase extends JavaArchitectureTestCase {
 		 */
 		@Nonnull
 		public JavaArchunitTestCase.Builder javaClasses(@Nonnull JavaClasses javaClasses) {
-			this.javaClasses = Preconditions.checkNotNull(javaClasses, "javaClasses must not be null");
+			this.javaClasses = Objects.requireNonNull(javaClasses, "javaClasses must not be null");
 			return this;
 		}
 
@@ -271,7 +271,7 @@ public class JavaArchunitTestCase extends JavaArchitectureTestCase {
 		 */
 		@Nonnull
 		public JavaArchunitTestCase.Builder allowedPackages(@Nonnull Set<PackagePermission> allowedPackages) {
-			this.allowedPackages = Preconditions.checkNotNull(allowedPackages, "allowedPackages must not be null");
+			this.allowedPackages = Objects.requireNonNull(allowedPackages, "allowedPackages must not be null");
 			return this;
 		}
 
@@ -285,7 +285,7 @@ public class JavaArchunitTestCase extends JavaArchitectureTestCase {
 		 */
 		@Nonnull
 		public JavaArchunitTestCase.Builder allowedClasses(@Nonnull Set<ClassPermission> allowedClasses) {
-			this.allowedClasses = Preconditions.checkNotNull(allowedClasses, "allowedClasses must not be null");
+			this.allowedClasses = Objects.requireNonNull(allowedClasses, "allowedClasses must not be null");
 			return this;
 		}
 
@@ -301,10 +301,10 @@ public class JavaArchunitTestCase extends JavaArchitectureTestCase {
 		@Nonnull
 		public JavaArchunitTestCase build() {
 			return new JavaArchunitTestCase(
-					Preconditions.checkNotNull(javaArchitectureTestCaseSupported,
+					Objects.requireNonNull(javaArchitectureTestCaseSupported,
 							"javaArchitecturalTestCaseSupported must not be null"),
-					Preconditions.checkNotNull(allowedPackages, "allowedPackages must not be null"),
-					Preconditions.checkNotNull(javaClasses, "javaClasses must not be null"), allowedClasses);
+					Objects.requireNonNull(allowedPackages, "allowedPackages must not be null"),
+					Objects.requireNonNull(javaClasses, "javaClasses must not be null"), allowedClasses);
 		}
 	}
 	// </editor-fold>

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/JavaWalaTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/JavaWalaTestCase.java
@@ -13,6 +13,7 @@ import java.security.MessageDigest;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -23,7 +24,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.google.common.base.Preconditions;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
@@ -735,7 +735,7 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 		@Nonnull
 		public JavaWalaTestCase.Builder javaArchitectureTestCaseSupported(
 				@Nonnull JavaArchitectureTestCaseSupported javaArchitectureTestCaseSupported) {
-			this.javaArchitectureTestCaseSupported = Preconditions.checkNotNull(javaArchitectureTestCaseSupported,
+			this.javaArchitectureTestCaseSupported = Objects.requireNonNull(javaArchitectureTestCaseSupported,
 					"javaArchitecturalTestCaseSupported must not be null");
 			return this;
 		}
@@ -750,7 +750,7 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 		 */
 		@Nonnull
 		public JavaWalaTestCase.Builder javaClasses(@Nonnull JavaClasses javaClasses) {
-			this.javaClasses = Preconditions.checkNotNull(javaClasses, "javaClasses must not be null");
+			this.javaClasses = Objects.requireNonNull(javaClasses, "javaClasses must not be null");
 			return this;
 		}
 
@@ -779,7 +779,7 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 		 */
 		@Nonnull
 		public JavaWalaTestCase.Builder allowedPackages(@Nonnull Set<PackagePermission> allowedPackages) {
-			this.allowedPackages = Preconditions.checkNotNull(allowedPackages, "allowedPackages must not be null");
+			this.allowedPackages = Objects.requireNonNull(allowedPackages, "allowedPackages must not be null");
 			return this;
 		}
 
@@ -793,7 +793,7 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 		 */
 		@Nonnull
 		public JavaWalaTestCase.Builder allowedClasses(@Nonnull Set<ClassPermission> allowedClasses) {
-			this.allowedClasses = Preconditions.checkNotNull(allowedClasses, "allowedClasses must not be null");
+			this.allowedClasses = Objects.requireNonNull(allowedClasses, "allowedClasses must not be null");
 			return this;
 		}
 
@@ -809,11 +809,11 @@ public class JavaWalaTestCase extends JavaArchitectureTestCase {
 		@Nonnull
 		public JavaWalaTestCase build() {
 			return new JavaWalaTestCase(
-					Preconditions.checkNotNull(javaArchitectureTestCaseSupported,
+					Objects.requireNonNull(javaArchitectureTestCaseSupported,
 							"javaArchitecturalTestCaseSupported must not be null"),
-					Preconditions.checkNotNull(allowedPackages, "allowedPackages must not be null"),
-					Preconditions.checkNotNull(javaClasses, "javaClasses must not be null"),
-					Preconditions.checkNotNull(callGraph, "callGraph must not be null"), allowedClasses);
+					Objects.requireNonNull(allowedPackages, "allowedPackages must not be null"),
+					Objects.requireNonNull(javaClasses, "javaClasses must not be null"),
+					Objects.requireNonNull(callGraph, "callGraph must not be null"), allowedClasses);
 		}
 	}
 	// </editor-fold>

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/ReachabilityChecker.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/ReachabilityChecker.java
@@ -6,8 +6,9 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
-import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.util.config.AnalysisScopeReader;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -114,13 +115,11 @@ public class ReachabilityChecker {
 			return cached;
 		}
 		try {
-			List<DefaultEntrypoint> fresh = new ArrayList<>(io.vavr.collection.Stream
-					.ofAll(createClassHierarchy(classPath)).toJavaStream()
+			List<DefaultEntrypoint> fresh = StreamSupport.stream(createClassHierarchy(classPath).spliterator(), false)
 					.filter(iClass -> iClass.getClassLoader().getReference().equals(ClassLoaderReference.Application))
-					.map(IClass::getDeclaredMethods).map(io.vavr.collection.Stream::ofAll)
-					.flatMap(io.vavr.collection.Stream::toJavaStream).map(IMethod::getReference)
+					.flatMap(iClass -> iClass.getDeclaredMethods().stream()).map(IMethod::getReference)
 					.map(methodReference -> new DefaultEntrypoint(methodReference, applicationClassHierarchy))
-					.toList());
+					.collect(Collectors.toCollection(ArrayList::new));
 			List<DefaultEntrypoint> immutable = Collections.unmodifiableList(fresh);
 			List<DefaultEntrypoint> existing = ENTRYPOINTS_CACHE.putIfAbsent(cacheKey, immutable);
 			return existing != null ? existing : immutable;

--- a/src/main/java/de/tum/cit/ase/ares/api/internal/sanitization/SafeTypeThrowableSanitizer.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/internal/sanitization/SafeTypeThrowableSanitizer.java
@@ -8,6 +8,7 @@ import java.util.*;
 import java.util.function.Supplier;
 
 import org.junit.experimental.theories.internal.ParameterizedAssertionError;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.slf4j.*;
 
 import junit.framework.*;
@@ -42,7 +43,9 @@ enum SafeTypeThrowableSanitizer implements SpecificThrowableSanitizer {
 			entry("junit.framework.ComparisonFailure", new ThrowableCreatorWrapper(ComparisonFailureCreator::new)), //$NON-NLS-1$
 			entry("org.junit.ComparisonFailure", new ThrowableCreatorWrapper(ComparisonFailureCreator::new)), //$NON-NLS-1$
 			entry("org.junit.experimental.theories.internal.ParameterizedAssertionError", //$NON-NLS-1$
-					new ThrowableCreatorWrapper(ParameterizedAssertionErrorCreator::new)) //
+					new ThrowableCreatorWrapper(ParameterizedAssertionErrorCreator::new)), //
+			entry("org.junit.jupiter.api.extension.ParameterResolutionException", //$NON-NLS-1$
+					new ParameterResolutionExceptionCreator()) //
 	);
 
 	final Map<Class<? extends Throwable>, ThrowableCreator> cachedThrowableCreators = Collections
@@ -187,6 +190,23 @@ enum SafeTypeThrowableSanitizer implements SpecificThrowableSanitizer {
 				// ignore
 			}
 			return new ParameterizedAssertionError(targetException, methodName, params);
+		}
+	}
+
+	private static class ParameterResolutionExceptionCreator implements ThrowableCreator {
+
+		@Override
+		public Throwable create(ThrowableInfo info) {
+			var message = info.getMessage();
+			var cause = info.getCause();
+			// Since JUnit 6.1 both constructors reject a null message and the
+			// (String, Throwable) constructor additionally rejects a null cause
+			// (Preconditions.notNull). The default duplication always prefers the
+			// two-argument constructor, so a cause-less original would pass null and
+			// fail. Pick the constructor that matches the available cause instead.
+			if (cause == null)
+				return new ParameterResolutionException(message);
+			return new ParameterResolutionException(message, cause);
 		}
 	}
 }

--- a/src/main/java/de/tum/cit/ase/ares/api/phobos/PhobosTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/phobos/PhobosTestCase.java
@@ -1,8 +1,8 @@
 package de.tum.cit.ase.ares.api.phobos;
 
-import javax.annotation.Nonnull;
+import java.util.Objects;
 
-import com.google.common.base.Preconditions;
+import javax.annotation.Nonnull;
 
 import de.tum.cit.ase.ares.api.aop.fileSystem.FileSystemExtractor;
 import de.tum.cit.ase.ares.api.aop.networkSystem.NetworkSystemExtractor;
@@ -46,13 +46,12 @@ public abstract class PhobosTestCase {
 			@Nonnull FileSystemExtractor fileSystemExtractor,
 			@Nonnull NetworkSystemExtractor networkConnectionExtractor,
 			@Nonnull ResourceLimitsExtractor resourceLimitsExtractor) {
-		this.phobosTestCaseSupported = Preconditions.checkNotNull(phobosTestCaseSupported,
+		this.phobosTestCaseSupported = Objects.requireNonNull(phobosTestCaseSupported,
 				"phobosTestCaseSupported must not be null");
-		this.fileSystemExtractor = Preconditions.checkNotNull(fileSystemExtractor,
-				"fileSystemExtractor must not be null");
-		this.networkConnectionExtractor = Preconditions.checkNotNull(networkConnectionExtractor,
+		this.fileSystemExtractor = Objects.requireNonNull(fileSystemExtractor, "fileSystemExtractor must not be null");
+		this.networkConnectionExtractor = Objects.requireNonNull(networkConnectionExtractor,
 				"networkConnectionExtractor must not be null");
-		this.resourceLimitsExtractor = Preconditions.checkNotNull(resourceLimitsExtractor,
+		this.resourceLimitsExtractor = Objects.requireNonNull(resourceLimitsExtractor,
 				"resourceLimitsExtractor must not be null");
 	}
 	// </editor-fold>

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/SecurityPolicyReaderAndDirector.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/SecurityPolicyReaderAndDirector.java
@@ -2,11 +2,10 @@ package de.tum.cit.ase.ares.api.policy;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import com.google.common.base.Preconditions;
 
 import de.tum.cit.ase.ares.api.localization.Messages;
 import de.tum.cit.ase.ares.api.policy.director.SecurityPolicyDirector;
@@ -133,7 +132,7 @@ public class SecurityPolicyReaderAndDirector {
 		// write zero security tests - in a security boundary, silent no-op generation
 		// is
 		// the dangerous direction.
-		return Preconditions.checkNotNull(this.securityTestCaseFactoryAndBuilder,
+		return Objects.requireNonNull(this.securityTestCaseFactoryAndBuilder,
 				"createTestCases() must be called before writeTestCases()").writeTestCases(testFolderPath);
 	}
 
@@ -146,7 +145,7 @@ public class SecurityPolicyReaderAndDirector {
 	 */
 	@Nonnull
 	public SecurityPolicyReaderAndDirector writeTestCasesAndContinue(Path testFolderPath) {
-		Preconditions.checkNotNull(this.securityTestCaseFactoryAndBuilder,
+		Objects.requireNonNull(this.securityTestCaseFactoryAndBuilder,
 				"securityTestCaseFactoryAndBuilder must not be null").writeTestCases(testFolderPath);
 		return this;
 	}
@@ -161,7 +160,7 @@ public class SecurityPolicyReaderAndDirector {
 	 * @author Markus Paulsen
 	 */
 	public SecurityPolicyReaderAndDirector executeTestCases() {
-		Preconditions.checkNotNull(this.securityTestCaseFactoryAndBuilder,
+		Objects.requireNonNull(this.securityTestCaseFactoryAndBuilder,
 				"securityTestCaseFactoryAndBuilder must not be null").executeTestCases();
 		return this;
 	}

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/director/SecurityPolicyDirector.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/director/SecurityPolicyDirector.java
@@ -1,11 +1,10 @@
 package de.tum.cit.ase.ares.api.policy.director;
 
 import java.nio.file.Path;
+import java.util.Objects;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import com.google.common.base.Preconditions;
 
 import de.tum.cit.ase.ares.api.policy.SecurityPolicy;
 import de.tum.cit.ase.ares.api.policy.director.java.SecurityPolicyJavaDirector;
@@ -109,15 +108,14 @@ public abstract class SecurityPolicyDirector {
 	public SecurityPolicyDirector(@Nonnull Creator creator, @Nonnull Writer writer, @Nonnull Executer executer,
 			@Nonnull EssentialDataReader essentialDataReader, @Nonnull ProjectScanner projectScanner,
 			@Nonnull Path essentialPackagesPath, @Nonnull Path essentialClassesPath) {
-		this.creator = Preconditions.checkNotNull(creator, "creator must not be null");
-		this.writer = Preconditions.checkNotNull(writer, "writer must not be null");
-		this.executer = Preconditions.checkNotNull(executer, "executer must not be null");
-		this.essentialDataReader = Preconditions.checkNotNull(essentialDataReader,
-				"essentialDataReader must not be null");
-		this.projectScanner = Preconditions.checkNotNull(projectScanner, "javaScanner must not be null");
-		this.essentialPackagesPath = Preconditions.checkNotNull(essentialPackagesPath,
+		this.creator = Objects.requireNonNull(creator, "creator must not be null");
+		this.writer = Objects.requireNonNull(writer, "writer must not be null");
+		this.executer = Objects.requireNonNull(executer, "executer must not be null");
+		this.essentialDataReader = Objects.requireNonNull(essentialDataReader, "essentialDataReader must not be null");
+		this.projectScanner = Objects.requireNonNull(projectScanner, "javaScanner must not be null");
+		this.essentialPackagesPath = Objects.requireNonNull(essentialPackagesPath,
 				"essentialPackagesPath must not be null");
-		this.essentialClassesPath = Preconditions.checkNotNull(essentialClassesPath,
+		this.essentialClassesPath = Objects.requireNonNull(essentialClassesPath,
 				"essentialClassesPath must not be null");
 	}
 	// </editor-fold>

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/director/java/SecurityPolicyJavaDirector.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/director/java/SecurityPolicyJavaDirector.java
@@ -6,8 +6,6 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.google.common.base.Preconditions;
-
 import de.tum.cit.ase.ares.api.aop.AOPMode;
 import de.tum.cit.ase.ares.api.architecture.ArchitectureMode;
 import de.tum.cit.ase.ares.api.buildtoolconfiguration.BuildMode;
@@ -50,14 +48,14 @@ public class SecurityPolicyJavaDirector extends SecurityPolicyDirector {
 	 * Default path to the essential packages YAML file.
 	 */
 	@Nonnull
-	public static final Path DEFAULT_ESSENTIAL_PACKAGES_PATH = Preconditions.checkNotNull(FileTools
+	public static final Path DEFAULT_ESSENTIAL_PACKAGES_PATH = Objects.requireNonNull(FileTools
 			.resolveFileOnSourceDirectory("configuration", "essentialFiles", "java", "EssentialPackages.yaml"));
 
 	/**
 	 * Default path to the essential classes YAML file.
 	 */
 	@Nonnull
-	public static final Path DEFAULT_ESSENTIAL_CLASSES_PATH = Preconditions.checkNotNull(
+	public static final Path DEFAULT_ESSENTIAL_CLASSES_PATH = Objects.requireNonNull(
 			FileTools.resolveFileOnSourceDirectory("configuration", "essentialFiles", "java", "EssentialClasses.yaml"));
 
 	// <editor-fold desc="Constructor">
@@ -141,7 +139,7 @@ public class SecurityPolicyJavaDirector extends SecurityPolicyDirector {
 					projectFolderPath);
 		}
 		@Nonnull
-		ProgrammingLanguageConfiguration config = Preconditions.checkNotNull(
+		ProgrammingLanguageConfiguration config = Objects.requireNonNull(
 				securityPolicy.regardingTheSupervisedCode().theFollowingProgrammingLanguageConfigurationIsUsed());
 		return switch (config) {
 		case JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ -> generateFactoryAndBuilder(BuildMode.MAVEN,

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/reader/SecurityPolicyReader.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/reader/SecurityPolicyReader.java
@@ -1,13 +1,12 @@
 package de.tum.cit.ase.ares.api.policy.reader;
 
 import java.nio.file.Path;
+import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import com.google.common.base.Preconditions;
-import com.google.common.io.MoreFiles;
 
 import de.tum.cit.ase.ares.api.localization.Messages;
 import de.tum.cit.ase.ares.api.policy.SecurityPolicy;
@@ -50,7 +49,7 @@ public abstract class SecurityPolicyReader {
 	 * @param objectMapper the non-null object mapper for reading files.
 	 */
 	public SecurityPolicyReader(@Nonnull ObjectMapper objectMapper) {
-		this.objectMapper = Preconditions.checkNotNull(objectMapper, "objectMapper must not be null");
+		this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
 	}
 	// </editor-fold>
 
@@ -72,12 +71,30 @@ public abstract class SecurityPolicyReader {
 
 	// <editor-fold desc="Static methods">
 	public static SecurityPolicyReader selectSecurityPolicyReader(Path securityPolicyFilePath) {
-		Preconditions.checkNotNull(securityPolicyFilePath, "securityPolicyFilePath must not be null");
-		return switch (MoreFiles.getFileExtension(securityPolicyFilePath)) {
+		Objects.requireNonNull(securityPolicyFilePath, "securityPolicyFilePath must not be null");
+		return switch (getFileExtension(securityPolicyFilePath)) {
 		case "yaml", "yml" -> SecurityPolicyYAMLReader.yamlBuilder().yamlMapper(new YAMLMapper()).build();
-		default -> throw new IllegalArgumentException(Messages.localized("policy.reader.unsupported.format",
-				MoreFiles.getFileExtension(securityPolicyFilePath)));
+		default -> throw new IllegalArgumentException(
+				Messages.localized("policy.reader.unsupported.format", getFileExtension(securityPolicyFilePath)));
 		};
+	}
+
+	/**
+	 * Returns the lowercase-free file extension (the part after the last
+	 * {@code '.'} in the file name), or the empty string if there is none. Replaces
+	 * Guava's {@code MoreFiles.getFileExtension}.
+	 *
+	 * @param path the path whose file extension is returned.
+	 * @return the file extension without the leading dot, or {@code ""}.
+	 */
+	private static String getFileExtension(Path path) {
+		Path fileName = path.getFileName();
+		if (fileName == null) {
+			return "";
+		}
+		String name = fileName.toString();
+		int lastDotIndex = name.lastIndexOf('.');
+		return (lastDotIndex == -1) ? "" : name.substring(lastDotIndex + 1);
 	}
 	// </editor-fold>
 }

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/reader/yaml/SecurityPolicyYAMLReader.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/reader/yaml/SecurityPolicyYAMLReader.java
@@ -10,7 +10,6 @@ import javax.annotation.Nullable;
 import com.fasterxml.jackson.core.exc.StreamReadException;
 import com.fasterxml.jackson.databind.DatabindException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import com.google.common.base.Preconditions;
 
 import de.tum.cit.ase.ares.api.localization.Messages;
 import de.tum.cit.ase.ares.api.policy.SecurityPolicy;
@@ -65,9 +64,9 @@ public class SecurityPolicyYAMLReader extends SecurityPolicyReader {
 	@Nonnull
 	public SecurityPolicy readSecurityPolicyFrom(@Nonnull Path securityPolicyPath) {
 		@Nonnull
-		Path path = Preconditions.checkNotNull(securityPolicyPath, "The security policy path must not be null");
+		Path path = Objects.requireNonNull(securityPolicyPath, "The security policy path must not be null");
 		@Nonnull
-		Class<SecurityPolicy> yamlClass = Preconditions.checkNotNull(SecurityPolicy.class,
+		Class<SecurityPolicy> yamlClass = Objects.requireNonNull(SecurityPolicy.class,
 				"The security policy class must not be null.");
 		try {
 			return FileTools.readYamlFile(FileTools.readFile(path), yamlClass);

--- a/src/main/java/de/tum/cit/ase/ares/api/securitytest/TestCaseAbstractFactoryAndBuilder.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/securitytest/TestCaseAbstractFactoryAndBuilder.java
@@ -4,13 +4,11 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
 
 import de.tum.cit.ase.ares.api.aop.AOPMode;
 import de.tum.cit.ase.ares.api.aop.AOPTestCase;
@@ -205,30 +203,28 @@ public abstract class TestCaseAbstractFactoryAndBuilder {
 			@Nullable ArchitectureMode architectureMode, @Nullable AOPMode aopMode,
 			@Nullable SecurityPolicy securityPolicy, @Nullable Path projectPath) {
 		// <editor-fold desc="Tools">
-		this.creator = Preconditions.checkNotNull(creator);
-		this.writer = Preconditions.checkNotNull(writer);
-		this.executer = Preconditions.checkNotNull(executer);
-		this.essentialDataReader = Preconditions.checkNotNull(essentialDataReader);
-		this.projectScanner = Preconditions.checkNotNull(projectScanner);
+		this.creator = Objects.requireNonNull(creator);
+		this.writer = Objects.requireNonNull(writer);
+		this.executer = Objects.requireNonNull(executer);
+		this.essentialDataReader = Objects.requireNonNull(essentialDataReader);
+		this.projectScanner = Objects.requireNonNull(projectScanner);
 		// </editor-fold>
 
 		// <editor-fold desc="Modes and Project Paths">
-		this.buildMode = MoreObjects.firstNonNull(buildMode, projectScanner.scanForBuildMode());
-		this.architectureMode = MoreObjects.firstNonNull(architectureMode, ArchitectureMode.WALA);
-		this.aopMode = MoreObjects.firstNonNull(aopMode, AOPMode.INSTRUMENTATION);
+		this.buildMode = Objects.requireNonNullElse(buildMode, projectScanner.scanForBuildMode());
+		this.architectureMode = Objects.requireNonNullElse(architectureMode, ArchitectureMode.WALA);
+		this.aopMode = Objects.requireNonNullElse(aopMode, AOPMode.INSTRUMENTATION);
 		this.projectPath = projectPath;
 		// </editor-fold>
 
 		// <editor-fold desc="Essential Data">
-		this.essentialPackagesPath = Preconditions.checkNotNull(essentialPackagesPath,
+		this.essentialPackagesPath = Objects.requireNonNull(essentialPackagesPath,
 				"essentialPackagesPath must not be null");
-		this.essentialClassesPath = Preconditions.checkNotNull(essentialClassesPath,
+		this.essentialClassesPath = Objects.requireNonNull(essentialClassesPath,
 				"essentialClassesPath must not be null");
-		this.essentialPackages = Preconditions
-				.checkNotNull(essentialDataReader, "essentialPackagesReader must not be null")
+		this.essentialPackages = Objects.requireNonNull(essentialDataReader, "essentialPackagesReader must not be null")
 				.readEssentialPackagesFrom(this.essentialPackagesPath).getEssentialPackages();
-		this.essentialClasses = Preconditions
-				.checkNotNull(essentialDataReader, "essentialClassesReader must not be null")
+		this.essentialClasses = Objects.requireNonNull(essentialDataReader, "essentialClassesReader must not be null")
 				.readEssentialClassesFrom(this.essentialClassesPath).getEssentialClasses();
 		// </editor-fold>
 

--- a/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/essentialModel/EssentialClasses.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/essentialModel/EssentialClasses.java
@@ -2,11 +2,10 @@ package de.tum.cit.ase.ares.api.securitytest.java.essentialModel;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import com.google.common.collect.Streams;
 
 /**
  * Represents the essential classes required for the security test.
@@ -61,10 +60,11 @@ public record EssentialClasses(@Nonnull List<String> essentialJavaClasses,
 	 */
 	@Nonnull
 	public List<String> getEssentialClasses() {
-		return Streams.concat(essentialJavaClasses.stream(), essentialArchunitClasses.stream(),
-				essentialWalaClasses.stream(), essentialAspectJClasses.stream(),
-				essentialInstrumentationClasses.stream(), essentialAresClasses.stream(), essentialJUnitClasses.stream())
-				.toList();
+		return Stream
+				.of(essentialJavaClasses.stream(), essentialArchunitClasses.stream(), essentialWalaClasses.stream(),
+						essentialAspectJClasses.stream(), essentialInstrumentationClasses.stream(),
+						essentialAresClasses.stream(), essentialJUnitClasses.stream())
+				.flatMap(stream -> stream).toList();
 	}
 
 	/**

--- a/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/essentialModel/EssentialPackages.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/essentialModel/EssentialPackages.java
@@ -2,11 +2,10 @@ package de.tum.cit.ase.ares.api.securitytest.java.essentialModel;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import com.google.common.collect.Streams;
 
 /**
  * Represents the essential packages required for the security test.
@@ -62,10 +61,11 @@ public record EssentialPackages(@Nonnull List<String> essentialJavaPackages,
 	 */
 	@Nonnull
 	public List<String> getEssentialPackages() {
-		return Streams.concat(essentialJavaPackages.stream(), essentialArchunitPackages.stream(),
-				essentialWalaPackages.stream(), essentialAspectJPackages.stream(),
-				essentialInstrumentationPackages.stream(), essentialAresPackages.stream(),
-				essentialJUnitPackages.stream()).toList();
+		return Stream
+				.of(essentialJavaPackages.stream(), essentialArchunitPackages.stream(), essentialWalaPackages.stream(),
+						essentialAspectJPackages.stream(), essentialInstrumentationPackages.stream(),
+						essentialAresPackages.stream(), essentialJUnitPackages.stream())
+				.flatMap(stream -> stream).toList();
 	}
 
 	/**

--- a/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/essentialModel/yaml/EssentialDataYAMLReader.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/essentialModel/yaml/EssentialDataYAMLReader.java
@@ -2,12 +2,12 @@ package de.tum.cit.ase.ares.api.securitytest.java.essentialModel.yaml;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.core.exc.StreamReadException;
 import com.fasterxml.jackson.databind.DatabindException;
-import com.google.common.base.Preconditions;
 
 import de.tum.cit.ase.ares.api.securitytest.java.essentialModel.EssentialClasses;
 import de.tum.cit.ase.ares.api.securitytest.java.essentialModel.EssentialDataReader;
@@ -46,9 +46,9 @@ public class EssentialDataYAMLReader implements EssentialDataReader {
 	@Nonnull
 	public EssentialClasses readEssentialClassesFrom(@Nonnull Path essentialClassesPath) {
 		@Nonnull
-		Path path = Preconditions.checkNotNull(essentialClassesPath, "The essential classes path must not be null!");
+		Path path = Objects.requireNonNull(essentialClassesPath, "The essential classes path must not be null!");
 		@Nonnull
-		Class<EssentialClasses> yamlClass = Preconditions.checkNotNull(EssentialClasses.class,
+		Class<EssentialClasses> yamlClass = Objects.requireNonNull(EssentialClasses.class,
 				"The essential classes class must not be null!");
 		try {
 			return FileTools.readYamlFile(FileTools.readFile(path), yamlClass);
@@ -76,9 +76,9 @@ public class EssentialDataYAMLReader implements EssentialDataReader {
 	@Nonnull
 	public EssentialPackages readEssentialPackagesFrom(@Nonnull Path essentialPackagesPath) {
 		@Nonnull
-		Path path = Preconditions.checkNotNull(essentialPackagesPath, "The essential packages path must not be null!");
+		Path path = Objects.requireNonNull(essentialPackagesPath, "The essential packages path must not be null!");
 		@Nonnull
-		Class<EssentialPackages> yamlClass = Preconditions.checkNotNull(EssentialPackages.class,
+		Class<EssentialPackages> yamlClass = Objects.requireNonNull(EssentialPackages.class,
 				"The essential packages class must not be null!");
 		try {
 			return FileTools.readYamlFile(FileTools.readFile(path), yamlClass);

--- a/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScanner.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScanner.java
@@ -17,8 +17,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.google.common.base.Preconditions;
-
 import de.tum.cit.ase.ares.api.buildtoolconfiguration.BuildMode;
 import de.tum.cit.ase.ares.api.securitytest.ReservedPackageGuard;
 import de.tum.cit.ase.ares.api.util.ProjectSourcesFinder;
@@ -47,7 +45,7 @@ public class JavaProjectScanner implements ProjectScanner {
 	 * Regex pattern to match public class declarations in Java files.
 	 */
 	@Nonnull
-	private static final Pattern CLASS_PATTERN = Preconditions.checkNotNull(
+	private static final Pattern CLASS_PATTERN = Objects.requireNonNull(
 			Pattern.compile(
 					"\\bpublic\\s+(?:final\\s+|abstract\\s+|strictfp\\s+)*class\\s+([A-Za-z_$][A-Za-z0-9_$]*)\\b"),
 			"CLASS_PATTERN must not be null");
@@ -56,7 +54,7 @@ public class JavaProjectScanner implements ProjectScanner {
 	 * Regex pattern to match package declarations in Java files.
 	 */
 	@Nonnull
-	private static final Pattern PACKAGE_PATTERN = Preconditions.checkNotNull(
+	private static final Pattern PACKAGE_PATTERN = Objects.requireNonNull(
 			Pattern.compile("\\bpackage\\s+([A-Za-z_$][A-Za-z0-9_$]*(?:\\.[A-Za-z_$][A-Za-z0-9_$]*)*)\\s*;"),
 			"PACKAGE_PATTERN must not be null");
 
@@ -64,7 +62,7 @@ public class JavaProjectScanner implements ProjectScanner {
 	 * Regex pattern to detect the main method in Java files.
 	 */
 	@Nonnull
-	private static final Pattern MAIN_METHOD_PATTERN = Preconditions.checkNotNull(Pattern.compile(
+	private static final Pattern MAIN_METHOD_PATTERN = Objects.requireNonNull(Pattern.compile(
 			"\\bpublic\\s+static\\s+void\\s+main\\s*\\(\\s*String\\s*(?:\\[\\s*]|\\.\\.\\.)\\s*[A-Za-z_$][A-Za-z0-9_$]*\\s*\\)"),
 			"MAIN_METHOD_PATTERN must not be null");
 
@@ -72,8 +70,8 @@ public class JavaProjectScanner implements ProjectScanner {
 	 * Regex pattern to identify test annotations in Java files.
 	 */
 	@Nonnull
-	private static final Pattern TEST_ANNOTATION_PATTERN = Preconditions
-			.checkNotNull(Pattern.compile("@(?:Test|Property)\\b"), "TEST_ANNOTATION_PATTERN must not be null");
+	private static final Pattern TEST_ANNOTATION_PATTERN = Objects
+			.requireNonNull(Pattern.compile("@(?:Test|Property)\\b"), "TEST_ANNOTATION_PATTERN must not be null");
 	// </editor-fold>
 
 	// <editor-fold desc="Variable Regex Patterns (defined by project)">
@@ -193,8 +191,8 @@ public class JavaProjectScanner implements ProjectScanner {
 	 * @return true if the file is a regular Java file, false otherwise
 	 */
 	private boolean fileIsJavaFile(@Nonnull Path path, @Nonnull BasicFileAttributes attributes) {
-		return Preconditions.checkNotNull(attributes, "attributes must not be null").isRegularFile()
-				&& Preconditions.checkNotNull(path, "path must not be null").toString().endsWith(".java");
+		return Objects.requireNonNull(attributes, "attributes must not be null").isRegularFile()
+				&& Objects.requireNonNull(path, "path must not be null").toString().endsWith(".java");
 	}
 
 	/**

--- a/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/specific/PathLocationProvider.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/specific/PathLocationProvider.java
@@ -2,11 +2,11 @@ package de.tum.cit.ase.ares.api.securitytest.java.specific;
 
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
 
-import com.google.common.base.Preconditions;
 import com.tngtech.archunit.core.importer.Location;
 import com.tngtech.archunit.junit.LocationProvider;
 
@@ -50,7 +50,7 @@ public class PathLocationProvider implements LocationProvider {
 	@Nonnull
 	public Set<Location> get(Class<?> testClass) {
 		@Nonnull
-		Class<?> protectedTestClass = Preconditions.checkNotNull(testClass, "testClass must not be null");
+		Class<?> protectedTestClass = Objects.requireNonNull(testClass, "testClass must not be null");
 		if (!protectedTestClass.isAnnotationPresent(StudentCompiledClassesPath.class)) {
 			throw new SecurityException(String.format(
 					"Ares Security Error (Reason: Ares-Code; Stage: Creation): %s can only be used on classes annotated with @%s",

--- a/src/main/java/de/tum/cit/ase/ares/api/structural/AttributeTestProvider.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/structural/AttributeTestProvider.java
@@ -13,8 +13,9 @@ import java.util.stream.*;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.json.JSONArray;
 import org.junit.jupiter.api.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * This test evaluates if the specified attributes in the structure oracle are
@@ -42,14 +43,14 @@ public abstract class AttributeTestProvider extends StructuralTestProvider {
 		if (structureOracleJSON == null)
 			throw failure(
 					"The AttributeTest test can only run if the structural oracle (test.json) is present. If you do not provide it, delete AttributeTest.java!"); //$NON-NLS-1$
-		for (var i = 0; i < structureOracleJSON.length(); i++) {
-			var expectedClassJSON = structureOracleJSON.getJSONObject(i);
+		for (var i = 0; i < structureOracleJSON.size(); i++) {
+			var expectedClassJSON = structureOracleJSON.get(i);
 			// Only test the classes that have attributes defined in the oracle.
 			if (expectedClassJSON.has(JSON_PROPERTY_CLASS) && (expectedClassJSON.has(JSON_PROPERTY_ATTRIBUTES)
 					|| expectedClassJSON.has(JSON_PROPERTY_ENUM_VALUES))) {
-				var expectedClassPropertiesJSON = expectedClassJSON.getJSONObject(JSON_PROPERTY_CLASS);
-				var expectedClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_NAME);
-				var expectedPackageName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_PACKAGE);
+				var expectedClassPropertiesJSON = expectedClassJSON.get(JSON_PROPERTY_CLASS);
+				var expectedClassName = expectedClassPropertiesJSON.get(JSON_PROPERTY_NAME).asText();
+				var expectedPackageName = expectedClassPropertiesJSON.get(JSON_PROPERTY_PACKAGE).asText();
 				var expectedClassStructure = new ExpectedClassStructure(expectedClassName, expectedPackageName,
 						expectedClassJSON);
 				tests.add(dynamicTest("testAttributes[" + expectedClassName + "]", //$NON-NLS-1$ //$NON-NLS-2$
@@ -101,11 +102,11 @@ public abstract class AttributeTestProvider extends StructuralTestProvider {
 	 *                           modifiers of each attribute.
 	 */
 	protected static void checkAttributes(String expectedClassName, Class<?> observedClass,
-			JSONArray expectedAttributes) {
-		for (var i = 0; i < expectedAttributes.length(); i++) {
-			var expectedAttribute = expectedAttributes.getJSONObject(i);
-			var expectedName = expectedAttribute.getString(JSON_PROPERTY_NAME);
-			var expectedTypeName = expectedAttribute.getString(JSON_PROPERTY_TYPE);
+			JsonNode expectedAttributes) {
+		for (var i = 0; i < expectedAttributes.size(); i++) {
+			var expectedAttribute = expectedAttributes.get(i);
+			var expectedName = expectedAttribute.get(JSON_PROPERTY_NAME).asText();
+			var expectedTypeName = expectedAttribute.get(JSON_PROPERTY_TYPE).asText();
 			var expectedModifiers = getExpectedJsonProperty(expectedAttribute, JSON_PROPERTY_MODIFIERS);
 			var expectedAnnotations = getExpectedJsonProperty(expectedAttribute, JSON_PROPERTY_ANNOTATIONS);
 
@@ -159,14 +160,14 @@ public abstract class AttributeTestProvider extends StructuralTestProvider {
 	 *                           consists of the name of each enum value.
 	 */
 	protected static void checkEnumValues(String expectedClassName, Class<?> observedClass,
-			JSONArray expectedEnumValues) {
+			JsonNode expectedEnumValues) {
 		if (!observedClass.isEnum())
 			throw localizedFailure("structural.attribute.noEnumConstants", expectedClassName); //$NON-NLS-1$
 		@SuppressWarnings("unchecked")
 		var observedEnumValues = ((Class<? extends Enum<?>>) observedClass).getEnumConstants();
 		var observedEnumNames = Stream.of(observedEnumValues).map(Enum::name).collect(Collectors.toSet());
-		var expectedEnumNames = IntStream.range(0, expectedEnumValues.length()).mapToObj(expectedEnumValues::getString)
-				.collect(Collectors.toSet());
+		var expectedEnumNames = IntStream.range(0, expectedEnumValues.size())
+				.mapToObj(i -> expectedEnumValues.get(i).asText()).collect(Collectors.toSet());
 		var missing = expectedEnumNames.stream().filter(not(observedEnumNames::contains)).findFirst();
 		missing.ifPresent(missingName -> fail(
 				localized("structural.attribute.missingEnumConstants", expectedClassName, missingName))); //$NON-NLS-1$

--- a/src/main/java/de/tum/cit/ase/ares/api/structural/ClassTestProvider.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/structural/ClassTestProvider.java
@@ -10,8 +10,9 @@ import java.util.*;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.json.JSONObject;
 import org.junit.jupiter.api.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * This test evaluates the hierarchy of the class, i.e. if the class is abstract
@@ -40,9 +41,9 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 		if (structureOracleJSON == null)
 			throw failure(
 					"The ClassTest test can only run if the structural oracle (test.json) is present. If you do not provide it, delete ClassTest.java!"); //$NON-NLS-1$
-		for (var i = 0; i < structureOracleJSON.length(); i++) {
-			var expectedClassJSON = structureOracleJSON.getJSONObject(i);
-			var expectedClassPropertiesJSON = expectedClassJSON.getJSONObject(JSON_PROPERTY_CLASS);
+		for (var i = 0; i < structureOracleJSON.size(); i++) {
+			var expectedClassJSON = structureOracleJSON.get(i);
+			var expectedClassPropertiesJSON = expectedClassJSON.get(JSON_PROPERTY_CLASS);
 			/*
 			 * Only test the classes that have additional properties (except name and
 			 * package) defined in the structure oracle.
@@ -50,8 +51,8 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 			if (expectedClassPropertiesJSON.has(JSON_PROPERTY_NAME)
 					&& expectedClassPropertiesJSON.has(JSON_PROPERTY_PACKAGE)
 					&& hasAdditionalProperties(expectedClassPropertiesJSON)) {
-				var expectedClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_NAME);
-				var expectedPackageName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_PACKAGE);
+				var expectedClassName = expectedClassPropertiesJSON.get(JSON_PROPERTY_NAME).asText();
+				var expectedPackageName = expectedClassPropertiesJSON.get(JSON_PROPERTY_PACKAGE).asText();
 				var expectedClassStructure = new ExpectedClassStructure(expectedClassName, expectedPackageName,
 						expectedClassJSON);
 				tests.add(dynamicTest("testClass[" + expectedClassName + "]", () -> testClass(expectedClassStructure))); //$NON-NLS-1$ //$NON-NLS-2$
@@ -67,8 +68,9 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 		return dynamicContainer(getClass().getName(), new URI(getClass().getName()), tests.stream());
 	}
 
-	protected static boolean hasAdditionalProperties(JSONObject jsonObject) {
-		List<String> keys = new ArrayList<>(jsonObject.keySet());
+	protected static boolean hasAdditionalProperties(JsonNode jsonObject) {
+		List<String> keys = new ArrayList<>();
+		jsonObject.fieldNames().forEachRemaining(keys::add);
 		keys.remove(JSON_PROPERTY_NAME);
 		keys.remove(JSON_PROPERTY_PACKAGE);
 		return !keys.isEmpty();
@@ -93,7 +95,7 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 	}
 
 	private static void checkBasicClassProperties(String expectedClassName, Class<?> observedClass,
-			JSONObject expectedClassPropertiesJSON) {
+			JsonNode expectedClassPropertiesJSON) {
 		if (checkBooleanOf(expectedClassPropertiesJSON, "isAbstract") //$NON-NLS-1$
 				&& !Modifier.isAbstract(observedClass.getModifiers()))
 			throw localizedFailure("structural.class.abstract", expectedClassName); //$NON-NLS-1$
@@ -111,17 +113,17 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 		}
 	}
 
-	private static boolean checkBooleanOf(JSONObject expectedClassPropertiesJSON, String booleanProperty) {
+	private static boolean checkBooleanOf(JsonNode expectedClassPropertiesJSON, String booleanProperty) {
 		return expectedClassPropertiesJSON.has(booleanProperty)
-				&& expectedClassPropertiesJSON.getBoolean(booleanProperty);
+				&& expectedClassPropertiesJSON.get(booleanProperty).asBoolean();
 	}
 
 	private static void checkSuperclass(String expectedClassName, Class<?> observedClass,
-			JSONObject expectedClassPropertiesJSON) {
+			JsonNode expectedClassPropertiesJSON) {
 		// Filter out the enums, since there is a separate test for them
 		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_SUPERCLASS)
-				&& !"Enum".equals(expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS))) { //$NON-NLS-1$
-			var expectedSuperClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS);
+				&& !"Enum".equals(expectedClassPropertiesJSON.get(JSON_PROPERTY_SUPERCLASS).asText())) { //$NON-NLS-1$
+			var expectedSuperClassName = expectedClassPropertiesJSON.get(JSON_PROPERTY_SUPERCLASS).asText();
 			if (!checkExpectedType(observedClass.getSuperclass(), observedClass.getGenericSuperclass(),
 					expectedSuperClassName)) {
 				throw localizedFailure("structural.class.extends", expectedClassName, expectedSuperClassName); //$NON-NLS-1$
@@ -130,13 +132,13 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 	}
 
 	private static void checkInterfaces(String expectedClassName, Class<?> observedClass,
-			JSONObject expectedClassPropertiesJSON) {
+			JsonNode expectedClassPropertiesJSON) {
 		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_INTERFACES)) {
-			var expectedInterfaces = expectedClassPropertiesJSON.getJSONArray(JSON_PROPERTY_INTERFACES);
+			var expectedInterfaces = expectedClassPropertiesJSON.get(JSON_PROPERTY_INTERFACES);
 			var observedInterfaces = observedClass.getInterfaces();
 			var observedGenericInterfaceTypes = observedClass.getGenericInterfaces();
-			for (var i = 0; i < expectedInterfaces.length(); i++) {
-				var expectedInterface = expectedInterfaces.getString(i);
+			for (var i = 0; i < expectedInterfaces.size(); i++) {
+				var expectedInterface = expectedInterfaces.get(i).asText();
 				var implementsInterface = false;
 				for (var j = 0; j < observedInterfaces.length; j++) {
 					var observedInterface = observedInterfaces[j];
@@ -153,9 +155,9 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 	}
 
 	private static void checkAnnotations(String expectedClassName, Class<?> observedClass,
-			JSONObject expectedClassPropertiesJSON) {
+			JsonNode expectedClassPropertiesJSON) {
 		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_ANNOTATIONS)) {
-			var expectedAnnotations = expectedClassPropertiesJSON.getJSONArray(JSON_PROPERTY_ANNOTATIONS);
+			var expectedAnnotations = expectedClassPropertiesJSON.get(JSON_PROPERTY_ANNOTATIONS);
 			var observedAnnotations = observedClass.getAnnotations();
 			var annotationsAreRight = checkAnnotations(observedAnnotations, expectedAnnotations);
 			if (!annotationsAreRight)

--- a/src/main/java/de/tum/cit/ase/ares/api/structural/ConstructorTestProvider.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/structural/ConstructorTestProvider.java
@@ -10,8 +10,9 @@ import java.util.*;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.json.JSONArray;
 import org.junit.jupiter.api.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * This test evaluates if the specified constructors in the structure oracle are
@@ -39,14 +40,14 @@ public abstract class ConstructorTestProvider extends StructuralTestProvider {
 		if (structureOracleJSON == null)
 			throw failure(
 					"The ConstructorTest can only run if the structural oracle (test.json) is present. If you do not provide it, delete ConstructorTest.java!"); //$NON-NLS-1$
-		for (var i = 0; i < structureOracleJSON.length(); i++) {
-			var expectedClassJSON = structureOracleJSON.getJSONObject(i);
+		for (var i = 0; i < structureOracleJSON.size(); i++) {
+			var expectedClassJSON = structureOracleJSON.get(i);
 
 			// Only test the constructors if they are specified in the structure diff
 			if (expectedClassJSON.has(JSON_PROPERTY_CLASS) && expectedClassJSON.has(JSON_PROPERTY_CONSTRUCTORS)) {
-				var expectedClassPropertiesJSON = expectedClassJSON.getJSONObject(JSON_PROPERTY_CLASS);
-				var expectedClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_NAME);
-				var expectedPackageName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_PACKAGE);
+				var expectedClassPropertiesJSON = expectedClassJSON.get(JSON_PROPERTY_CLASS);
+				var expectedClassName = expectedClassPropertiesJSON.get(JSON_PROPERTY_NAME).asText();
+				var expectedPackageName = expectedClassPropertiesJSON.get(JSON_PROPERTY_PACKAGE).asText();
 				var expectedClassStructure = new ExpectedClassStructure(expectedClassName, expectedPackageName,
 						expectedClassJSON);
 				tests.add(dynamicTest("testConstructors[" + expectedClassName + "]", //$NON-NLS-1$ //$NON-NLS-2$
@@ -94,9 +95,9 @@ public abstract class ConstructorTestProvider extends StructuralTestProvider {
 	 *                             visibility modifiers.
 	 */
 	protected static void checkConstructors(String expectedClassName, Class<?> observedClass,
-			JSONArray expectedConstructors) {
-		for (var i = 0; i < expectedConstructors.length(); i++) {
-			var expectedConstructor = expectedConstructors.getJSONObject(i);
+			JsonNode expectedConstructors) {
+		for (var i = 0; i < expectedConstructors.size(); i++) {
+			var expectedConstructor = expectedConstructors.get(i);
 			var expectedParameters = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_PARAMETERS);
 			var expectedModifiers = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_MODIFIERS);
 			var expectedAnnotations = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_ANNOTATIONS);
@@ -124,7 +125,7 @@ public abstract class ConstructorTestProvider extends StructuralTestProvider {
 		}
 	}
 
-	private static void checkConstructorCorrectness(String expectedClassName, JSONArray expectedParameters,
+	private static void checkConstructorCorrectness(String expectedClassName, JsonNode expectedParameters,
 			boolean parametersAreCorrect, boolean modifiersAreCorrect, boolean annotationsAreCorrect) {
 		String parameters = describeParameters(expectedParameters);
 		if (!parametersAreCorrect)

--- a/src/main/java/de/tum/cit/ase/ares/api/structural/MethodTestProvider.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/structural/MethodTestProvider.java
@@ -10,8 +10,9 @@ import java.util.*;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.json.JSONArray;
 import org.junit.jupiter.api.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * This test evaluates if the specified methods in the structure oracle are
@@ -40,13 +41,13 @@ public abstract class MethodTestProvider extends StructuralTestProvider {
 		if (structureOracleJSON == null)
 			throw failure(
 					"The MethodTest test can only run if the structural oracle (test.json) is present. If you do not provide it, delete MethodTest.java!"); //$NON-NLS-1$
-		for (var i = 0; i < structureOracleJSON.length(); i++) {
-			var expectedClassJSON = structureOracleJSON.getJSONObject(i);
+		for (var i = 0; i < structureOracleJSON.size(); i++) {
+			var expectedClassJSON = structureOracleJSON.get(i);
 			// Only test the classes that have methods defined in the structure oracle.
 			if (expectedClassJSON.has(JSON_PROPERTY_CLASS) && expectedClassJSON.has(JSON_PROPERTY_METHODS)) {
-				var expectedClassPropertiesJSON = expectedClassJSON.getJSONObject(JSON_PROPERTY_CLASS);
-				var expectedClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_NAME);
-				var expectedPackageName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_PACKAGE);
+				var expectedClassPropertiesJSON = expectedClassJSON.get(JSON_PROPERTY_CLASS);
+				var expectedClassName = expectedClassPropertiesJSON.get(JSON_PROPERTY_NAME).asText();
+				var expectedPackageName = expectedClassPropertiesJSON.get(JSON_PROPERTY_PACKAGE).asText();
 				var expectedClassStructure = new ExpectedClassStructure(expectedClassName, expectedPackageName,
 						expectedClassJSON);
 				tests.add(dynamicTest("testMethods[" + expectedClassName + "]", //$NON-NLS-1$ //$NON-NLS-2$
@@ -93,14 +94,14 @@ public abstract class MethodTestProvider extends StructuralTestProvider {
 	 *                          parameter types, return type and the visibility
 	 *                          modifiers of each method.
 	 */
-	protected static void checkMethods(String expectedClassName, Class<?> observedClass, JSONArray expectedMethods) {
-		for (var i = 0; i < expectedMethods.length(); i++) {
-			var expectedMethod = expectedMethods.getJSONObject(i);
-			var expectedName = expectedMethod.getString(JSON_PROPERTY_NAME);
+	protected static void checkMethods(String expectedClassName, Class<?> observedClass, JsonNode expectedMethods) {
+		for (var i = 0; i < expectedMethods.size(); i++) {
+			var expectedMethod = expectedMethods.get(i);
+			var expectedName = expectedMethod.get(JSON_PROPERTY_NAME).asText();
 			var expectedParameters = getExpectedJsonProperty(expectedMethod, JSON_PROPERTY_PARAMETERS);
 			var expectedModifiers = getExpectedJsonProperty(expectedMethod, JSON_PROPERTY_MODIFIERS);
 			var expectedAnnotations = getExpectedJsonProperty(expectedMethod, JSON_PROPERTY_ANNOTATIONS);
-			var expectedReturnType = expectedMethod.getString(JSON_PROPERTY_RETURN_TYPE);
+			var expectedReturnType = expectedMethod.get(JSON_PROPERTY_RETURN_TYPE).asText();
 			var strictParameterOrder = getExpectedJsonBooleanProperty(expectedMethod, JSON_PROPERTY_STRICT_ORDER);
 			var checks = new MethodChecks();
 			for (Method observedMethod : observedClass.getDeclaredMethods()) {
@@ -130,7 +131,7 @@ public abstract class MethodTestProvider extends StructuralTestProvider {
 	}
 
 	private static void checkMethodCorrectness(String expectedClassName, String expectedName,
-			JSONArray expectedParameters, MethodChecks methodChecks) {
+			JsonNode expectedParameters, MethodChecks methodChecks) {
 		String parameters = StructuralTestProvider.describeParameters(expectedParameters);
 		if (!methodChecks.name)
 			throw localizedFailure("structural.method.name", expectedName, expectedClassName, parameters); //$NON-NLS-1$

--- a/src/main/java/de/tum/cit/ase/ares/api/structural/StructuralTestProvider.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/structural/StructuralTestProvider.java
@@ -12,9 +12,12 @@ import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.json.*;
 import org.opentest4j.AssertionFailedError;
 import org.slf4j.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 import de.tum.cit.ase.ares.api.structural.testutils.*;
 
@@ -58,6 +61,8 @@ public abstract class StructuralTestProvider {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StructuralTestProvider.class);
 
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
 	protected static final String JSON_PROPERTY_SUPERCLASS = "superclass"; //$NON-NLS-1$
 	protected static final String JSON_PROPERTY_INTERFACES = "interfaces"; //$NON-NLS-1$
 	protected static final String JSON_PROPERTY_ANNOTATIONS = "annotations"; //$NON-NLS-1$
@@ -78,10 +83,24 @@ public abstract class StructuralTestProvider {
 	private static final String PACKAGE_PATH_SEPARATOR = "."; //$NON-NLS-1$
 	private static final Pattern PACKAGE_NAME_IN_GENERIC_TYPE = Pattern.compile("(?:[^\\[\\]<>?,\\s.]++\\.)++"); //$NON-NLS-1$
 
-	protected static JSONArray structureOracleJSON;
+	protected static JsonNode structureOracleJSON;
 
 	protected StructuralTestProvider() {
 		// make constructor only protected
+	}
+
+	/**
+	 * Parses a JSON string into a {@link JsonNode}.
+	 *
+	 * @param json the JSON string to parse
+	 * @return the parsed JSON tree
+	 */
+	protected static JsonNode parseJsonArray(String json) {
+		try {
+			return OBJECT_MAPPER.readTree(json);
+		} catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+			throw new IllegalStateException("Failed to parse JSON", e); //$NON-NLS-1$
+		}
 	}
 
 	/**
@@ -122,8 +141,19 @@ public abstract class StructuralTestProvider {
 	 * @param jsonPropertyKey the key used in JSON
 	 * @return a JSON array of the elements (can be empty)
 	 */
-	protected static JSONArray getExpectedJsonProperty(JSONObject element, String jsonPropertyKey) {
-		return element.has(jsonPropertyKey) ? element.getJSONArray(jsonPropertyKey) : new JSONArray();
+	protected static JsonNode getExpectedJsonProperty(JsonNode element, String jsonPropertyKey) {
+		if (!element.has(jsonPropertyKey)) {
+			return JsonNodeFactory.instance.arrayNode();
+		}
+		JsonNode property = element.get(jsonPropertyKey);
+		// Fail fast on a malformed oracle (mirrors org.json#getJSONArray, which threw
+		// on
+		// a non-array) rather than silently treating a scalar as an empty array.
+		if (!property.isArray()) {
+			throw new IllegalStateException("Expected a JSON array for structure-oracle property '" + jsonPropertyKey
+					+ "' but found: " + property.getNodeType());
+		}
+		return property;
 	}
 
 	/**
@@ -134,8 +164,19 @@ public abstract class StructuralTestProvider {
 	 * @param jsonPropertyKey the key used in JSON
 	 * @return a boolean as specified in the JSON or false if not present
 	 */
-	protected static boolean getExpectedJsonBooleanProperty(JSONObject element, String jsonPropertyKey) {
-		return element.has(jsonPropertyKey) && element.getBoolean(jsonPropertyKey);
+	protected static boolean getExpectedJsonBooleanProperty(JsonNode element, String jsonPropertyKey) {
+		if (!element.has(jsonPropertyKey)) {
+			return false;
+		}
+		JsonNode property = element.get(jsonPropertyKey);
+		// Fail fast on a malformed oracle (mirrors org.json#getBoolean, which threw on
+		// a
+		// non-boolean) rather than silently coercing via asBoolean().
+		if (!property.isBoolean()) {
+			throw new IllegalStateException("Expected a JSON boolean for structure-oracle property '" + jsonPropertyKey
+					+ "' but found: " + property.getNodeType());
+		}
+		return property.booleanValue();
 	}
 
 	/**
@@ -143,10 +184,10 @@ public abstract class StructuralTestProvider {
 	 * element match the ones in the expected structural element.
 	 *
 	 * @param observedModifiers The observed modifiers as a string array.
-	 * @param expectedModifiers The expected modifiers as a JSONArray.
+	 * @param expectedModifiers The expected modifiers as a JsonNode array.
 	 * @return True if they match, false otherwise.
 	 */
-	protected static boolean checkModifiers(String[] observedModifiers, JSONArray expectedModifiers) {
+	protected static boolean checkModifiers(String[] observedModifiers, JsonNode expectedModifiers) {
 		/*
 		 * If both the observed and expected elements have no modifiers, then they
 		 * match. A note: for technical reasons, we get in case of no observed
@@ -159,8 +200,9 @@ public abstract class StructuralTestProvider {
 		 * array of the observed ones and if any forbidden modifiers were used.
 		 */
 		Set<ModifierSpecification> modifierSpecifications = new HashSet<>();
-		for (var i = 0; i < expectedModifiers.length(); i++)
-			modifierSpecifications.add(ModifierSpecification.getModifierForJsonString(expectedModifiers.getString(i)));
+		for (var i = 0; i < expectedModifiers.size(); i++)
+			modifierSpecifications
+					.add(ModifierSpecification.getModifierForJsonString(expectedModifiers.get(i).asText()));
 		Set<String> observedModifiersSet = Set.of(observedModifiers);
 		Set<String> allowedModifiers = modifierSpecifications.stream().map(ModifierSpecification::getModifier)
 				.collect(Collectors.toSet());
@@ -200,7 +242,7 @@ public abstract class StructuralTestProvider {
 		}
 	}
 
-	protected static boolean checkAnnotations(Annotation[] observedAnnotations, JSONArray expectedAnnotations) {
+	protected static boolean checkAnnotations(Annotation[] observedAnnotations, JsonNode expectedAnnotations) {
 		/*
 		 * If both the observed and expected elements have no annotations, then they
 		 * match. A note: for technical reasons, we get in case of no observed
@@ -212,15 +254,15 @@ public abstract class StructuralTestProvider {
 		 * If the number of the annotations does not match, then the annotations per se
 		 * do not match either.
 		 */
-		if (observedAnnotations.length != expectedAnnotations.length())
+		if (observedAnnotations.length != expectedAnnotations.size())
 			return false;
 		/*
 		 * Otherwise check if each expected annotation is contained in the array of the
 		 * observed ones. If at least one isn't, then the modifiers don't match.
 		 */
-		for (Object expectedAnnotation : expectedAnnotations) {
+		for (JsonNode expectedAnnotation : expectedAnnotations) {
 			var expectedAnnotationFound = false;
-			var expectedAnnotationAsString = (String) expectedAnnotation;
+			var expectedAnnotationAsString = expectedAnnotation.asText();
 			for (Annotation observedAnnotation : observedAnnotations)
 				if (checkExpectedType(observedAnnotation.annotationType(), observedAnnotation.annotationType(),
 						expectedAnnotationAsString)) {
@@ -239,10 +281,11 @@ public abstract class StructuralTestProvider {
 	 * element.
 	 *
 	 * @param observedParameters The actual parameter types as a classes array.
-	 * @param expectedParameters The expected parameter type names as a JSONArray.
+	 * @param expectedParameters The expected parameter type names as a JsonNode
+	 *                           array.
 	 * @return True if they match, false otherwise.
 	 */
-	protected static boolean checkParameters(Class<?>[] observedParameters, JSONArray expectedParameters,
+	protected static boolean checkParameters(Class<?>[] observedParameters, JsonNode expectedParameters,
 			boolean strictOrder) {
 		/*
 		 * If both the observed and expected elements have no parameters, then they
@@ -254,11 +297,11 @@ public abstract class StructuralTestProvider {
 		 * If the number of parameters do not match, then the parameters cannot match
 		 * either.
 		 */
-		if (observedParameters.length != expectedParameters.length())
+		if (observedParameters.length != expectedParameters.size())
 			return false;
-		var expectedParameterTypeNames = new String[expectedParameters.length()];
-		for (var i = 0; i < expectedParameters.length(); i++)
-			expectedParameterTypeNames[i] = expectedParameters.getString(i);
+		var expectedParameterTypeNames = new String[expectedParameters.size()];
+		for (var i = 0; i < expectedParameters.size(); i++)
+			expectedParameterTypeNames[i] = expectedParameters.get(i).asText();
 
 		var observedParameterTypeNames = new String[observedParameters.length];
 		for (var i = 0; i < observedParameters.length; i++)
@@ -289,7 +332,7 @@ public abstract class StructuralTestProvider {
 	 * @param expectedParameters the parameters to describe.
 	 * @return A localized string describing the parameters.
 	 */
-	protected static String describeParameters(JSONArray expectedParameters) {
+	protected static String describeParameters(JsonNode expectedParameters) {
 		return expectedParameters.isEmpty() ? localized("structural.common.noParams") //$NON-NLS-1$
 				: localized("structural.common.withParams", expectedParameters); //$NON-NLS-1$
 	}
@@ -351,9 +394,9 @@ public abstract class StructuralTestProvider {
 	 *
 	 * @param structureOracleFileUrl The file url of the structure oracle file,
 	 *                               which is used for the structural tests.
-	 * @return The JSONArray representation of the structure oracle.
+	 * @return The JsonNode representation of the structure oracle.
 	 */
-	protected static JSONArray retrieveStructureOracleJSON(URL structureOracleFileUrl) {
+	protected static JsonNode retrieveStructureOracleJSON(URL structureOracleFileUrl) {
 		if (structureOracleFileUrl == null)
 			return null;
 		var result = new StringBuilder();
@@ -365,7 +408,7 @@ public abstract class StructuralTestProvider {
 		} catch (IOException e) {
 			LOG.error("Could not open stream from URL: {}", structureOracleFileUrl, e); //$NON-NLS-1$
 		}
-		return new JSONArray(result.toString());
+		return parseJsonArray(result.toString());
 	}
 
 	/**
@@ -378,10 +421,10 @@ public abstract class StructuralTestProvider {
 
 		private final String expectedClassName;
 		private final String expectedPackageName;
-		private final JSONObject expectedClassJson;
+		private final JsonNode expectedClassJson;
 
 		public ExpectedClassStructure(String expectedClassName, String expectedPackageName,
-				JSONObject expectedClassJson) {
+				JsonNode expectedClassJson) {
 			this.expectedClassName = Objects.requireNonNull(expectedClassName);
 			this.expectedPackageName = Objects.requireNonNull(expectedPackageName);
 			this.expectedClassJson = Objects.requireNonNull(expectedClassJson);
@@ -395,7 +438,7 @@ public abstract class StructuralTestProvider {
 			return expectedPackageName;
 		}
 
-		public JSONObject getExpectedClassJson() {
+		public JsonNode getExpectedClassJson() {
 			return expectedClassJson;
 		}
 
@@ -410,12 +453,12 @@ public abstract class StructuralTestProvider {
 			return getExpectedClassJson().has(propertyName);
 		}
 
-		public JSONObject getPropertyAsJsonObject(String propertyName) {
-			return getExpectedClassJson().getJSONObject(propertyName);
+		public JsonNode getPropertyAsJsonObject(String propertyName) {
+			return getExpectedClassJson().get(propertyName);
 		}
 
-		public JSONArray getPropertyAsJsonArray(String propertyName) {
-			return getExpectedClassJson().getJSONArray(propertyName);
+		public JsonNode getPropertyAsJsonArray(String propertyName) {
+			return getExpectedClassJson().get(propertyName);
 		}
 	}
 

--- a/src/main/java/de/tum/cit/ase/ares/api/structural/testutils/ClassNameScanner.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/structural/testutils/ClassNameScanner.java
@@ -12,10 +12,9 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.slf4j.*;
 
-import info.debatty.java.stringsimilarity.*;
-
 import de.tum.cit.ase.ares.api.AresConfiguration;
 import de.tum.cit.ase.ares.api.util.ProjectSourcesFinder;
+import de.tum.cit.ase.ares.api.util.StringSimilarity;
 
 /**
  * This class scans the submission project if the current expected class is
@@ -48,22 +47,6 @@ import de.tum.cit.ase.ares.api.util.ProjectSourcesFinder;
 public class ClassNameScanner {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClassNameScanner.class);
-
-	/**
-	 * Jaro-Winkler string similarity for typo correction to compute the overall
-	 * similarity
-	 */
-	private static final JaroWinkler JARO_WINKLER = new JaroWinkler();
-	/**
-	 * Normalized Levenshtein as alternative to spot some typos better (e.g. in
-	 * longer strings)
-	 */
-	private static final NormalizedLevenshtein NORMALIZED_LEVENSHTEIN = new NormalizedLevenshtein();
-	/**
-	 * Damerau-Levenshtein to compute the edit distance to have an absolute value
-	 * for the amount of difference
-	 */
-	private static final Damerau DAMERAU_LEVENSHTEIN = new Damerau();
 
 	/*
 	 * The class name and package name of the expected class that is currently being
@@ -326,7 +309,7 @@ public class ClassNameScanner {
 		 * next to each other are swapped. (We only use this rule for strings with
 		 * length of at least two)
 		 */
-		double distance = DAMERAU_LEVENSHTEIN.distance(a, b);
+		double distance = StringSimilarity.damerauLevenshteinDistance(a, b);
 		if (distance <= 1.0 && Math.max(a.length(), b.length()) > 2)
 			return true;
 		/*
@@ -342,7 +325,8 @@ public class ClassNameScanner {
 		 * that share some letters. It is similar for NL-similarity (which has some
 		 * benefits for long strings).
 		 */
-		return JARO_WINKLER.similarity(a, b) > 0.9 || NORMALIZED_LEVENSHTEIN.similarity(a, b) > 0.9;
+		return StringSimilarity.jaroWinklerSimilarity(a, b) > 0.9
+				|| StringSimilarity.normalizedLevenshteinSimilarity(a, b) > 0.9;
 	}
 
 	static String describePackageNameLocalized(String packageName) {

--- a/src/main/java/de/tum/cit/ase/ares/api/util/FileTools.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/util/FileTools.java
@@ -32,7 +32,6 @@ import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.io.Closer;
 import com.opencsv.CSVParser;
 import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
@@ -160,23 +159,41 @@ public class FileTools {
 			return Files.newInputStream(path.normalize());
 		}
 		JarFile jar = new JarFile(Path.of(jarMatcher.group(1)).toFile());
-		Closer closer = Closer.create();
 		try {
-			closer.register(jar);
 			JarEntry entry = jar.getJarEntry(jarMatcher.group(2).replace('\\', '/'));
 			if (entry == null) {
 				throw new SecurityException("Jar entry not found: " + jarMatcher.group(2).replace('\\', '/') + " in "
 						+ Path.of(jarMatcher.group(1)));
 			}
-			InputStream entryStream = closer.register(jar.getInputStream(entry));
+			InputStream entryStream = jar.getInputStream(entry);
 			return new FilterInputStream(entryStream) {
 				@Override
 				public void close() throws IOException {
-					closer.close();
+					// Close the entry stream first, then the backing jar, mirroring the
+					// reverse-order close the Guava Closer previously provided. The primary
+					// (entry-stream) failure is preserved; a subsequent jar-close failure is
+					// attached as a suppressed exception rather than masking it.
+					Throwable primary = null;
+					try {
+						super.close();
+					} catch (Throwable closeFailure) {
+						primary = closeFailure;
+						throw closeFailure;
+					} finally {
+						if (primary == null) {
+							jar.close();
+						} else {
+							try {
+								jar.close();
+							} catch (Throwable jarCloseFailure) {
+								primary.addSuppressed(jarCloseFailure);
+							}
+						}
+					}
 				}
 			};
 		} catch (Exception e) {
-			closer.close();
+			jar.close();
 			throw e;
 		}
 	}

--- a/src/main/java/de/tum/cit/ase/ares/api/util/StringSimilarity.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/util/StringSimilarity.java
@@ -1,0 +1,258 @@
+/*
+ * Portions of this file are derived from the "java-string-similarity" library
+ * by Thibault Debatty (https://github.com/tdebatty/java-string-similarity),
+ * specifically the Levenshtein, NormalizedLevenshtein, Damerau and JaroWinkler
+ * algorithms. That library is distributed under the MIT License: The MIT
+ * License Copyright 2015 Thibault Debatty. Permission is hereby granted, free
+ * of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions: The above copyright notice and this permission
+ * notice shall be included in all copies or substantial portions of the
+ * Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+ * EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package de.tum.cit.ase.ares.api.util;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+/**
+ * In-house string-similarity metrics vendored from the MIT-licensed <a href=
+ * "https://github.com/tdebatty/java-string-similarity">java-string-similarity</a>
+ * library by Thibault Debatty.
+ * <p>
+ * The algorithm bodies are reproduced verbatim (only adapted to static methods)
+ * so that their numeric results are identical to the original library, on which
+ * {@link de.tum.cit.ase.ares.api.structural.testutils.ClassNameScanner} relies
+ * for its typo-detection thresholds. Replacing this with a "standard"
+ * reimplementation would shift results around those thresholds.
+ */
+public final class StringSimilarity {
+
+	private static final double JARO_WINKLER_THRESHOLD = 0.7;
+	private static final int THREE = 3;
+	private static final double JW_COEF = 0.1;
+
+	private StringSimilarity() {
+		throw new UnsupportedOperationException("StringSimilarity is a utility class and should not be instantiated");
+	}
+
+	/**
+	 * Jaro-Winkler similarity with the library default threshold (0.7).
+	 *
+	 * @param s1 the first string to compare.
+	 * @param s2 the second string to compare.
+	 * @return the Jaro-Winkler similarity in the range [0, 1].
+	 */
+	public static double jaroWinklerSimilarity(String s1, String s2) {
+		if (s1 == null) {
+			throw new NullPointerException("s1 must not be null");
+		}
+		if (s2 == null) {
+			throw new NullPointerException("s2 must not be null");
+		}
+		if (s1.equals(s2)) {
+			return 1;
+		}
+		int[] mtp = jaroWinklerMatches(s1, s2);
+		float m = mtp[0];
+		if (m == 0) {
+			return 0f;
+		}
+		double j = ((m / s1.length() + m / s2.length() + (m - mtp[1]) / m)) / THREE;
+		double jw = j;
+		if (j > JARO_WINKLER_THRESHOLD) {
+			jw = j + Math.min(JW_COEF, 1.0 / mtp[THREE]) * mtp[2] * (1 - j);
+		}
+		return jw;
+	}
+
+	private static int[] jaroWinklerMatches(String s1, String s2) {
+		String max;
+		String min;
+		if (s1.length() > s2.length()) {
+			max = s1;
+			min = s2;
+		} else {
+			max = s2;
+			min = s1;
+		}
+		int range = Math.max(max.length() / 2 - 1, 0);
+		int[] matchIndexes = new int[min.length()];
+		Arrays.fill(matchIndexes, -1);
+		boolean[] matchFlags = new boolean[max.length()];
+		int matches = 0;
+		for (int mi = 0; mi < min.length(); mi++) {
+			char c1 = min.charAt(mi);
+			for (int xi = Math.max(mi - range, 0), xn = Math.min(mi + range + 1, max.length()); xi < xn; xi++) {
+				if (!matchFlags[xi] && c1 == max.charAt(xi)) {
+					matchIndexes[mi] = xi;
+					matchFlags[xi] = true;
+					matches++;
+					break;
+				}
+			}
+		}
+		char[] ms1 = new char[matches];
+		char[] ms2 = new char[matches];
+		for (int i = 0, si = 0; i < min.length(); i++) {
+			if (matchIndexes[i] != -1) {
+				ms1[si] = min.charAt(i);
+				si++;
+			}
+		}
+		for (int i = 0, si = 0; i < max.length(); i++) {
+			if (matchFlags[i]) {
+				ms2[si] = max.charAt(i);
+				si++;
+			}
+		}
+		int transpositions = 0;
+		for (int mi = 0; mi < ms1.length; mi++) {
+			if (ms1[mi] != ms2[mi]) {
+				transpositions++;
+			}
+		}
+		int prefix = 0;
+		for (int mi = 0; mi < min.length(); mi++) {
+			if (s1.charAt(mi) == s2.charAt(mi)) {
+				prefix++;
+			} else {
+				break;
+			}
+		}
+		return new int[] { matches, transpositions / 2, prefix, max.length() };
+	}
+
+	/**
+	 * Normalized Levenshtein similarity, computed as
+	 * {@code 1 - levenshtein(s1, s2) / max(|s1|, |s2|)}.
+	 *
+	 * @param s1 the first string to compare.
+	 * @param s2 the second string to compare.
+	 * @return the similarity in the range [0, 1].
+	 */
+	public static double normalizedLevenshteinSimilarity(String s1, String s2) {
+		return 1.0 - normalizedLevenshteinDistance(s1, s2);
+	}
+
+	private static double normalizedLevenshteinDistance(String s1, String s2) {
+		if (s1 == null) {
+			throw new NullPointerException("s1 must not be null");
+		}
+		if (s2 == null) {
+			throw new NullPointerException("s2 must not be null");
+		}
+		if (s1.equals(s2)) {
+			return 0;
+		}
+		int mLen = Math.max(s1.length(), s2.length());
+		if (mLen == 0) {
+			return 0;
+		}
+		return levenshteinDistance(s1, s2) / mLen;
+	}
+
+	private static double levenshteinDistance(String s1, String s2) {
+		if (s1 == null) {
+			throw new NullPointerException("s1 must not be null");
+		}
+		if (s2 == null) {
+			throw new NullPointerException("s2 must not be null");
+		}
+		if (s1.equals(s2)) {
+			return 0;
+		}
+		if (s1.length() == 0) {
+			return s2.length();
+		}
+		if (s2.length() == 0) {
+			return s1.length();
+		}
+		int[] v0 = new int[s2.length() + 1];
+		int[] v1 = new int[s2.length() + 1];
+		int[] vtemp;
+		for (int i = 0; i < v0.length; i++) {
+			v0[i] = i;
+		}
+		for (int i = 0; i < s1.length(); i++) {
+			v1[0] = i + 1;
+			for (int j = 0; j < s2.length(); j++) {
+				int cost = 1;
+				if (s1.charAt(i) == s2.charAt(j)) {
+					cost = 0;
+				}
+				v1[j + 1] = Math.min(v1[j] + 1, Math.min(v0[j + 1] + 1, v0[j] + cost));
+			}
+			vtemp = v0;
+			v0 = v1;
+			v1 = vtemp;
+		}
+		return v0[s2.length()];
+	}
+
+	/**
+	 * Unrestricted Damerau-Levenshtein distance (with transposition of two adjacent
+	 * characters), not the optimal-string-alignment variant.
+	 *
+	 * @param s1 the first string to compare.
+	 * @param s2 the second string to compare.
+	 * @return the computed distance.
+	 */
+	public static double damerauLevenshteinDistance(String s1, String s2) {
+		if (s1 == null) {
+			throw new NullPointerException("s1 must not be null");
+		}
+		if (s2 == null) {
+			throw new NullPointerException("s2 must not be null");
+		}
+		if (s1.equals(s2)) {
+			return 0;
+		}
+		int inf = s1.length() + s2.length();
+		HashMap<Character, Integer> da = new HashMap<>();
+		for (int d = 0; d < s1.length(); d++) {
+			da.put(s1.charAt(d), 0);
+		}
+		for (int d = 0; d < s2.length(); d++) {
+			da.put(s2.charAt(d), 0);
+		}
+		int[][] h = new int[s1.length() + 2][s2.length() + 2];
+		for (int i = 0; i <= s1.length(); i++) {
+			h[i + 1][0] = inf;
+			h[i + 1][1] = i;
+		}
+		for (int j = 0; j <= s2.length(); j++) {
+			h[0][j + 1] = inf;
+			h[1][j + 1] = j;
+		}
+		for (int i = 1; i <= s1.length(); i++) {
+			int db = 0;
+			for (int j = 1; j <= s2.length(); j++) {
+				int i1 = da.get(s2.charAt(j - 1));
+				int j1 = db;
+				int cost = 1;
+				if (s1.charAt(i - 1) == s2.charAt(j - 1)) {
+					cost = 0;
+					db = j;
+				}
+				h[i + 1][j + 1] = min4(h[i][j] + cost, h[i + 1][j] + 1, h[i][j + 1] + 1,
+						h[i1][j1] + (i - i1 - 1) + 1 + (j - j1 - 1));
+			}
+			da.put(s1.charAt(i - 1), i);
+		}
+		return h[s1.length() + 1][s2.length() + 1];
+	}
+
+	private static int min4(int a, int b, int c, int d) {
+		return Math.min(a, Math.min(b, Math.min(c, d)));
+	}
+}

--- a/src/test/java/de/tum/cit/ase/ares/api/structural/testutils/ClassNameScannerTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/structural/testutils/ClassNameScannerTest.java
@@ -1,0 +1,56 @@
+package de.tum.cit.ase.ares.api.structural.testutils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the typo-detection threshold decisions of
+ * {@link ClassNameScanner#isMisspelledWithHighProbability(String, String)}.
+ * These guard the branch boundaries (length difference, Damerau distance, and
+ * the Jaro-Winkler / Normalized-Levenshtein 0.9 cut-off) so that vendoring the
+ * string-similarity algorithms in
+ * {@link de.tum.cit.ase.ares.api.util.StringSimilarity} cannot silently shift
+ * the decisions.
+ */
+class ClassNameScannerTest {
+
+	@Test
+	void singleEditTyposAreMisspellings() {
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("Helper", "Helpr")).isTrue();
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("Calculator", "Calculatro")).isTrue();
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("Account", "Acount")).isTrue();
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("Student", "Studetn")).isTrue();
+	}
+
+	@Test
+	void distanceTwoButHighSimilarityIsMisspelling() {
+		// distance == 2, Jaro-Winkler similarity > 0.9
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("DataBase", "Databse")).isTrue();
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("HashMap", "HsahMpa")).isTrue();
+	}
+
+	@Test
+	void largeLengthDifferenceIsNotAMisspelling() {
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("Main", "MainHelperClass")).isFalse();
+	}
+
+	@Test
+	void distanceAboveTwoIsNotAMisspelling() {
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("Pingu", "Penguin")).isFalse();
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("Apple", "Orange")).isFalse();
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("Cat", "Dog")).isFalse();
+	}
+
+	@Test
+	void distanceTwoWithLowSimilarityIsNotAMisspelling() {
+		// distance == 2, but both Jaro-Winkler and Normalized-Levenshtein <= 0.9
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("abcd", "xbcy")).isFalse();
+	}
+
+	@Test
+	void shortStringsWithoutSharedCharactersAreNotMisspellings() {
+		// distance == 1 but max length <= 2 falls through to the similarity check
+		assertThat(ClassNameScanner.isMisspelledWithHighProbability("ab", "ba")).isFalse();
+	}
+}

--- a/src/test/java/de/tum/cit/ase/ares/api/util/StringSimilarityTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/util/StringSimilarityTest.java
@@ -1,0 +1,66 @@
+package de.tum.cit.ase.ares.api.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Golden-master tests for {@link StringSimilarity}. The expected values were
+ * captured from the MIT-licensed info.debatty java-string-similarity library
+ * (proven bit-identical by the former parity test) before that dependency was
+ * removed. They guard against accidental drift in the vendored algorithms.
+ */
+class StringSimilarityTest {
+
+	private static final double TOLERANCE = 1e-9;
+
+	@Test
+	void damerauLevenshteinDistanceMatchesGoldenValues() {
+		assertThat(StringSimilarity.damerauLevenshteinDistance("Main", "Main")).isEqualTo(0.0);
+		assertThat(StringSimilarity.damerauLevenshteinDistance("MainClass", "MianClass")).isEqualTo(1.0);
+		assertThat(StringSimilarity.damerauLevenshteinDistance("Student", "Studetn")).isEqualTo(1.0);
+		assertThat(StringSimilarity.damerauLevenshteinDistance("abcdefgh", "abcdefhg")).isEqualTo(1.0);
+		assertThat(StringSimilarity.damerauLevenshteinDistance("Pingu", "Penguin")).isEqualTo(3.0);
+		assertThat(StringSimilarity.damerauLevenshteinDistance("ABCDEF", "abcdef")).isEqualTo(6.0);
+		assertThat(StringSimilarity.damerauLevenshteinDistance("Main", "")).isEqualTo(4.0);
+		assertThat(StringSimilarity.damerauLevenshteinDistance("abcd", "xbcy")).isEqualTo(2.0);
+	}
+
+	@Test
+	void jaroWinklerSimilarityMatchesGoldenValues() {
+		assertThat(StringSimilarity.jaroWinklerSimilarity("Main", "Main")).isEqualTo(1.0);
+		assertThat(StringSimilarity.jaroWinklerSimilarity("MainClass", "MianClass")).isCloseTo(0.9666666328907013,
+				within(TOLERANCE));
+		assertThat(StringSimilarity.jaroWinklerSimilarity("Calculator", "Calcualtor")).isCloseTo(0.9833333492279053,
+				within(TOLERANCE));
+		assertThat(StringSimilarity.jaroWinklerSimilarity("Pingu", "Penguin")).isCloseTo(0.8114285290241241,
+				within(TOLERANCE));
+		assertThat(StringSimilarity.jaroWinklerSimilarity("café", "cafe")).isCloseTo(0.8833333194255829,
+				within(TOLERANCE));
+		assertThat(StringSimilarity.jaroWinklerSimilarity("ABCDEF", "abcdef")).isEqualTo(0.0);
+		assertThat(StringSimilarity.jaroWinklerSimilarity("HelperUtil", "HelperUtils")).isCloseTo(0.9972451816905629,
+				within(TOLERANCE));
+	}
+
+	@Test
+	void normalizedLevenshteinSimilarityMatchesGoldenValues() {
+		assertThat(StringSimilarity.normalizedLevenshteinSimilarity("Main", "Main")).isEqualTo(1.0);
+		assertThat(StringSimilarity.normalizedLevenshteinSimilarity("MainClass", "MianClass"))
+				.isCloseTo(0.7777777777777778, within(TOLERANCE));
+		assertThat(StringSimilarity.normalizedLevenshteinSimilarity("Helper", "Helpr")).isCloseTo(0.8333333333333334,
+				within(TOLERANCE));
+		assertThat(StringSimilarity.normalizedLevenshteinSimilarity("Pingu", "Penguin")).isCloseTo(0.5714285714285714,
+				within(TOLERANCE));
+		assertThat(StringSimilarity.normalizedLevenshteinSimilarity("ABCDEF", "abcdef")).isEqualTo(0.0);
+		assertThat(StringSimilarity.normalizedLevenshteinSimilarity("HelperUtil", "HelperUtils"))
+				.isCloseTo(0.9090909090909091, within(TOLERANCE));
+	}
+
+	@Test
+	void equalStringsAreFullySimilar() {
+		assertThat(StringSimilarity.jaroWinklerSimilarity("x", "x")).isEqualTo(1.0);
+		assertThat(StringSimilarity.normalizedLevenshteinSimilarity("x", "x")).isEqualTo(1.0);
+		assertThat(StringSimilarity.damerauLevenshteinDistance("x", "x")).isEqualTo(0.0);
+	}
+}

--- a/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/FileSystemAccessDeleteTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/FileSystemAccessDeleteTest.java
@@ -368,6 +368,38 @@ class FileSystemAccessDeleteTest extends SystemAccessTest {
 				ThirdPartyPackagePenguin.class);
 	}
 
+	/* -------------------------------------------------------------------- */
+	/* org.apache.commons.io.FileUtils.forceDelete (third-party wrapper) */
+	/* -------------------------------------------------------------------- */
+
+	@PublicTest
+	@Policy(value = ARCHUNIT_ASPECTJ_POLICY_ONE_PATH_ALLOWED_DELETE, withinPath = THIRD_PARTY_WITHIN_PATH)
+	void test_commonsIoForceDelete_archunit_aspectj() {
+		assertAresSecurityExceptionDelete(DeleteThirdPartyPackageMain::accessFileSystemViaCommonsIoForceDelete,
+				ThirdPartyPackagePenguin.class);
+	}
+
+	@PublicTest
+	@Policy(value = ARCHUNIT_INSTRUMENTATION_POLICY_ONE_PATH_ALLOWED_DELETE, withinPath = THIRD_PARTY_WITHIN_PATH)
+	void test_commonsIoForceDelete_archunit_instrumentation() {
+		assertAresSecurityExceptionDelete(DeleteThirdPartyPackageMain::accessFileSystemViaCommonsIoForceDelete,
+				ThirdPartyPackagePenguin.class);
+	}
+
+	@PublicTest
+	@Policy(value = WALA_ASPECTJ_POLICY_ONE_PATH_ALLOWED_DELETE, withinPath = THIRD_PARTY_WITHIN_PATH)
+	void test_commonsIoForceDelete_wala_aspectj() {
+		assertAresSecurityExceptionDelete(DeleteThirdPartyPackageMain::accessFileSystemViaCommonsIoForceDelete,
+				ThirdPartyPackagePenguin.class);
+	}
+
+	@PublicTest
+	@Policy(value = WALA_INSTRUMENTATION_POLICY_ONE_PATH_ALLOWED_DELETE, withinPath = THIRD_PARTY_WITHIN_PATH)
+	void test_commonsIoForceDelete_wala_instrumentation() {
+		assertAresSecurityExceptionDelete(DeleteThirdPartyPackageMain::accessFileSystemViaCommonsIoForceDelete,
+				ThirdPartyPackagePenguin.class);
+	}
+
 	@Disabled("This test is disabled because testing in this manner is not possible. FileSystemProvider.installedProviders() "
 			+ "gets a violation whule trying to access java.net.URL.openConnection().")
 	@PublicTest

--- a/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/delete/thirdPartyPackage/DeleteThirdPartyPackageMain.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/delete/thirdPartyPackage/DeleteThirdPartyPackageMain.java
@@ -18,4 +18,12 @@ public class DeleteThirdPartyPackageMain {
 	public static void accessFileSystemViaThirdPartyPackage() throws IOException {
 		ThirdPartyPackagePenguin.deleteFile();
 	}
+
+	/**
+	 * Access the file system using the {@link ThirdPartyPackagePenguin} class for
+	 * deletion through Apache Commons IO's {@code FileUtils.forceDelete}.
+	 */
+	public static void accessFileSystemViaCommonsIoForceDelete() throws IOException {
+		ThirdPartyPackagePenguin.deleteFileViaCommonsIo();
+	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/integration/testuser/subject/architectureTests/thirdpartypackage/ThirdPartyPackagePenguin.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/testuser/subject/architectureTests/thirdpartypackage/ThirdPartyPackagePenguin.java
@@ -1,8 +1,11 @@
 package de.tum.cit.ase.ares.integration.testuser.subject.architectureTests.thirdpartypackage;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import org.apache.commons.io.FileUtils;
 
 /**
  * This class is used to emulate a third-party package that is not part of the
@@ -35,6 +38,17 @@ public class ThirdPartyPackagePenguin {
 
 	public static void deleteFile() throws IOException {
 		Files.delete(Path.of(
+				"src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/delete/nottrusteddir/nottrusted.txt"));
+	}
+
+	/**
+	 * Deletes the not-trusted file through Apache Commons IO's
+	 * {@link FileUtils#forceDelete(File)}. The actual delete happens inside the
+	 * (non-woven) commons-io library, so this exercises the dedicated
+	 * {@code FileUtils.forceDelete} interception rather than a JDK delete call.
+	 */
+	public static void deleteFileViaCommonsIo() throws IOException {
+		FileUtils.forceDelete(new File(
 				"src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/delete/nottrusteddir/nottrusted.txt"));
 	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/testutilities/CustomConditionEvents.java
+++ b/src/test/java/de/tum/cit/ase/ares/testutilities/CustomConditionEvents.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.lang.ConditionEvent;
 import com.tngtech.archunit.lang.ConditionEvents;
 
@@ -35,7 +34,7 @@ public class CustomConditionEvents implements ConditionEvents {
 
 	@Override
 	public Collection<ConditionEvent> getViolating() {
-		return ImmutableList.copyOf(violations);
+		return List.copyOf(violations);
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

Reduces the dependency surface and adds report-only static analysis, plus two
small correctness/test additions. Split into five focused commits.

## Commits

1. **refactor: replace Guava, Vavr and org.json with JDK and in-house equivalents**
   Drops Guava, Vavr, org.json and java-string-similarity. Guava
   `Preconditions`/`MoreFiles`/`MoreObjects`/`ImmutableList`/`Streams`/`Closer`
   move to JDK APIs; Vavr streams in `ReachabilityChecker` move to
   `java.util.stream`; structure-oracle parsing moves from org.json to Jackson
   (failing fast on a malformed oracle); a new in-house `StringSimilarity`
   (Damerau-Levenshtein, Jaro-Winkler, normalised Levenshtein) replaces the
   debatty library in `ClassNameScanner`. opencsv keeps only its raw CSV reader.

2. **build: swap test dependencies to maintained artefacts**
   junit-vintage-engine to the plain `junit` (JUnit 4) API, mockito-inline to
   mockito-core, with version bumps. `SafeTypeThrowableSanitizer` learns to
   duplicate `ParameterResolutionException` under JUnit 6.1's stricter
   constructors.

3. **build: add report-only static analysis and bump Maven plugins**
   Checkstyle, PMD and SpotBugs as manual, report-only goals (never fail the
   build), plus current versions for the build plugins and jacoco.

4. **fix(aop): tolerate null allowedClasses during partially-armed settings**
   Treats a null `allowedClasses` as an empty allow-list, closing a volatile
   write-ordering race in `JavaAOPTestCaseSettings` that could throw an NPE in
   the instrumentation toolbox.

5. **test(aop): add commons-io FileUtils.forceDelete forbidden delete case**
   Covers the dedicated `FileUtils.forceDelete` interception across all four
   ArchUnit/WALA x AspectJ/Instrumentation modes.

## Verification

`mvn test-compile` passes locally (Java 17). The static-analysis plugins added
in commit 3 run report-only: Checkstyle is clean (0 violations); PMD, CPD and
SpotBugs report findings without failing the build. Full `mvn test` left to CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tool and dependency versions for improved compatibility and maintainability.
  * Replaced internal utility libraries with Java standard library equivalents to reduce external dependencies.
  * Migrated JSON processing to improve performance and library efficiency.

* **Tests**
  * Expanded test coverage for string similarity algorithms and file system access validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->