### PR TITLE
Revert commons-io FileUtils.forceDelete test that breaks the suite on main

### DIFF
--- a/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/FileSystemAccessDeleteTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/FileSystemAccessDeleteTest.java
@@ -368,38 +368,6 @@ class FileSystemAccessDeleteTest extends SystemAccessTest {
 				ThirdPartyPackagePenguin.class);
 	}
 
-	/* -------------------------------------------------------------------- */
-	/* org.apache.commons.io.FileUtils.forceDelete (third-party wrapper) */
-	/* -------------------------------------------------------------------- */
-
-	@PublicTest
-	@Policy(value = ARCHUNIT_ASPECTJ_POLICY_ONE_PATH_ALLOWED_DELETE, withinPath = THIRD_PARTY_WITHIN_PATH)
-	void test_commonsIoForceDelete_archunit_aspectj() {
-		assertAresSecurityExceptionDelete(DeleteThirdPartyPackageMain::accessFileSystemViaCommonsIoForceDelete,
-				ThirdPartyPackagePenguin.class);
-	}
-
-	@PublicTest
-	@Policy(value = ARCHUNIT_INSTRUMENTATION_POLICY_ONE_PATH_ALLOWED_DELETE, withinPath = THIRD_PARTY_WITHIN_PATH)
-	void test_commonsIoForceDelete_archunit_instrumentation() {
-		assertAresSecurityExceptionDelete(DeleteThirdPartyPackageMain::accessFileSystemViaCommonsIoForceDelete,
-				ThirdPartyPackagePenguin.class);
-	}
-
-	@PublicTest
-	@Policy(value = WALA_ASPECTJ_POLICY_ONE_PATH_ALLOWED_DELETE, withinPath = THIRD_PARTY_WITHIN_PATH)
-	void test_commonsIoForceDelete_wala_aspectj() {
-		assertAresSecurityExceptionDelete(DeleteThirdPartyPackageMain::accessFileSystemViaCommonsIoForceDelete,
-				ThirdPartyPackagePenguin.class);
-	}
-
-	@PublicTest
-	@Policy(value = WALA_INSTRUMENTATION_POLICY_ONE_PATH_ALLOWED_DELETE, withinPath = THIRD_PARTY_WITHIN_PATH)
-	void test_commonsIoForceDelete_wala_instrumentation() {
-		assertAresSecurityExceptionDelete(DeleteThirdPartyPackageMain::accessFileSystemViaCommonsIoForceDelete,
-				ThirdPartyPackagePenguin.class);
-	}
-
 	@Disabled("This test is disabled because testing in this manner is not possible. FileSystemProvider.installedProviders() "
 			+ "gets a violation whule trying to access java.net.URL.openConnection().")
 	@PublicTest

--- a/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/delete/thirdPartyPackage/DeleteThirdPartyPackageMain.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/delete/thirdPartyPackage/DeleteThirdPartyPackageMain.java
@@ -18,12 +18,4 @@ public class DeleteThirdPartyPackageMain {
 	public static void accessFileSystemViaThirdPartyPackage() throws IOException {
 		ThirdPartyPackagePenguin.deleteFile();
 	}
-
-	/**
-	 * Access the file system using the {@link ThirdPartyPackagePenguin} class for
-	 * deletion through Apache Commons IO's {@code FileUtils.forceDelete}.
-	 */
-	public static void accessFileSystemViaCommonsIoForceDelete() throws IOException {
-		ThirdPartyPackagePenguin.deleteFileViaCommonsIo();
-	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/integration/testuser/subject/architectureTests/thirdpartypackage/ThirdPartyPackagePenguin.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/testuser/subject/architectureTests/thirdpartypackage/ThirdPartyPackagePenguin.java
@@ -1,11 +1,8 @@
 package de.tum.cit.ase.ares.integration.testuser.subject.architectureTests.thirdpartypackage;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import org.apache.commons.io.FileUtils;
 
 /**
  * This class is used to emulate a third-party package that is not part of the
@@ -38,17 +35,6 @@ public class ThirdPartyPackagePenguin {
 
 	public static void deleteFile() throws IOException {
 		Files.delete(Path.of(
-				"src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/delete/nottrusteddir/nottrusted.txt"));
-	}
-
-	/**
-	 * Deletes the not-trusted file through Apache Commons IO's
-	 * {@link FileUtils#forceDelete(File)}. The actual delete happens inside the
-	 * (non-woven) commons-io library, so this exercises the dedicated
-	 * {@code FileUtils.forceDelete} interception rather than a JDK delete call.
-	 */
-	public static void deleteFileViaCommonsIo() throws IOException {
-		FileUtils.forceDelete(new File(
 				"src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/subject/fileSystem/delete/nottrusteddir/nottrusted.txt"));
 	}
 }


### PR DESCRIPTION
## Summary

Reverts commit `88069e19` ("test(aop): add commons-io FileUtils.forceDelete forbidden delete case"), which broke the full test suite on `main`. `mvn install` / `mvn test` currently fail with roughly 25 failures and 805 errors (NoClassDefFound on subject classes plus WALA "bad file" IllegalArgument) across otherwise unrelated AOP integration tests. This revert restores the suite to **0 failures / 0 errors**.

## Changes

- **Revert (test)**: remove the 4 `commons-io FileUtils.forceDelete` cases in `FileSystemAccessDeleteTest`, the `accessFileSystemViaCommonsIoForceDelete` subject method in `DeleteThirdPartyPackageMain`, and the `deleteFileViaCommonsIo` / commons-io import in `ThirdPartyPackagePenguin` (3 files, 54 deletions).

## Rationale

The four cases load, weave and ByteBuddy-retransform the large `org.apache.commons.io.FileUtils` class. In the shared single test JVM (`forkCount=1`, `reuseForks=true`) this extra cumulative load tips the pre-existing WALA/ByteBuddy cross-test contamination over a threshold, cascading NoClassDefFound failures into ~800 unrelated AOP tests. The added cases pass in isolation and in small `-Dtest=` subsets, but make the full suite fail.

Bisection against the last green state confirmed this commit as the sole regressor:

| Commit | Full suite |
|--------|-----------|
| `a86d738f` (pre-merge baseline) | 2248 run, **0 / 0** ✅ |
| `efc23cef` (plugin bumps) | 0 / 0 ✅ |
| `0ad7e7b9` (test deps) | 0 / 0 ✅ |
| `1ebf82db` (aop null-allowedClasses) | 0 / 0 ✅ |
| **`88069e19`** (this revert's target) | **25 fail / 805 err** ❌ |

`commons-io` `provided` vs `compile` scope is irrelevant here (it is bundled in neither agent jar; the shade config excludes it either way).

Verified after revert: full `mvn install` → **2258 run, 0 failures, 0 errors, 266 skipped, BUILD SUCCESS**.

The `FileUtils.forceDelete` interception coverage should be reintroduced once the underlying shared-JVM contamination is addressed separately (it needs per-test JVM isolation or a WALA/ByteBuddy state reset).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed test coverage for Apache Commons IO FileUtils.forceDelete functionality. Updated test utilities to use only JDK-based filesystem deletion implementations, simplifying the test suite and reducing third-party wrapper dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->