### PR TITLE
Fix CI-red test failures: locale assertion + WALA cross-test contamination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,6 +467,16 @@
 				<version>3.5.6</version>
 				<configuration>
 					<forkCount>1</forkCount>
+					<!-- Start a fresh JVM for every test class instead of reusing one for the
+						whole suite. The WALA call-graph analysis accumulates global state across
+						test methods in a shared JVM; past a threshold this non-deterministically
+						makes WALA report zero violations for forbidden operations (parallelStream,
+						third-party deletes), so security meta-tests that expect a violation fail.
+						The effect is architecture-dependent (observed on x86_64 CI, not on local
+						arm64), which makes it impossible to reproduce reliably without process
+						isolation. A fresh JVM per class resets that global state, since each class
+						passes in isolation. -->
+					<reuseForks>false</reuseForks>
 					<!-- Kill (and report) a hung forked JVM rather than letting CI run until
 						the runner dies. 2400s sits above a legitimate full-suite run yet below
 						the 45-minute CI job timeout, so a real hang is caught with a report. -->

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/JavaWalaTestCaseCollectionTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/JavaWalaTestCaseCollectionTest.java
@@ -10,6 +10,7 @@ import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.lang.ArchRule;
 
+import de.tum.cit.ase.ares.api.localization.Messages;
 import de.tum.cit.ase.ares.api.policy.policySubComponents.PackagePermission;
 
 /**
@@ -28,10 +29,15 @@ public class JavaWalaTestCaseCollectionTest {
 		// Check if the cause is a SecurityException
 		Throwable cause = ex.getCause();
 		Assertions.assertTrue(cause instanceof SecurityException);
-		// Print actual message for debugging
-		System.out.println("Actual message: " + cause.getMessage());
-		Assertions.assertTrue(cause.getMessage().contains("utility.initialization")
-				|| cause.getMessage().contains("nicht instanziiert werden"));
+		// Compare against the localized message rather than a hard-coded German
+		// substring: the active locale on CI (English) differs from a German
+		// development machine, so a fixed-language check is environment-dependent.
+		// Recomputing the expected text through the same Messages mechanism keeps
+		// the assertion locale-independent while still proving it is the
+		// utility-initialization error for this class.
+		String expectedMessage = Messages.localized("security.general.utility.initialization",
+				JavaWalaTestCaseCollection.class.getSimpleName());
+		Assertions.assertEquals(expectedMessage, cause.getMessage());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fixes the test failures that keep CI red on `main` (independent of any code change): one locale-dependent assertion and the WALA cross-test contamination that makes architecture security meta-tests non-deterministically pass on local arm64 but fail on the x86_64 CI runner.

## Changes

- **test (locale)**: `JavaWalaTestCaseCollectionTest.constructor_ThrowsSecurityException` compared the SecurityException message against the German wording / the literal key. CI runs an English locale, so it failed there while passing on a German dev machine. Now it recomputes the expected message via the same `Messages` mechanism and compares for equality (locale-independent).
- **build (test isolation)**: set `reuseForks=false` so surefire starts a fresh JVM per test class. WALA's call-graph analysis accumulates global state across test methods in a shared JVM; past a threshold it non-deterministically reports zero violations for forbidden operations (`parallelStream`, third-party deletes), failing the meta-tests that expect a `SecurityException`. The effect is architecture-dependent (x86_64 CI, not local arm64). Each class passes in isolation, so a per-class JVM reset removes it. `forkCount` stays 1 to avoid parallel forks racing on the shared on-disk fixtures.

## Rationale / verification

- The locale fix is verified green on a Linux + Java 21 container.
- The contamination is the documented hardest blocker: it only appears after enough analyses accumulate in one JVM, and only on x86_64, so it cannot be reproduced on local arm64 (full suite is green there). Process isolation is the robust fix that does not depend on reproducing the exact ordering. CI on this PR is the faithful x86_64 verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by running each test class in a separate JVM for the fast profile
  * Enhanced security exception test assertions with localization support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->