### PR TITLE
build: bump version to 2.0.1-Beta8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,7 @@
 					</execution>
 					<execution>
 						<id>weave-main-classes</id>
-						<phase>process-classes</phase>
+						<phase>compile</phase>
 						<goals>
 							<goal>compile</goal>
 						</goals>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.tum.cit.ase</groupId>
 	<artifactId>ares</artifactId>
-	<version>2.0.1-Beta7</version>
+	<version>2.0.1-Beta8</version>
 	<properties>
 		<!-- 0. General Project Settings -->
 		<maven.compiler.source>17</maven.compiler.source>

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJAbstractAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJAbstractAdviceDefinitions.aj
@@ -522,6 +522,73 @@ public abstract aspect JavaAspectJAbstractAdviceDefinitions {
 	private static final ThreadLocal<String[]> CALLSTACK_INSPECTION_CACHE = new ThreadLocal<>();
 
 	/**
+	 * Per-thread re-entrancy guard for the AspectJ advice. The advice body performs
+	 * file-system work (path canonicalisation, settings/localisation reads) and
+	 * stack walks; under load-time weaving those operations are themselves woven and
+	 * re-enter the advice on the same thread. Without a guard the advice recurses on
+	 * its own internal operations, producing unbounded redundant work (and, during
+	 * JDK class loading, a {@link ClassCircularityError}). {@link #enterAdvice()}
+	 * returns {@code false} when the advice is already executing on this thread so the
+	 * nested invocation returns immediately; the outermost invocation clears the flag
+	 * in a {@code finally} via {@link #exitAdvice()}. Skipping nested invocations is
+	 * correct because the advice itself is trusted Ares code, not student code.
+	 */
+	@Nonnull
+	private static final ThreadLocal<Boolean> ADVICE_IN_PROGRESS = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+	/**
+	 * Marks entry into an advice body for the current thread.
+	 *
+	 * @return {@code true} if this is the outermost (non-re-entrant) invocation and
+	 *         the caller should proceed; {@code false} if the advice is already
+	 *         executing on this thread and the caller must return immediately.
+	 */
+	protected static boolean enterAdvice() {
+		if (Boolean.TRUE.equals(ADVICE_IN_PROGRESS.get())) {
+			return false;
+		}
+		ADVICE_IN_PROGRESS.set(Boolean.TRUE);
+		return true;
+	}
+
+	/**
+	 * Clears the per-thread advice re-entrancy flag. Must be called from a
+	 * {@code finally} paired with an {@link #enterAdvice()} that returned
+	 * {@code true}.
+	 */
+	protected static void exitAdvice() {
+		ADVICE_IN_PROGRESS.set(Boolean.FALSE);
+	}
+
+	/**
+	 * Verifies that {@code value}'s runtime class is JDK-origin before the advice
+	 * invokes any overridable method on it. The advice runs inside the re-entrancy
+	 * guard ({@link #enterAdvice()}); if it called an overridable method (e.g.
+	 * {@code toString()}, {@code intValue()}, {@code iterator()}) on an
+	 * attacker-supplied subclass, that student code would execute while the guard is
+	 * active and any forbidden operation it performs would be silently skipped. Only
+	 * the bootstrap and platform class loaders load JDK classes; student/user code is
+	 * loaded by the application class loader (or a child). A JDK-origin instance is
+	 * safe to call overridable methods on, and trusting the loader correctly allows
+	 * legitimate JDK subclasses (e.g. {@code sun.security.ssl.SSLSocketImpl extends
+	 * java.net.Socket}) that an exact-class check would wrongly reject. An untrusted
+	 * subtype is treated as a violation (fail-closed) and blocked, because Ares
+	 * cannot inspect it without running untrusted code. {@link Class#getClassLoader()}
+	 * is final and cannot be spoofed.
+	 *
+	 * @param value the attacker-controlled argument about to be inspected
+	 */
+	protected static void requireTrustedRuntimeType(@Nonnull Object value) {
+		ClassLoader loader = value.getClass().getClassLoader();
+		if (loader != null && loader != ClassLoader.getPlatformClassLoader()) {
+			throw new SecurityException(
+					"Ares Security Error (Reason: Student-Code; Stage: Execution): Ares cannot safely inspect an"
+							+ " argument of untrusted type " + value.getClass().getName()
+							+ " (not a JDK type) but was blocked by Ares.");
+		}
+	}
+
+	/**
 	 * Finds the caller directly above the first method on the current call stack
 	 * that belongs to the given restricted package.
 	 * <p>

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJCommandSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJCommandSystemAdviceDefinitions.aj
@@ -654,6 +654,21 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 	 * @author Markus Paulsen
 	 */
 	public static void checkCommandSystemInteraction(@Nonnull String action, @Nonnull JoinPoint thisJoinPoint) {
+		// Re-entrancy guard: the advice body's own file-system and stack-walk work is
+		// woven and re-enters this advice on the same thread, causing unbounded
+		// recursion (and ClassCircularityError during class loading). Skip nested
+		// invocations (trusted Ares internals); enforce only the outermost one.
+		if (!enterAdvice()) {
+			return;
+		}
+		try {
+			checkCommandSystemInteractionImpl(action, thisJoinPoint);
+		} finally {
+			exitAdvice();
+		}
+	}
+
+	private static void checkCommandSystemInteractionImpl(@Nonnull String action, @Nonnull JoinPoint thisJoinPoint) {
 		// <editor-fold desc="Get information from settings">
 		@Nullable
 		final String aopMode = getValueFromSettings("aopMode");

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJFileSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJFileSystemAdviceDefinitions.aj
@@ -334,6 +334,8 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 			if (variableValue == null) {
 				return null;
 			} else if (variableValue instanceof Path) {
+				// Path is an interface; only call into trusted JDK path impls.
+				requireTrustedRuntimeType(variableValue);
 				return ((Path) variableValue).normalize().toAbsolutePath();
 			} else if (variableValue instanceof URI uri) {
 				if (!"file".equalsIgnoreCase(uri.getScheme())) {
@@ -357,6 +359,8 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 				// "/" is the root directory and is a valid path - let it be processed normally
 				return Path.of((String) variableValue).normalize().toAbsolutePath();
 			} else if (variableValue instanceof File) {
+				// File is not final; a student subclass could run code in toURI().
+				requireTrustedRuntimeType(variableValue);
 				return Path.of(((File) variableValue).toURI()).normalize().toAbsolutePath();
 			} else {
 				return null;
@@ -1038,6 +1042,22 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 	 * @author Markus Paulsen
 	 */
 	public void checkFileSystemInteraction(@Nonnull String action, @Nonnull JoinPoint thisJoinPoint) {
+		// Re-entrancy guard: under load-time weaving the advice body's own file-system
+		// and stack-walk work is itself woven and re-enters this advice on the same
+		// thread, causing unbounded recursion (and ClassCircularityError during class
+		// loading). Skip nested invocations (trusted Ares internals); enforce only the
+		// outermost one.
+		if (!enterAdvice()) {
+			return;
+		}
+		try {
+			checkFileSystemInteractionImpl(action, thisJoinPoint);
+		} finally {
+			exitAdvice();
+		}
+	}
+
+	private void checkFileSystemInteractionImpl(@Nonnull String action, @Nonnull JoinPoint thisJoinPoint) {
 		// <editor-fold desc="Get information from settings">
 		@Nullable
 		final String aopMode = getValueFromSettings("aopMode");

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJNetworkSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJNetworkSystemAdviceDefinitions.aj
@@ -192,6 +192,7 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 			return target;
 		}
 		if (value instanceof InetSocketAddress inetSocketAddress) {
+			requireTrustedRuntimeType(value);
 			String host = inetSocketAddress.getHostString();
 			if (host == null || host.isBlank()) {
 				InetAddress address = inetSocketAddress.getAddress();
@@ -200,6 +201,7 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 			return new NetworkTarget(host, inetSocketAddress.getPort());
 		}
 		if (value instanceof SocketAddress socketAddress) {
+			requireTrustedRuntimeType(value);
 			String socketAddressAsString = socketAddress.toString();
 			int delimiter = socketAddressAsString.lastIndexOf(':');
 			if (delimiter > 0 && delimiter + 1 < socketAddressAsString.length()) {
@@ -214,6 +216,7 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 			return null;
 		}
 		if (value instanceof HttpRequest httpRequest) {
+			requireTrustedRuntimeType(value);
 			return variableToTarget(httpRequest.uri());
 		}
 		if (value instanceof URI uri) {
@@ -225,9 +228,11 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 			return new NetworkTarget(url.getHost(), port >= 0 ? port : -1);
 		}
 		if (value instanceof URLConnection urlConnection) {
+			requireTrustedRuntimeType(value);
 			return variableToTarget(urlConnection.getURL());
 		}
 		if (value instanceof DatagramPacket datagramPacket) {
+			requireTrustedRuntimeType(value);
 			InetAddress address = datagramPacket.getAddress();
 			if (address != null && datagramPacket.getPort() > 0) {
 				return new NetworkTarget(address.getHostAddress(), datagramPacket.getPort());
@@ -235,12 +240,15 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 			return null;
 		}
 		if (value instanceof Socket socket) {
+			requireTrustedRuntimeType(value);
 			return extractSocketTarget(socket);
 		}
 		if (value instanceof DatagramSocket datagramSocket) {
+			requireTrustedRuntimeType(value);
 			return extractDatagramSocketTarget(datagramSocket);
 		}
 		if (value instanceof SocketChannel socketChannel) {
+			requireTrustedRuntimeType(value);
 			try {
 				return variableToTarget(socketChannel.getRemoteAddress());
 			} catch (Exception ignored) {
@@ -248,6 +256,7 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 			}
 		}
 		if (value instanceof DatagramChannel datagramChannel) {
+			requireTrustedRuntimeType(value);
 			try {
 				return variableToTarget(datagramChannel.getRemoteAddress());
 			} catch (Exception ignored) {
@@ -255,6 +264,7 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 			}
 		}
 		if (value instanceof InetAddress inetAddress) {
+			requireTrustedRuntimeType(value);
 			return new NetworkTarget(inetAddress.getHostAddress(), -1);
 		}
 		if (value instanceof String str) {
@@ -405,6 +415,7 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 			return new NetworkTarget(host, port);
 		}
 		if (hostCandidate instanceof InetAddress inetAddress) {
+			requireTrustedRuntimeType(hostCandidate);
 			return new NetworkTarget(inetAddress.getHostAddress(), port);
 		}
 		return null;
@@ -423,6 +434,7 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 		if (!(value instanceof Number number)) {
 			return null;
 		}
+		requireTrustedRuntimeType(value);
 		int port = number.intValue();
 		if (port < 0 || port > 65_535) {
 			return null;
@@ -751,6 +763,24 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 	 * @author Kevin Fischer
 	 */
 	public static void checkNetworkSystemInteraction(
+			@Nonnull String action,
+			@Nonnull JoinPoint thisJoinPoint
+	) {
+		// Re-entrancy guard: the advice body's own network/file and stack-walk work is
+		// woven and re-enters this advice on the same thread, causing unbounded
+		// recursion (and ClassCircularityError during class loading). Skip nested
+		// invocations (trusted Ares internals); enforce only the outermost one.
+		if (!enterAdvice()) {
+			return;
+		}
+		try {
+			checkNetworkSystemInteractionImpl(action, thisJoinPoint);
+		} finally {
+			exitAdvice();
+		}
+	}
+
+	private static void checkNetworkSystemInteractionImpl(
 			@Nonnull String action,
 			@Nonnull JoinPoint thisJoinPoint
 	) {

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJThreadSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJThreadSystemAdviceDefinitions.aj
@@ -623,6 +623,24 @@ public aspect JavaAspectJThreadSystemAdviceDefinitions extends JavaAspectJAbstra
 			@Nonnull String action,
 			@Nonnull JoinPoint thisJoinPoint
 	) {
+		// Re-entrancy guard: the advice body's own file-system and stack-walk work is
+		// woven and re-enters this advice on the same thread, causing unbounded
+		// recursion (and ClassCircularityError during class loading). Skip nested
+		// invocations (trusted Ares internals); enforce only the outermost one.
+		if (!enterAdvice()) {
+			return;
+		}
+		try {
+			checkThreadSystemInteractionImpl(action, thisJoinPoint);
+		} finally {
+			exitAdvice();
+		}
+	}
+
+	private void checkThreadSystemInteractionImpl(
+			@Nonnull String action,
+			@Nonnull JoinPoint thisJoinPoint
+	) {
 		// <editor-fold desc="Get information from settings">
 		@Nullable
 		final String aopMode = getValueFromSettings("aopMode");

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceAbstractToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceAbstractToolbox.java
@@ -519,6 +519,77 @@ public abstract class JavaInstrumentationAdviceAbstractToolbox {
 	private static final ThreadLocal<String[]> CALLSTACK_INSPECTION_CACHE = new ThreadLocal<>();
 
 	/**
+	 * Per-thread re-entrancy guard for the instrumentation advice. The advice's own
+	 * body performs file-system work (reading settings, localisation bundles,
+	 * building messages) and walks the stack, which can lazily load JDK classes
+	 * such as {@code sun.nio.fs.UnixException}. Loading those classes re-enters the
+	 * file-system advice on the same thread; without a guard that re-entry runs the
+	 * full check again while the class is still being defined, producing a
+	 * {@link ClassCircularityError}. {@link #enterAdvice()} returns {@code false}
+	 * when the advice is already executing on this thread so the nested invocation
+	 * returns immediately; the outermost invocation always clears the flag in a
+	 * {@code finally} via {@link #exitAdvice()}. Skipping nested invocations is
+	 * correct because the advice itself is trusted Ares code, not student code.
+	 */
+	@Nonnull
+	private static final ThreadLocal<Boolean> ADVICE_IN_PROGRESS = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+	/**
+	 * Marks entry into an advice body for the current thread.
+	 *
+	 * @return {@code true} if this is the outermost (non-re-entrant) invocation and
+	 *         the caller should proceed; {@code false} if the advice is already
+	 *         executing on this thread and the caller must return immediately.
+	 */
+	static boolean enterAdvice() {
+		if (Boolean.TRUE.equals(ADVICE_IN_PROGRESS.get())) {
+			return false;
+		}
+		ADVICE_IN_PROGRESS.set(Boolean.TRUE);
+		return true;
+	}
+
+	/**
+	 * Clears the per-thread advice re-entrancy flag. Must be called from a
+	 * {@code finally} block paired with a {@link #enterAdvice()} that returned
+	 * {@code true}.
+	 */
+	static void exitAdvice() {
+		ADVICE_IN_PROGRESS.set(Boolean.FALSE);
+	}
+
+	/**
+	 * Verifies that {@code value}'s EXACT runtime class is {@code trusted} before the
+	 * advice invokes any overridable method on it. {@link Object#getClass()} is
+	 * {@code final} and cannot be spoofed, so this is a reliable trust check. The
+	 * advice runs inside the re-entrancy guard ({@link #enterAdvice()}); if it invoked
+	 * an overridable method (e.g. {@code toString()}, {@code intValue()}) on an
+	 * attacker-supplied subclass, that student code would execute while the guard is
+	 * active and any forbidden operation it performs would be silently skipped. To
+	 * keep that impossible, the advice only calls methods on exact trusted JDK
+	 * classes; an untrusted subtype is treated as a violation (fail-closed) and
+	 * blocked, because Ares cannot inspect it without running untrusted code.
+	 *
+	 * @param value   the attacker-controlled argument about to be inspected
+	 * @param trusted the exact JDK class the advice is allowed to call methods on
+	 */
+	static void requireTrustedRuntimeType(@Nonnull Object value) {
+		ClassLoader loader = value.getClass().getClassLoader();
+		// Bootstrap (null) and platform class loaders only ever load JDK classes; user
+		// and student code is loaded by the application/system class loader (or a child
+		// of it). A JDK-origin instance is safe to call overridable methods on, and this
+		// correctly trusts legitimate JDK subclasses (e.g. sun.security.ssl.SSLSocketImpl
+		// extends java.net.Socket, jdk.nio.zipfs paths) that an exact-class check would
+		// wrongly reject. Class.getClassLoader() is final and cannot be spoofed.
+		if (loader != null && loader != ClassLoader.getPlatformClassLoader()) {
+			throw new SecurityException(
+					"Ares Security Error (Reason: Student-Code; Stage: Execution): Ares cannot safely inspect an"
+							+ " argument of untrusted type " + value.getClass().getName()
+							+ " (not a JDK type) but was blocked by Ares.");
+		}
+	}
+
+	/**
 	 * Finds the caller directly above the first method on the current call stack
 	 * that belongs to the given restricted package.
 	 * <p>

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceCommandSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceCommandSystemToolbox.java
@@ -216,11 +216,14 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 			return null;
 		} else if (variableValue instanceof String[] && ((String[]) variableValue).length != 0) {
 			parts = (String[]) variableValue;
-		} else if (variableValue instanceof List<?>
-				&& ((List<?>) variableValue).stream().allMatch(o -> o instanceof String)) {
-			@SuppressWarnings("unchecked")
-			List<String> stringList = (List<String>) variableValue;
-			parts = stringList.toArray(new String[0]);
+		} else if (variableValue instanceof List<?>) {
+			// List is an interface; only call stream()/toArray() on trusted JDK lists.
+			requireTrustedRuntimeType(variableValue);
+			if (((List<?>) variableValue).stream().allMatch(o -> o instanceof String)) {
+				@SuppressWarnings("unchecked")
+				List<String> stringList = (List<String>) variableValue;
+				parts = stringList.toArray(new String[0]);
+			}
 		} else if (variableValue instanceof String) {
 			parts = parseCommandString((String) variableValue);
 		}
@@ -325,6 +328,8 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 			return false;
 		} else if (observedVariable instanceof List<?>) {
 			List<?> list = (List<?>) observedVariable;
+			// List is an interface; only call stream()/iterator() on trusted JDK lists.
+			requireTrustedRuntimeType(observedVariable);
 			// Recurse only when elements are themselves nested Lists/arrays (i.e. multiple
 			// commands). A flat List<String> is a single (command, arg, arg, ...) sequence
 			// and must be handed to variableToCommand whole; otherwise individual args that
@@ -370,6 +375,8 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 			return null;
 		} else if (observedVariable instanceof List<?>) {
 			List<?> list = (List<?>) observedVariable;
+			// List is an interface; only call stream()/iterator() on trusted JDK lists.
+			requireTrustedRuntimeType(observedVariable);
 			// Mirror the recursion guard from analyseViolation: only descend into nested
 			// Lists/arrays so flat List<String> command sequences are matched as a whole.
 			if (list.stream().anyMatch(o -> o instanceof List<?> || (o != null && o.getClass().isArray()))) {
@@ -407,6 +414,8 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 			return null;
 		} else if (observedVariable instanceof List<?>) {
 			List<?> list = (List<?>) observedVariable;
+			// List is an interface; only call stream()/iterator() on trusted JDK lists.
+			requireTrustedRuntimeType(observedVariable);
 			if (list.stream().anyMatch(o -> o instanceof List<?> || (o != null && o.getClass().isArray()))) {
 				for (Object element : list) {
 					String violationPath = extractExecutablePathViolation(element, pathsAllowedToExecute);
@@ -659,6 +668,24 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 	 * @author Markus Paulsen
 	 */
 	public static void checkCommandSystemInteraction(@Nonnull String action, @Nonnull String declaringTypeName,
+			@Nonnull String methodName, @Nonnull String methodSignature, @Nullable Object[] attributes,
+			@Nullable Object[] parameters, @Nullable Object instance) {
+		// Re-entrancy guard: the advice body performs file work and stack walks that
+		// lazily load JDK classes; loading those re-enters the advice on the same
+		// thread, causing ClassCircularityError and unbounded recursion. Skip nested
+		// invocations (trusted Ares internals); enforce only the outermost one.
+		if (!enterAdvice()) {
+			return;
+		}
+		try {
+			checkCommandSystemInteractionImpl(action, declaringTypeName, methodName, methodSignature, attributes,
+					parameters, instance);
+		} finally {
+			exitAdvice();
+		}
+	}
+
+	private static void checkCommandSystemInteractionImpl(@Nonnull String action, @Nonnull String declaringTypeName,
 			@Nonnull String methodName, @Nonnull String methodSignature, @Nullable Object[] attributes,
 			@Nullable Object[] parameters, @Nullable Object instance) {
 		// <editor-fold desc="Get information from settings">

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceFileSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceFileSystemToolbox.java
@@ -359,6 +359,9 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 			if (variableValue == null) {
 				return null;
 			} else if (variableValue instanceof Path) {
+				// Path is an interface; a student implementation could run code in
+				// normalize()/toAbsolutePath(). Only call into trusted JDK path impls.
+				requireTrustedRuntimeType(variableValue);
 				return ((Path) variableValue).normalize().toAbsolutePath();
 			} else if (variableValue instanceof URI uri) {
 				if (!"file".equalsIgnoreCase(uri.getScheme())) {
@@ -382,6 +385,8 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 				// "/" is the root directory and is a valid path - let it be processed normally
 				return Path.of((String) variableValue).normalize().toAbsolutePath();
 			} else if (variableValue instanceof File) {
+				// File is not final; a student subclass could run code in toURI().
+				requireTrustedRuntimeType(variableValue);
 				return Path.of(((File) variableValue).toURI()).normalize().toAbsolutePath();
 			} else {
 				return null;
@@ -440,6 +445,9 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 			}
 			return false;
 		} else if (observedVariable instanceof List<?>) {
+			// List is an interface; a student impl could run code in iterator(). Only
+			// iterate trusted JDK collections (JDK-origin classes only).
+			requireTrustedRuntimeType(observedVariable);
 			for (Object element : (List<?>) observedVariable) {
 				boolean violation = analyseViolation(element, allowedPaths, allowNonExistingPathsToBeConsidered);
 				if (violation) {
@@ -482,6 +490,9 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 			}
 			return null;
 		} else if (observedVariable instanceof List<?>) {
+			// List is an interface; a student impl could run code in iterator(). Only
+			// iterate trusted JDK collections (JDK-origin classes only).
+			requireTrustedRuntimeType(observedVariable);
 			for (Object element : (List<?>) observedVariable) {
 				String violationPath = extractViolationPath(element, allowedPaths, allowNonExistingPathsToBeConsidered);
 				if (violationPath != null) {
@@ -1436,43 +1447,57 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 	public static void checkFileSystemInteraction(@Nonnull String action, @Nonnull String declaringTypeName,
 			@Nonnull String methodName, @Nonnull String methodSignature, @Nullable Object[] attributes,
 			@Nullable Object[] parameters, @Nullable Object instance) {
-		// <editor-fold desc="Check instrumentation mode early">
-		@Nullable
-		final String aopMode = getValueFromSettings("aopMode");
-		if (aopMode == null || aopMode.isEmpty() || !aopMode.equals("INSTRUMENTATION")) {
+		// Re-entrancy guard: the body below performs file-system work and stack walks
+		// that can lazily load JDK classes (e.g. sun.nio.fs.UnixException). Loading
+		// those re-enters this advice on the same thread; running the full check during
+		// class definition triggers a ClassCircularityError. Skip nested invocations.
+		if (!enterAdvice()) {
 			return;
 		}
-		@Nullable
-		final String restrictedPackage = getValueFromSettings("restrictedPackage");
-		if (restrictedPackage == null || restrictedPackage.isEmpty()) {
-			return;
-		}
-		if (isProjectSourcesFinderInProgress()) {
-			return;
-		}
-		@Nullable
-		final String[] allowedClasses = getValueFromSettings("allowedListedClasses");
-		// </editor-fold>
-		// <editor-fold desc="Get information from attributes">
-		@Nonnull
-		final String fullMethodSignature = declaringTypeName + "." + methodName + methodSignature;
-		// </editor-fold>
-		// <editor-fold desc="Check callstack">
-		@Nullable
-		String fileSystemMethodToCheck = (restrictedPackage == null) ? null
-				: checkIfCallstackCriteriaIsViolated(restrictedPackage, allowedClasses, declaringTypeName, methodName);
-		if (fileSystemMethodToCheck == null) {
-			return;
-		}
-		@Nullable
-		String studentCalledMethod = findFirstMethodOutsideOfRestrictedPackage(restrictedPackage);
-		// </editor-fold>
+		try {
+			// <editor-fold desc="Check instrumentation mode early">
+			@Nullable
+			final String aopMode = getValueFromSettings("aopMode");
+			if (aopMode == null || aopMode.isEmpty() || !aopMode.equals("INSTRUMENTATION")) {
+				return;
+			}
+			@Nullable
+			final String restrictedPackage = getValueFromSettings("restrictedPackage");
+			if (restrictedPackage == null || restrictedPackage.isEmpty()) {
+				return;
+			}
+			if (isProjectSourcesFinderInProgress()) {
+				return;
+			}
+			@Nullable
+			final String[] allowedClasses = getValueFromSettings("allowedListedClasses");
+			// </editor-fold>
+			// <editor-fold desc="Get information from attributes">
+			@Nonnull
+			final String fullMethodSignature = declaringTypeName + "." + methodName + methodSignature;
+			// </editor-fold>
+			// <editor-fold desc="Check callstack">
+			@Nullable
+			String fileSystemMethodToCheck = (restrictedPackage == null) ? null
+					: checkIfCallstackCriteriaIsViolated(restrictedPackage, allowedClasses, declaringTypeName,
+							methodName);
+			if (fileSystemMethodToCheck == null) {
+				return;
+			}
+			@Nullable
+			String studentCalledMethod = findFirstMethodOutsideOfRestrictedPackage(restrictedPackage);
+			// </editor-fold>
 
-		List<Map.Entry<String, Boolean>> actionsToValidate = deriveActionChecks(action, declaringTypeName, parameters);
-		for (Map.Entry<String, Boolean> actionCheck : actionsToValidate) {
-			checkFileSystemInteractionForAction(actionCheck.getKey(), Boolean.TRUE.equals(actionCheck.getValue()),
-					declaringTypeName, methodName, methodSignature, attributes, parameters, instance, restrictedPackage,
-					allowedClasses, fileSystemMethodToCheck, studentCalledMethod, fullMethodSignature);
+			List<Map.Entry<String, Boolean>> actionsToValidate = deriveActionChecks(action, declaringTypeName,
+					parameters);
+			for (Map.Entry<String, Boolean> actionCheck : actionsToValidate) {
+				checkFileSystemInteractionForAction(actionCheck.getKey(), Boolean.TRUE.equals(actionCheck.getValue()),
+						declaringTypeName, methodName, methodSignature, attributes, parameters, instance,
+						restrictedPackage, allowedClasses, fileSystemMethodToCheck, studentCalledMethod,
+						fullMethodSignature);
+			}
+		} finally {
+			exitAdvice();
 		}
 	}
 	// </editor-fold>

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
@@ -234,6 +234,7 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 			return target;
 		}
 		if (value instanceof InetSocketAddress inetSocketAddress) {
+			requireTrustedRuntimeType(value);
 			String host = inetSocketAddress.getHostString();
 			if (host == null || host.isBlank()) {
 				InetAddress address = inetSocketAddress.getAddress();
@@ -242,6 +243,7 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 			return new NetworkTarget(host, inetSocketAddress.getPort());
 		}
 		if (value instanceof SocketAddress socketAddress) {
+			requireTrustedRuntimeType(value);
 			String socketAddressAsString = socketAddress.toString();
 			int delimiter = socketAddressAsString.lastIndexOf(':');
 			if (delimiter > 0 && delimiter + 1 < socketAddressAsString.length()) {
@@ -260,6 +262,7 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 		try {
 			Class<?> httpRequestClass = Class.forName("java.net.http.HttpRequest", false, null);
 			if (httpRequestClass.isInstance(value)) {
+				requireTrustedRuntimeType(value);
 				Object uri = httpRequestClass.getMethod("uri").invoke(value);
 				return variableToTarget(uri);
 			}
@@ -277,9 +280,11 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 			return new NetworkTarget(url.getHost(), port >= 0 ? port : -1);
 		}
 		if (value instanceof URLConnection urlConnection) {
+			requireTrustedRuntimeType(value);
 			return variableToTarget(urlConnection.getURL());
 		}
 		if (value instanceof DatagramPacket datagramPacket) {
+			requireTrustedRuntimeType(value);
 			InetAddress address = datagramPacket.getAddress();
 			if (address != null && datagramPacket.getPort() > 0) {
 				return new NetworkTarget(address.getHostAddress(), datagramPacket.getPort());
@@ -287,12 +292,15 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 			return null;
 		}
 		if (value instanceof Socket socket) {
+			requireTrustedRuntimeType(value);
 			return extractSocketTarget(socket);
 		}
 		if (value instanceof DatagramSocket datagramSocket) {
+			requireTrustedRuntimeType(value);
 			return extractDatagramSocketTarget(datagramSocket);
 		}
 		if (value instanceof SocketChannel socketChannel) {
+			requireTrustedRuntimeType(value);
 			try {
 				return variableToTarget(socketChannel.getRemoteAddress());
 			} catch (Exception ignored) {
@@ -300,6 +308,7 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 			}
 		}
 		if (value instanceof DatagramChannel datagramChannel) {
+			requireTrustedRuntimeType(value);
 			try {
 				return variableToTarget(datagramChannel.getRemoteAddress());
 			} catch (Exception ignored) {
@@ -307,6 +316,7 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 			}
 		}
 		if (value instanceof InetAddress inetAddress) {
+			requireTrustedRuntimeType(value);
 			return new NetworkTarget(inetAddress.getHostAddress(), -1);
 		}
 		if (value instanceof String str) {
@@ -465,6 +475,7 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 			return new NetworkTarget(host, port);
 		}
 		if (hostCandidate instanceof InetAddress inetAddress) {
+			requireTrustedRuntimeType(hostCandidate);
 			return new NetworkTarget(inetAddress.getHostAddress(), port);
 		}
 		return null;
@@ -481,6 +492,7 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 		if (!(value instanceof Number number)) {
 			return null;
 		}
+		requireTrustedRuntimeType(value);
 		int port = number.intValue();
 		if (port < 0 || port > 65_535) {
 			return null;
@@ -845,6 +857,24 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	 * @author Kevin Fischer
 	 */
 	public static void checkNetworkSystemInteraction(@Nonnull String action, @Nonnull String declaringTypeName,
+			@Nonnull String methodName, @Nonnull String methodSignature, @Nullable Object[] attributes,
+			@Nullable Object[] parameters, @Nullable Object instance) {
+		// Re-entrancy guard: the advice body performs network/file work and stack walks
+		// that lazily load JDK classes; loading those re-enters the advice on the same
+		// thread, causing ClassCircularityError and unbounded recursion. Skip nested
+		// invocations (trusted Ares internals); enforce only the outermost one.
+		if (!enterAdvice()) {
+			return;
+		}
+		try {
+			checkNetworkSystemInteractionImpl(action, declaringTypeName, methodName, methodSignature, attributes,
+					parameters, instance);
+		} finally {
+			exitAdvice();
+		}
+	}
+
+	private static void checkNetworkSystemInteractionImpl(@Nonnull String action, @Nonnull String declaringTypeName,
 			@Nonnull String methodName, @Nonnull String methodSignature, @Nullable Object[] attributes,
 			@Nullable Object[] parameters, @Nullable Object instance) {
 		// <editor-fold desc="Get information from settings">

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceThreadSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceThreadSystemToolbox.java
@@ -556,6 +556,8 @@ public final class JavaInstrumentationAdviceThreadSystemToolbox extends JavaInst
 				collectThreadClassNames(Array.get(observedVariable, i), out);
 			}
 		} else if (observedVariable instanceof List<?>) {
+			// List is an interface; only iterate trusted JDK lists.
+			requireTrustedRuntimeType(observedVariable);
 			for (Object element : (List<?>) observedVariable) {
 				collectThreadClassNames(element, out);
 			}
@@ -592,6 +594,24 @@ public final class JavaInstrumentationAdviceThreadSystemToolbox extends JavaInst
 	 * @author Markus Paulsen
 	 */
 	public static void checkThreadSystemInteraction(@Nonnull String action, @Nonnull String declaringTypeName,
+			@Nonnull String methodName, @Nonnull String methodSignature, @Nullable Object[] attributes,
+			@Nullable Object[] parameters, @Nullable Object instance) {
+		// Re-entrancy guard: the advice body performs file work and stack walks that
+		// lazily load JDK classes; loading those re-enters the advice on the same
+		// thread, causing ClassCircularityError and unbounded recursion. Skip nested
+		// invocations (trusted Ares internals); enforce only the outermost one.
+		if (!enterAdvice()) {
+			return;
+		}
+		try {
+			checkThreadSystemInteractionImpl(action, declaringTypeName, methodName, methodSignature, attributes,
+					parameters, instance);
+		} finally {
+			exitAdvice();
+		}
+	}
+
+	private static void checkThreadSystemInteractionImpl(@Nonnull String action, @Nonnull String declaringTypeName,
 			@Nonnull String methodName, @Nonnull String methodSignature, @Nullable Object[] attributes,
 			@Nullable Object[] parameters, @Nullable Object instance) {
 		// <editor-fold desc="Get information from settings">


### PR DESCRIPTION
## Summary

Bumps the Ares project version from `2.0.1-Beta7` to `2.0.1-Beta8` in `pom.xml`.

## Changes

- **build (pom.xml)**: `<version>` raised from `2.0.1-Beta7` to `2.0.1-Beta8`.

## Rationale

Prepares the next Beta release. The canonical version is defined solely in `pom.xml`; Maven resolves the new coordinate cleanly (`project.version` evaluates to `2.0.1-Beta8`).

> Note: The README and `docs/` still reference `2.0.1-Beta6` (the last published release), so they were left untouched here as they are out of scope for a strict Beta7 to Beta8 bump. Worth a separate documentation pass once Beta8 is published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Incremented project version to Beta 8.
* **New Features**
  * Added stricter “trusted runtime type” validation for file system, network, and thread-related interceptions to reduce unsafe execution on untrusted runtime implementations.
* **Bug Fixes**
  * Prevented recursive advice/instrumentation execution with per-thread re-entrancy guards across command, file system, network, and thread checks to avoid infinite recursion and related failures.
* **Refactor**
  * Moved existing advice logic into guarded implementation helpers to ensure consistent re-entrancy handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->