### PR TITLE
fix: stabilise jqwik strict timeouts

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/internal/TimeoutUtils.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/internal/TimeoutUtils.java
@@ -85,17 +85,20 @@ public final class TimeoutUtils {
 		}
 	}
 
-	private static void terminateTimedOutExecution(Future<?> future, ExecutorService executorService,
+	static void terminateTimedOutExecution(Future<?> future, ExecutorService executorService,
 			Duration terminationGracePeriod, IntConsumer fatalProcessTerminator) {
+		executorService.shutdown();
 		future.cancel(true);
-		executorService.shutdownNow();
 		/*
-		 * Give interruption-aware code time to finish before the owning thread
-		 * continues. If it ignores interruption, the fork is already contaminated:
-		 * returning would let untrusted code outlive its security, IO and reporting
-		 * lifecycle and affect later tests in a reused JVM. Thread.stop() cannot repair
-		 * that safely or reliably, so fail closed by terminating the complete worker
-		 * process and let Maven, Gradle or the IDE report the crashed test fork.
+		 * Future.cancel(true) delivers the single interruption that asks the timed-out
+		 * execution to stop. Calling shutdownNow() here would interrupt the worker a
+		 * second time; that interruption can race with interruption-aware code leaving
+		 * its body. Give it time to finish before the owning thread continues. If it
+		 * ignores interruption, the fork is already contaminated: returning would let
+		 * untrusted code outlive its security, IO and reporting lifecycle and affect
+		 * later tests in a reused JVM. Thread.stop() cannot repair that safely or
+		 * reliably, so fail closed by terminating the complete worker process and let
+		 * Maven, Gradle or the IDE report the crashed test fork.
 		 */
 		if (!awaitTermination(executorService, terminationGracePeriod.toMillis())) {
 			fatalProcessTerminator.accept(UNRESPONSIVE_TIMEOUT_EXIT_CODE);

--- a/src/main/java/de/tum/cit/ase/ares/api/jqwik/JqwikContext.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/jqwik/JqwikContext.java
@@ -6,15 +6,15 @@ import java.util.Optional;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import net.jqwik.api.lifecycle.PropertyLifecycleContext;
+import net.jqwik.api.lifecycle.*;
 
 import de.tum.cit.ase.ares.api.context.*;
 
 @API(status = Status.INTERNAL)
 public class JqwikContext extends TestContext {
-	private final PropertyLifecycleContext lifecycleContext;
+	private final MethodLifecycleContext lifecycleContext;
 
-	JqwikContext(PropertyLifecycleContext lifecycleContext) {
+	JqwikContext(MethodLifecycleContext lifecycleContext) {
 		this.lifecycleContext = lifecycleContext;
 	}
 
@@ -44,10 +44,17 @@ public class JqwikContext extends TestContext {
 	}
 
 	public PropertyLifecycleContext getPropertyLifecycleContext() {
-		return lifecycleContext;
+		if (lifecycleContext instanceof PropertyLifecycleContext propertyLifecycleContext) {
+			return propertyLifecycleContext;
+		}
+		throw new IllegalStateException("This context represents a jqwik try, not a property"); //$NON-NLS-1$
 	}
 
 	public static JqwikContext of(PropertyLifecycleContext lifecycleContext) {
+		return new JqwikContext(lifecycleContext);
+	}
+
+	public static JqwikContext of(TryLifecycleContext lifecycleContext) {
 		return new JqwikContext(lifecycleContext);
 	}
 

--- a/src/main/java/de/tum/cit/ase/ares/api/jqwik/JqwikStrictTimeoutExtension.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/jqwik/JqwikStrictTimeoutExtension.java
@@ -1,6 +1,7 @@
 package de.tum.cit.ase.ares.api.jqwik;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -29,27 +30,28 @@ import de.tum.cit.ase.ares.api.internal.TimeoutUtils;
  * @author Christian Femers
  */
 @API(status = Status.MAINTAINED)
-public class JqwikStrictTimeoutExtension implements AroundPropertyHook {
+public class JqwikStrictTimeoutExtension implements AroundTryHook {
 	private static final Duration TERMINATION_GRACE_PERIOD = Duration.ofSeconds(1);
 
 	@Override
-	public int aroundPropertyProximity() {
+	public int aroundTryProximity() {
 		/*
-		 * Keep the timeout inside Ares's security, IO and reporting hooks. Their setup
-		 * and cleanup mutate engine-wide state and must remain on jqwik's owning
-		 * thread; only the actual property execution belongs on the timeout worker.
+		 * Keep the timeout inside jqwik's try lifecycle and Ares's security, IO and
+		 * reporting hooks. Their setup and cleanup mutate engine-wide state and must
+		 * remain on jqwik's owning thread; only one invocation of the property method
+		 * belongs on the timeout worker.
 		 */
 		return 40;
 	}
 
 	@Override
-	public PropertyExecutionResult aroundProperty(PropertyLifecycleContext context, PropertyExecutor property)
+	public TryExecutionResult aroundTry(TryLifecycleContext context, TryExecutor aTry, List<Object> parameters)
 			throws Throwable {
 		DomainContext domainContext = CurrentDomainContext.get();
 		TestDescriptor desc = CurrentTestDescriptor.get();
 		return TimeoutUtils.performTimeoutExecution(
 				() -> CurrentDomainContext.runWithContext(domainContext,
-						() -> CurrentTestDescriptor.runWithDescriptor(desc, property::execute)),
+						() -> CurrentTestDescriptor.runWithDescriptor(desc, () -> aTry.execute(parameters))),
 				JqwikContext.of(context), TERMINATION_GRACE_PERIOD);
 	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/api/internal/TimeoutUtilsTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/internal/TimeoutUtilsTest.java
@@ -2,22 +2,41 @@ package de.tum.cit.ase.ares.api.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.opentest4j.AssertionFailedError;
 
 import de.tum.cit.ase.ares.api.StrictTimeout;
 import de.tum.cit.ase.ares.api.context.TestContext;
 
 class TimeoutUtilsTest {
+	@Test
+	void timedOutExecutionUsesOneCancellationInterrupt() {
+		Future<?> future = mock(Future.class);
+		ExecutorService executorService = mock(ExecutorService.class);
+		when(executorService.isTerminated()).thenReturn(true);
+
+		TimeoutUtils.terminateTimedOutExecution(future, executorService, Duration.ofSeconds(1),
+				exitCode -> fail("Interruption-aware execution must not request fatal termination")); //$NON-NLS-1$
+
+		InOrder cancellationOrder = inOrder(executorService, future);
+		cancellationOrder.verify(executorService).shutdown();
+		cancellationOrder.verify(future).cancel(true);
+		verify(executorService, never()).shutdownNow();
+	}
 
 	@Test
 	void interruptionAwareExecutionFinishesBeforeControlReturns() throws Exception {

--- a/src/test/java/de/tum/cit/ase/ares/integration/JqwickTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/JqwickTest.java
@@ -36,6 +36,7 @@ class JqwickTest {
 	private final String provokeTimeoutSleepExample = "provokeTimeoutSleepExample";
 	private final String provokeTimeoutSleepProperty = "provokeTimeoutSleepProperty";
 	private final String provokeTimeoutSleepTries = "provokeTimeoutSleepTries";
+	private final String strictTimeoutAppliesPerTry = "strictTimeoutAppliesPerTry";
 	private final String testHiddenIncomplete = "testHiddenIncomplete";
 	private final String testLocaleDe = "testLocaleDe";
 	private final String testPublicIncomplete = "testPublicIncomplete";
@@ -123,6 +124,11 @@ class JqwickTest {
 	@TestTest
 	void test_provokeTimeoutSleepTries() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(provokeTimeoutSleepTries, AssertionFailedError.class));
+	}
+
+	@TestTest
+	void test_strictTimeoutAppliesPerTry() {
+		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(strictTimeoutAppliesPerTry));
 	}
 
 	@TestTest

--- a/src/test/java/de/tum/cit/ase/ares/integration/testuser/JqwickUser.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/testuser/JqwickUser.java
@@ -138,6 +138,13 @@ public class JqwickUser {
 		sleepUntilInterrupted();
 	}
 
+	@Public
+	@Property(tries = 5)
+	@StrictTimeout(value = 250, unit = TimeUnit.MILLISECONDS)
+	void strictTimeoutAppliesPerTry(@SuppressWarnings("unused") @ForAll int x) throws InterruptedException {
+		Thread.sleep(100);
+	}
+
 	private void sleepUntilInterrupted() throws InterruptedException {
 		try {
 			Thread.sleep(300);


### PR DESCRIPTION
## Summary

- enforce `@StrictTimeout` around each jqwik try instead of the complete property lifecycle
- keep jqwik lifecycle and store finalisation on the owning engine thread
- use one cancellation interrupt before waiting for timeout-worker termination
- add regression coverage for per-try timeout semantics

## Root cause

The timeout extension wrapped jqwik's complete `PropertyExecutor` in a worker thread. When a timed property was interrupted, jqwik could still be running lifecycle or clean-up work on that worker. The one-second termination grace period then expired and correctly halted the contaminated Surefire fork with exit code 124. This produced the intermittent failure observed in the integration job for #118, although the dependency update itself was unrelated.

## Impact

Timed-out property invocations still fail pre-emptively, while jqwik lifecycle clean-up remains on the engine thread. A property with several individually valid tries no longer incorrectly shares one aggregate strict-timeout budget.

## Validation

- 12 consecutive runs of `mvn test -f pom.xml -Dtest=de.tum.cit.ase.ares.integration.JqwickTest`
- `mvn test -Punit-core-tests -f pom.xml`
- `mvn test -Pintegration-core-tests -f pom.xml`
- `mvn spotless:check checkstyle:check pmd:check`
- `mvn spotbugs:check`

Local validation used Java 17; CI will additionally validate Java 21.
