### PR TITLE
chore(renovate): pin jqwik, aspectj and exclude byte-buddy -jdk5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,28 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "net.jqwik:*"
+      ],
+      "allowedVersions": "<1.10.0",
+      "description": "Pinned to the newest 1.9.x. jqwik 1.10.x crashes Ares with ArrayIndexOutOfBoundsException in StoreRepository.streamAllStores under thread-spawning properties, and the 1.10.x line targets junit-platform 1.14 while Ares builds on junit-platform 6.x. Revisit once jqwik ships a JUnit 6 compatible release."
+    },
+    {
+      "matchPackageNames": [
+        "org.aspectj:*"
+      ],
+      "allowedVersions": "<=1.9.25.1",
+      "description": "Pinned at 1.9.25.1. The aspectjtools (ajc) Eclipse JDT compiler in this line regressed with an internal NullPointerException (SourceTypeBinding.resolveTypeFor) when weaving field-declaring anonymous classes; 1.9.25.1 is usable only because the affected tests were refactored. Do not let it drift further without re-verifying the weave."
+    },
+    {
+      "matchPackageNames": [
+        "net.bytebuddy:*"
+      ],
+      "allowedVersions": "!/-jdk5$/",
+      "description": "Exclude the -jdk5 (Java 5 bytecode) build variant. Renovate misreads the -jdk5 classifier as a newer version, but Ares targets Java 17/21 and must use the standard build."
+    }
   ]
 }


### PR DESCRIPTION
Stops Renovate from re-proposing dependency updates that break the build.

- `net.jqwik:*` → `<1.10.0` (1.10.x crashes with AIOOBE in `StoreRepository.streamAllStores` under thread-spawning properties; also targets junit-platform 1.14, not 6.x)
- `org.aspectj:*` → `<=1.9.25.1` (later ajc/JDT builds may reintroduce the weaving NPE on field-declaring anonymous classes)
- `net.bytebuddy:*` → exclude the `-jdk5` Java 5 bytecode variant (Ares targets Java 17/21)

Follow-up to closing #104, #81, #87.