### PR TITLE
ci: bump GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,14 +12,14 @@ on:
 jobs:
   build-and-test:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
## Summary

Updates the Maven CI workflow (`.github/workflows/maven.yml`) to current action majors:
- `runs-on`: `ubuntu-22.04` → `ubuntu-24.04`
- `actions/checkout`: `v4` → `v7`
- `actions/setup-java`: `v4` → `v5`

The `setup-java` step configuration (`java-version: '21'`, `distribution: 'temurin'`, `cache: 'maven'`) is unchanged and remains valid on v5.

## Supersedes
These manual bumps replace the open Renovate PRs, which can be closed once this merges:
- #109 (ubuntu v24)
- #108 (setup-java v5)
- #105 (checkout v7)