### PR TITLE
Version and validate security policy values

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJCommandSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJCommandSystemAdviceDefinitions.aj
@@ -130,7 +130,8 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 	 * Checks whether an actual command name matches an allowed command name.
 	 * <p>
 	 * Description: Returns {@code false} if either value is null. Otherwise
-	 * performs an exact string equality check.
+	 * performs an exact string equality check, except that {@code *} permits every
+	 * command.
 	 *
 	 * @param actualCommand  the command name from the intercepted call; may be null
 	 * @param allowedCommand the command name from the security policy; may be null
@@ -142,7 +143,7 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 		if (actualCommand == null || allowedCommand == null) {
 			return false;
 		}
-		return allowedCommand.equals(actualCommand);
+		return "*".equals(allowedCommand) || allowedCommand.equals(actualCommand);
 	}
 
 	/**
@@ -154,7 +155,8 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 	 * path-separator boundary, so a relative path in the policy matches an absolute
 	 * path at runtime. Substring ("contains") matching is intentionally NOT used: it
 	 * would let a student append arbitrary content to an allowed argument and defeat
-	 * argument pinning.
+	 * argument pinning. A sole {@code *} permits every argument list; otherwise
+	 * {@code *} permits any one argument at its declared position.
 	 *
 	 * @param allowedArguments the allowed arguments from policy
 	 * @param actualArguments  the actual arguments from the command
@@ -163,6 +165,9 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 	 * @author Markus Paulsen
 	 */
 	private static boolean argumentsMatch(@Nullable String[] allowedArguments, @Nullable String[] actualArguments) {
+		if (allowedArguments != null && allowedArguments.length == 1 && "*".equals(allowedArguments[0])) {
+			return true;
+		}
 		if (allowedArguments == null && actualArguments == null) {
 			return true;
 		}
@@ -177,6 +182,9 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 			String allowed = allowedArguments[i];
 			@Nonnull
 			String actual = actualArguments[i];
+			if ("*".equals(allowed)) {
+				continue;
+			}
 			// Exact match
 			if (allowed.equals(actual)) {
 				continue;

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJFileSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJFileSystemAdviceDefinitions.aj
@@ -186,6 +186,11 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 		if (allowedPathsAsStrings == null || allowedPathsAsStrings.length == 0) {
 			return true;
 		}
+		for (String allowedPath : allowedPathsAsStrings) {
+			if ("*".equals(allowedPath)) {
+				return false;
+			}
+		}
 
 		// SECURITY: Resolve symlinks FIRST to get the canonical path before any checks.
 		// This prevents TOCTOU attacks where symlinks could be manipulated between

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJNetworkSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJNetworkSystemAdviceDefinitions.aj
@@ -73,7 +73,7 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 	 * @param target       the resolved network target to evaluate; may be null
 	 * @param allowedHosts parallel array of allowed hostname patterns; the wildcard
 	 *                     {@code "*"} matches any host
-	 * @param allowedPorts parallel array of allowed port numbers; {@code -1}
+	 * @param allowedPorts parallel array of allowed port numbers; {@code 0}
 	 *                     matches any port
 	 * @return {@code true} if the target is forbidden; {@code false} if it is
 	 *         explicitly allowed
@@ -145,12 +145,12 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 	/**
 	 * Checks whether an actual port number matches an allowed port.
 	 * <p>
-	 * Description: A value of {@code -1} for {@code allowedPort} acts as a wildcard
+	 * Description: A value of {@code 0} for {@code allowedPort} acts as a wildcard
 	 * that permits any port number. Otherwise performs an exact integer equality
 	 * check.
 	 *
 	 * @param actualPort  the port resolved from the intercepted call
-	 * @param allowedPort the port from the security policy; {@code -1} means any
+	 * @param allowedPort the port from the security policy; {@code 0} means any
 	 *                    port is permitted
 	 * @return {@code true} if the actual port is permitted by the policy
 	 * @since 2.0.0

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceCommandSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceCommandSystemToolbox.java
@@ -126,7 +126,8 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 	 * Checks whether an actual command name matches an allowed command name.
 	 * <p>
 	 * Description: Returns {@code false} if either value is null. Otherwise
-	 * performs an exact string equality check.
+	 * performs an exact string equality check, except that {@code *} permits every
+	 * command.
 	 *
 	 * @param actualCommand  the command name from the intercepted call; may be null
 	 * @param allowedCommand the command name from the security policy; may be null
@@ -138,7 +139,7 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 		if (actualCommand == null || allowedCommand == null) {
 			return false;
 		}
-		return allowedCommand.equals(actualCommand);
+		return "*".equals(allowedCommand) || allowedCommand.equals(actualCommand);
 	}
 
 	/**
@@ -150,7 +151,8 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 	 * path-separator boundary, so a relative path in the policy matches an absolute
 	 * path at runtime. Substring ("contains") matching is intentionally NOT used:
 	 * it would let a student append arbitrary content to an allowed argument and
-	 * defeat argument pinning.
+	 * defeat argument pinning. A sole {@code *} permits every argument list;
+	 * otherwise {@code *} permits any one argument at its declared position.
 	 *
 	 * @param allowedArguments the allowed arguments from policy
 	 * @param actualArguments  the actual arguments from the command
@@ -159,6 +161,9 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 	 * @author Markus Paulsen
 	 */
 	private static boolean argumentsMatch(@Nullable String[] allowedArguments, @Nullable String[] actualArguments) {
+		if (allowedArguments != null && allowedArguments.length == 1 && "*".equals(allowedArguments[0])) {
+			return true;
+		}
 		if (allowedArguments == null && actualArguments == null) {
 			return true;
 		}
@@ -173,6 +178,9 @@ public final class JavaInstrumentationAdviceCommandSystemToolbox extends JavaIns
 			String allowed = allowedArguments[i];
 			@Nonnull
 			String actual = actualArguments[i];
+			if ("*".equals(allowed)) {
+				continue;
+			}
 			// Exact match
 			if (allowed.equals(actual)) {
 				continue;

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceFileSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceFileSystemToolbox.java
@@ -204,6 +204,11 @@ public final class JavaInstrumentationAdviceFileSystemToolbox extends JavaInstru
 		if (allowedPathsAsStrings == null || allowedPathsAsStrings.length == 0) {
 			return true;
 		}
+		for (String allowedPath : allowedPathsAsStrings) {
+			if ("*".equals(allowedPath)) {
+				return false;
+			}
+		}
 
 		// SECURITY: Resolve symlinks FIRST to get the canonical path before any checks.
 		// This prevents TOCTOU attacks where symlinks could be manipulated between

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
@@ -108,8 +108,8 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	 * @param target       the resolved network target to evaluate; may be null
 	 * @param allowedHosts parallel array of allowed hostname patterns; the wildcard
 	 *                     {@code "*"} matches any host
-	 * @param allowedPorts parallel array of allowed port numbers; {@code -1}
-	 *                     matches any port
+	 * @param allowedPorts parallel array of allowed port numbers; {@code 0} matches
+	 *                     any port
 	 * @return {@code true} if the target is forbidden; {@code false} if it is
 	 *         explicitly allowed
 	 * @since 2.0.0
@@ -184,12 +184,12 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 	/**
 	 * Checks whether an actual port number matches an allowed port.
 	 * <p>
-	 * Description: A value of {@code -1} for {@code allowedPort} acts as a wildcard
+	 * Description: A value of {@code 0} for {@code allowedPort} acts as a wildcard
 	 * that permits any port number. Otherwise performs an exact integer equality
 	 * check.
 	 *
 	 * @param actualPort  the port resolved from the intercepted call
-	 * @param allowedPort the port from the security policy; {@code -1} means any
+	 * @param allowedPort the port from the security policy; {@code 0} means any
 	 *                    port is permitted
 	 * @return {@code true} if the actual port is permitted by the policy
 	 * @since 2.0.0

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/archunit/JavaArchunitTestCaseCollection.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/archunit/JavaArchunitTestCaseCollection.java
@@ -217,6 +217,9 @@ public final class JavaArchunitTestCaseCollection {
 						String packageName = javaClass.getPackageName();
 						return allowedPackages.stream().noneMatch(allowedPackage -> {
 							String allowed = allowedPackage.importTheFollowingPackage();
+							if ("*".equals(allowed)) {
+								return true;
+							}
 							// Trailing-dot tolerant, boundary-aware match: a bare startsWith would
 							// let allowed "com.foo" also cover the unrelated package "com.foobar".
 							String normalizedAllowed = allowed.endsWith(".")

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/SecurityPolicy.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/SecurityPolicy.java
@@ -37,6 +37,7 @@ import de.tum.cit.ase.ares.api.policy.policySubComponents.SupervisedCode;
 public record SecurityPolicy(int thisPolicyFileCompliesToThePolicyVersion,
 		@Nonnull SupervisedCode regardingTheSupervisedCode) {
 
+	/** The policy-format version supported by this Ares release. */
 	public static final int CURRENT_POLICY_VERSION = 1;
 
 	/**
@@ -105,6 +106,15 @@ public record SecurityPolicy(int thisPolicyFileCompliesToThePolicyVersion,
 		@Nullable
 		private SupervisedCode regardingTheSupervisedCode;
 
+		/**
+		 * Sets the policy-format version declared by the policy file.
+		 *
+		 * @param thisPolicyFileCompliesToThePolicyVersion the declared policy-format
+		 *                                                 version
+		 * @return this builder
+		 * @since 2.0.0
+		 * @author Markus Paulsen
+		 */
 		@Nonnull
 		public Builder thisPolicyFileCompliesToThePolicyVersion(int thisPolicyFileCompliesToThePolicyVersion) {
 			this.thisPolicyFileCompliesToThePolicyVersion = thisPolicyFileCompliesToThePolicyVersion;

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/SecurityPolicy.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/SecurityPolicy.java
@@ -27,11 +27,17 @@ import de.tum.cit.ase.ares.api.policy.policySubComponents.SupervisedCode;
  *
  * @since 2.0.0
  * @author Markus Paulsen
- * @param regardingTheSupervisedCode the details of the supervised code; must
- *                                   not be null.
+ * @param thisPolicyFileCompliesToThePolicyVersion the policy format version;
+ *                                                 must be exactly
+ *                                                 {@value #CURRENT_POLICY_VERSION}.
+ * @param regardingTheSupervisedCode               the details of the supervised
+ *                                                 code; must not be null.
  */
 @SuppressWarnings("unused")
-public record SecurityPolicy(@Nonnull SupervisedCode regardingTheSupervisedCode) {
+public record SecurityPolicy(int thisPolicyFileCompliesToThePolicyVersion,
+		@Nonnull SupervisedCode regardingTheSupervisedCode) {
+
+	public static final int CURRENT_POLICY_VERSION = 1;
 
 	/**
 	 * Constructs a SecurityPolicy instance with validated supervised code.
@@ -40,6 +46,10 @@ public record SecurityPolicy(@Nonnull SupervisedCode regardingTheSupervisedCode)
 	 * @author Markus Paulsen
 	 */
 	public SecurityPolicy {
+		if (thisPolicyFileCompliesToThePolicyVersion != CURRENT_POLICY_VERSION) {
+			throw new IllegalArgumentException(
+					"thisPolicyFileCompliesToThePolicyVersion must be exactly " + CURRENT_POLICY_VERSION);
+		}
 		Objects.requireNonNull(regardingTheSupervisedCode, "regardingTheSupervisedCode must not be null");
 	}
 
@@ -87,11 +97,19 @@ public record SecurityPolicy(@Nonnull SupervisedCode regardingTheSupervisedCode)
 	 */
 	public static class Builder {
 
+		private int thisPolicyFileCompliesToThePolicyVersion = CURRENT_POLICY_VERSION;
+
 		/**
 		 * The supervised code for the SecurityPolicy.
 		 */
 		@Nullable
 		private SupervisedCode regardingTheSupervisedCode;
+
+		@Nonnull
+		public Builder thisPolicyFileCompliesToThePolicyVersion(int thisPolicyFileCompliesToThePolicyVersion) {
+			this.thisPolicyFileCompliesToThePolicyVersion = thisPolicyFileCompliesToThePolicyVersion;
+			return this;
+		}
 
 		/**
 		 * Sets the supervised code for the SecurityPolicy.
@@ -117,7 +135,7 @@ public record SecurityPolicy(@Nonnull SupervisedCode regardingTheSupervisedCode)
 		 */
 		@Nonnull
 		public SecurityPolicy build() {
-			return new SecurityPolicy(
+			return new SecurityPolicy(thisPolicyFileCompliesToThePolicyVersion,
 					Objects.requireNonNull(regardingTheSupervisedCode, "regardingTheSupervisedCode must not be null"));
 		}
 	}

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/CommandPermission.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/CommandPermission.java
@@ -23,10 +23,12 @@ import de.tum.cit.ase.ares.api.localization.Messages;
  *
  * @since 2.0.0
  * @author Markus Paulsen
- * @param executeTheCommand  the command that is permitted to be executed; must
- *                           not be null.
- * @param withTheseArguments the predefined arguments for the command; must not
- *                           be null.
+ * @param executeTheCommand  the command that is permitted to be executed, or
+ *                           {@code *} for every command; must not be null.
+ * @param withTheseArguments the predefined arguments for the command. A sole
+ *                           {@code *} permits every argument list; within a
+ *                           longer list it permits any one argument at that
+ *                           position. Must not be null.
  */
 @SuppressWarnings("unused")
 public record CommandPermission(@Nonnull String executeTheCommand, @Nonnull List<String> withTheseArguments) {

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/FilePermission.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/FilePermission.java
@@ -5,8 +5,6 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import de.tum.cit.ase.ares.api.localization.Messages;
-
 /**
  * Allowed file operations.
  * <p>
@@ -23,8 +21,8 @@ import de.tum.cit.ase.ares.api.localization.Messages;
  * @param createAllFiles             whether creating files is permitted.
  * @param executeAllFiles            whether executing all files is permitted.
  * @param deleteAllFiles             whether deleting all files is permitted.
- * @param onThisPathAndAllPathsBelow the path where these permissions apply;
- *                                   must not be null.
+ * @param onThisPathAndAllPathsBelow the path where these permissions apply, or
+ *                                   {@code *} for every path; must not be null.
  */
 public record FilePermission(@Nonnull String onThisPathAndAllPathsBelow, boolean readAllFiles,
 		boolean overwriteAllFiles, boolean createAllFiles, boolean executeAllFiles, boolean deleteAllFiles) {
@@ -37,9 +35,8 @@ public record FilePermission(@Nonnull String onThisPathAndAllPathsBelow, boolean
 	 */
 	public FilePermission {
 		Objects.requireNonNull(onThisPathAndAllPathsBelow, "onThisPathAndAllPathsBelow must not be null");
-		if (onThisPathAndAllPathsBelow.isBlank()) {
-			throw new IllegalArgumentException(Messages.localized("policy.permission.file.path.blank"));
-		}
+		PolicyValueValidator.requireMatch("onThisPathAndAllPathsBelow", onThisPathAndAllPathsBelow,
+				PolicyValueValidator.FILE_PATH_PATTERN);
 	}
 
 	/**

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/NetworkPermission.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/NetworkPermission.java
@@ -23,7 +23,8 @@ import de.tum.cit.ase.ares.api.localization.Messages;
  * @param receiveData     whether receiving data is permitted.
  * @param onTheHost       the host where these operations are permitted; must
  *                        not be null.
- * @param onThePort       the port number where these operations are permitted.
+ * @param onThePort       the port number where these operations are permitted;
+ *                        {@code 0} permits every port.
  */
 public record NetworkPermission(@Nonnull String onTheHost, int onThePort, boolean openConnections, boolean sendData,
 		boolean receiveData) {
@@ -36,9 +37,7 @@ public record NetworkPermission(@Nonnull String onTheHost, int onThePort, boolea
 	 */
 	public NetworkPermission {
 		Objects.requireNonNull(onTheHost, "onTheHost must not be null");
-		if (onTheHost.isBlank()) {
-			throw new IllegalArgumentException(Messages.localized("policy.permission.network.host.blank"));
-		}
+		PolicyValueValidator.requireMatch("onTheHost", onTheHost, PolicyValueValidator.HOST_PATTERN);
 		if (onThePort < 0 || onThePort > 65535) {
 			throw new IllegalArgumentException(Messages.localized("policy.permission.network.port.invalid"));
 		}

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PackagePermission.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PackagePermission.java
@@ -5,8 +5,6 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import de.tum.cit.ase.ares.api.localization.Messages;
-
 /**
  * Allowed package import.
  * <p>
@@ -18,7 +16,8 @@ import de.tum.cit.ase.ares.api.localization.Messages;
  * @since 2.0.0
  * @author Markus Paulsen
  * @param importTheFollowingPackage the package that is permitted to be
- *                                  imported; must not be null.
+ *                                  imported, or {@code *} for every package;
+ *                                  must not be null.
  */
 public record PackagePermission(@Nonnull String importTheFollowingPackage) {
 
@@ -30,9 +29,7 @@ public record PackagePermission(@Nonnull String importTheFollowingPackage) {
 	 */
 	public PackagePermission {
 		Objects.requireNonNull(importTheFollowingPackage, "Package name must not be null");
-		if (importTheFollowingPackage.isBlank()) {
-			throw new IllegalArgumentException(Messages.localized("policy.permission.package.blank"));
-		}
+		PolicyValueValidator.requirePackageImport(importTheFollowingPackage);
 	}
 
 	/**

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueValidator.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueValidator.java
@@ -5,6 +5,8 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import de.tum.cit.ase.ares.api.localization.Messages;
+
 /** Regular expressions and helpers for validating security-policy values. */
 public final class PolicyValueValidator {
 
@@ -30,36 +32,80 @@ public final class PolicyValueValidator {
 			+ DNS_LABEL + ")*\\.?";
 	private static final String RECOGNISED_PLACEHOLDER = "\\$\\{(?:PROJECT_ROOT|java\\.home|user\\.home|java\\.io\\.tmpdir)\\}";
 
+	/** Matches the complete supported programming-language configuration format. */
 	public static final Pattern PROGRAMMING_LANGUAGE_CONFIGURATION_PATTERN = Pattern
 			.compile("^JAVA_USING_(?:MAVEN|GRADLE)_(?:ARCHUNIT|WALA)_AND_(?:ASPECTJ|INSTRUMENTATION)$");
+
+	/** Matches a dot-separated Java package name. */
 	public static final Pattern JAVA_PACKAGE_PATTERN = Pattern.compile("^" + JAVA_QUALIFIED_IDENTIFIER + "$");
+
+	/** Matches a single Java type name. */
 	public static final Pattern JAVA_CLASS_NAME_PATTERN = Pattern.compile("^" + JAVA_TYPE_IDENTIFIER + "$");
+
+	/** Matches a fully qualified Java class name. */
 	public static final Pattern JAVA_CLASS_PATH_PATTERN = Pattern.compile("^" + JAVA_CLASS_PATH + "$");
+
+	/**
+	 * Matches a supported file path, recognised placeholder expression, or
+	 * wildcard.
+	 */
 	public static final Pattern FILE_PATH_PATTERN = Pattern.compile(
 			"^(?:\\*|(?=.+$)(?=.*\\S)(?:(?:" + RECOGNISED_PLACEHOLDER + ")|(?!\\$\\{)[^*\\x00])+)$", Pattern.DOTALL);
+
+	/** Matches a DNS name, IP address, localhost, or host wildcard. */
 	public static final Pattern HOST_PATTERN = Pattern
 			.compile("^(?:\\*|localhost|" + IPV4_ADDRESS + "|" + IPV6_ADDRESS + "|" + DNS_NAME + ")$");
+
+	/** Matches a Java class path or one of the supported special thread tokens. */
 	public static final Pattern THREAD_CLASS_PATTERN = Pattern.compile("^(?:" + JAVA_CLASS_PATH
 			+ "|\\*|Lambda-Expression|<implicit-thread-op:(?:parallelStream|parallel|Thread\\.sleep|SubmissionPublisher\\.(?:submit|offer))>)$");
 
 	private PolicyValueValidator() {
-		throw new UnsupportedOperationException("PolicyValueValidator is a utility class");
+		throw new SecurityException(
+				Messages.localized("security.general.utility.initialization", "PolicyValueValidator"));
 	}
 
+	/**
+	 * Tests whether a nullable value fully matches a validation pattern.
+	 *
+	 * @param value   the value to test; may be {@code null}
+	 * @param pattern the validation pattern
+	 * @return {@code true} when the value is non-null and fully matches the pattern
+	 */
 	public static boolean matches(@Nullable String value, @Nonnull Pattern pattern) {
 		return value != null && pattern.matcher(value).matches();
 	}
 
+	/**
+	 * Tests whether a value is a Java package name or the package wildcard.
+	 *
+	 * @param value the package import value; may be {@code null}
+	 * @return {@code true} when the value is a valid package import
+	 */
 	public static boolean matchesPackageImport(@Nullable String value) {
 		return "*".equals(value) || matches(value, JAVA_PACKAGE_PATTERN);
 	}
 
+	/**
+	 * Requires a nullable value to fully match a validation pattern.
+	 *
+	 * @param field   the policy-field name used in the failure message
+	 * @param value   the value to validate; may be {@code null}
+	 * @param pattern the required validation pattern
+	 * @throws IllegalArgumentException if the value does not match the pattern
+	 */
 	public static void requireMatch(@Nonnull String field, @Nullable String value, @Nonnull Pattern pattern) {
 		if (!matches(value, pattern)) {
 			throw new IllegalArgumentException(field + " does not match " + pattern.pattern());
 		}
 	}
 
+	/**
+	 * Requires a value to be a Java package name or the package wildcard.
+	 *
+	 * @param value the package import value; may be {@code null}
+	 * @throws IllegalArgumentException if the value is not a valid package import
+	 */
 	public static void requirePackageImport(@Nullable String value) {
 		if (!matchesPackageImport(value)) {
 			throw new IllegalArgumentException(

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueValidator.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueValidator.java
@@ -49,8 +49,9 @@ public final class PolicyValueValidator {
 	 * Matches a supported file path, recognised placeholder expression, or
 	 * wildcard.
 	 */
-	public static final Pattern FILE_PATH_PATTERN = Pattern.compile(
-			"^(?:\\*|(?=.+$)(?=.*\\S)(?:(?:" + RECOGNISED_PLACEHOLDER + ")|(?!\\$\\{)[^*\\x00])+)$", Pattern.DOTALL);
+	public static final Pattern FILE_PATH_PATTERN = Pattern
+			.compile("^(?:\\*|(?=.+$)(?=.*\\S)(?!(?:.*[\\\\/])?\\.\\.(?:[\\\\/]|$))(?:(?:" + RECOGNISED_PLACEHOLDER
+					+ ")|(?!\\$\\{)[^*\\x00])+)$", Pattern.DOTALL);
 
 	/** Matches a DNS name, IP address, localhost, or host wildcard. */
 	public static final Pattern HOST_PATTERN = Pattern

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueValidator.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueValidator.java
@@ -1,0 +1,69 @@
+package de.tum.cit.ase.ares.api.policy.policySubComponents;
+
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Regular expressions and helpers for validating security-policy values. */
+public final class PolicyValueValidator {
+
+	private static final String JAVA_RESERVED_WORD = "abstract|assert|boolean|break|byte|case|catch|char|class|const|continue|default|do|double|else|enum|extends|false|final|finally|float|for|goto|if|implements|import|instanceof|int|interface|long|native|new|null|package|private|protected|public|return|short|static|strictfp|super|switch|synchronized|this|throw|throws|transient|true|try|void|volatile|while|_";
+	private static final String JAVA_IDENTIFIER = "(?!(?:" + JAVA_RESERVED_WORD
+			+ ")(?=\\.|$))\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
+	private static final String JAVA_TYPE_IDENTIFIER = "(?!(?:var|yield|record|sealed|permits)$)" + JAVA_IDENTIFIER;
+	private static final String JAVA_QUALIFIED_IDENTIFIER = JAVA_IDENTIFIER + "(?:\\." + JAVA_IDENTIFIER + ")*";
+	private static final String JAVA_CLASS_PATH = "(?:" + JAVA_IDENTIFIER + "\\.)*" + JAVA_TYPE_IDENTIFIER;
+	private static final String IPV4_COMPONENT = "(?:25[0-5]|2[0-4]\\d|1\\d{2}|[1-9]?\\d)";
+	private static final String IPV4_ADDRESS = "(?:" + IPV4_COMPONENT + "\\.){3}" + IPV4_COMPONENT;
+	private static final String IPV6_COMPONENT = "[0-9A-Fa-f]{1,4}";
+	private static final String IPV6_ADDRESS = "(?:" + "(?:" + IPV6_COMPONENT + ":){7}" + IPV6_COMPONENT + "|(?:"
+			+ IPV6_COMPONENT + ":){1,7}:" + "|(?:" + IPV6_COMPONENT + ":){1,6}:" + IPV6_COMPONENT + "|(?:"
+			+ IPV6_COMPONENT + ":){1,5}(?::" + IPV6_COMPONENT + "){1,2}" + "|(?:" + IPV6_COMPONENT + ":){1,4}(?::"
+			+ IPV6_COMPONENT + "){1,3}" + "|(?:" + IPV6_COMPONENT + ":){1,3}(?::" + IPV6_COMPONENT + "){1,4}" + "|(?:"
+			+ IPV6_COMPONENT + ":){1,2}(?::" + IPV6_COMPONENT + "){1,5}" + "|" + IPV6_COMPONENT + ":(?:(?::"
+			+ IPV6_COMPONENT + "){1,6})" + "|:(?:(?::" + IPV6_COMPONENT + "){1,7}|:)" + "|(?:" + IPV6_COMPONENT
+			+ ":){6}" + IPV4_ADDRESS + "|::(?:ffff(?::0{1,4})?:)?" + IPV4_ADDRESS + "|(?:" + IPV6_COMPONENT + ":){1,4}:"
+			+ IPV4_ADDRESS + ")";
+	private static final String DNS_LABEL = "[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?";
+	private static final String DNS_NAME = "(?!\\d+\\.\\d+\\.\\d+\\.\\d+\\.?$)(?=.{1,253}\\.?$)" + DNS_LABEL + "(?:\\."
+			+ DNS_LABEL + ")*\\.?";
+	private static final String RECOGNISED_PLACEHOLDER = "\\$\\{(?:PROJECT_ROOT|java\\.home|user\\.home|java\\.io\\.tmpdir)\\}";
+
+	public static final Pattern PROGRAMMING_LANGUAGE_CONFIGURATION_PATTERN = Pattern
+			.compile("^JAVA_USING_(?:MAVEN|GRADLE)_(?:ARCHUNIT|WALA)_AND_(?:ASPECTJ|INSTRUMENTATION)$");
+	public static final Pattern JAVA_PACKAGE_PATTERN = Pattern.compile("^" + JAVA_QUALIFIED_IDENTIFIER + "$");
+	public static final Pattern JAVA_CLASS_NAME_PATTERN = Pattern.compile("^" + JAVA_TYPE_IDENTIFIER + "$");
+	public static final Pattern JAVA_CLASS_PATH_PATTERN = Pattern.compile("^" + JAVA_CLASS_PATH + "$");
+	public static final Pattern FILE_PATH_PATTERN = Pattern.compile(
+			"^(?:\\*|(?=.+$)(?=.*\\S)(?:(?:" + RECOGNISED_PLACEHOLDER + ")|(?!\\$\\{)[^*\\x00])+)$", Pattern.DOTALL);
+	public static final Pattern HOST_PATTERN = Pattern
+			.compile("^(?:\\*|localhost|" + IPV4_ADDRESS + "|" + IPV6_ADDRESS + "|" + DNS_NAME + ")$");
+	public static final Pattern THREAD_CLASS_PATTERN = Pattern.compile("^(?:" + JAVA_CLASS_PATH
+			+ "|\\*|Lambda-Expression|<implicit-thread-op:(?:parallelStream|parallel|Thread\\.sleep|SubmissionPublisher\\.(?:submit|offer))>)$");
+
+	private PolicyValueValidator() {
+		throw new UnsupportedOperationException("PolicyValueValidator is a utility class");
+	}
+
+	public static boolean matches(@Nullable String value, @Nonnull Pattern pattern) {
+		return value != null && pattern.matcher(value).matches();
+	}
+
+	public static boolean matchesPackageImport(@Nullable String value) {
+		return "*".equals(value) || matches(value, JAVA_PACKAGE_PATTERN);
+	}
+
+	public static void requireMatch(@Nonnull String field, @Nullable String value, @Nonnull Pattern pattern) {
+		if (!matches(value, pattern)) {
+			throw new IllegalArgumentException(field + " does not match " + pattern.pattern());
+		}
+	}
+
+	public static void requirePackageImport(@Nullable String value) {
+		if (!matchesPackageImport(value)) {
+			throw new IllegalArgumentException(
+					"importTheFollowingPackage does not match " + JAVA_PACKAGE_PATTERN.pattern() + " or *");
+		}
+	}
+}

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/SupervisedCode.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/SupervisedCode.java
@@ -53,12 +53,19 @@ public record SupervisedCode(
 	public SupervisedCode {
 		Objects.requireNonNull(theFollowingProgrammingLanguageConfigurationIsUsed,
 				"ProgrammingLanguageConfiguration must not be null");
+		if (theSupervisedCodeUsesTheFollowingPackage != null) {
+			PolicyValueValidator.requireMatch("theSupervisedCodeUsesTheFollowingPackage",
+					theSupervisedCodeUsesTheFollowingPackage, PolicyValueValidator.JAVA_PACKAGE_PATTERN);
+		}
+		if (theMainClassInsideThisPackageIs != null) {
+			PolicyValueValidator.requireMatch("theMainClassInsideThisPackageIs", theMainClassInsideThisPackageIs,
+					PolicyValueValidator.JAVA_CLASS_NAME_PATTERN);
+		}
 		Objects.requireNonNull(theFollowingClassesAreTestClasses, "Test classes list must not be null");
 		for (String testClass : theFollowingClassesAreTestClasses) {
 			Objects.requireNonNull(testClass, "Test class entries must not be null");
-			if (testClass.isBlank()) {
-				throw new IllegalArgumentException("Test class entries must not be blank");
-			}
+			PolicyValueValidator.requireMatch("theFollowingClassesAreTestClasses entry", testClass,
+					PolicyValueValidator.JAVA_CLASS_PATH_PATTERN);
 		}
 		Objects.requireNonNull(theFollowingResourceAccessesArePermitted, "ResourceAccesses must not be null");
 		theFollowingClassesAreTestClasses = List.copyOf(theFollowingClassesAreTestClasses);

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/ThreadPermission.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/policySubComponents/ThreadPermission.java
@@ -37,9 +37,7 @@ public record ThreadPermission(int createTheFollowingNumberOfThreads, @Nonnull S
 		if (createTheFollowingNumberOfThreads < 0) {
 			throw new IllegalArgumentException(Messages.localized("policy.permission.thread.count.negative"));
 		}
-		if (ofThisClass.isBlank()) {
-			throw new IllegalArgumentException(Messages.localized("policy.permission.thread.class.blank"));
-		}
+		PolicyValueValidator.requireMatch("ofThisClass", ofThisClass, PolicyValueValidator.THREAD_CLASS_PATTERN);
 	}
 
 	/**

--- a/src/main/java/de/tum/cit/ase/ares/api/policy/reader/yaml/SecurityPolicySchemaValidator.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/policy/reader/yaml/SecurityPolicySchemaValidator.java
@@ -3,6 +3,7 @@ package de.tum.cit.ase.ares.api.policy.reader.yaml;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 
@@ -11,11 +12,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import de.tum.cit.ase.ares.api.policy.SecurityPolicy;
+import de.tum.cit.ase.ares.api.policy.policySubComponents.PolicyValueValidator;
 
 /** Validates the security-policy YAML tree before Jackson record binding. */
 final class SecurityPolicySchemaValidator {
 
-	private static final Set<String> ROOT_FIELDS = Set.of("regardingTheSupervisedCode");
+	private static final Set<String> ROOT_FIELDS = Set.of("thisPolicyFileCompliesToThePolicyVersion",
+			"regardingTheSupervisedCode");
 	private static final Set<String> SUPERVISED_CODE_FIELDS = Set.of(
 			"theFollowingProgrammingLanguageConfigurationIsUsed", "theSupervisedCodeUsesTheFollowingPackage",
 			"theMainClassInsideThisPackageIs", "theFollowingClassesAreTestClasses",
@@ -38,16 +41,28 @@ final class SecurityPolicySchemaValidator {
 
 	static void validate(@Nonnull JsonNode root) throws MismatchedInputException {
 		requireObject(root, "$", ROOT_FIELDS, ROOT_FIELDS);
+		requireIntegral(root, "thisPolicyFileCompliesToThePolicyVersion", "$");
+		if (!root.get("thisPolicyFileCompliesToThePolicyVersion").canConvertToInt() || root
+				.get("thisPolicyFileCompliesToThePolicyVersion").intValue() != SecurityPolicy.CURRENT_POLICY_VERSION) {
+			fail("$.thisPolicyFileCompliesToThePolicyVersion must be exactly " + SecurityPolicy.CURRENT_POLICY_VERSION);
+		}
 		JsonNode supervisedCode = root.get("regardingTheSupervisedCode");
 		requireObject(supervisedCode, "$.regardingTheSupervisedCode", SUPERVISED_CODE_FIELDS,
 				Set.of("theFollowingProgrammingLanguageConfigurationIsUsed", "theFollowingClassesAreTestClasses",
 						"theFollowingResourceAccessesArePermitted"));
 		requireText(supervisedCode, "theFollowingProgrammingLanguageConfigurationIsUsed",
 				"$.regardingTheSupervisedCode");
+		requirePattern(supervisedCode, "theFollowingProgrammingLanguageConfigurationIsUsed",
+				"$.regardingTheSupervisedCode", PolicyValueValidator.PROGRAMMING_LANGUAGE_CONFIGURATION_PATTERN);
 		requireOptionalText(supervisedCode, "theSupervisedCodeUsesTheFollowingPackage", "$.regardingTheSupervisedCode");
 		requireOptionalText(supervisedCode, "theMainClassInsideThisPackageIs", "$.regardingTheSupervisedCode");
+		requireOptionalPattern(supervisedCode, "theSupervisedCodeUsesTheFollowingPackage",
+				"$.regardingTheSupervisedCode", PolicyValueValidator.JAVA_PACKAGE_PATTERN);
+		requireOptionalPattern(supervisedCode, "theMainClassInsideThisPackageIs", "$.regardingTheSupervisedCode",
+				PolicyValueValidator.JAVA_CLASS_NAME_PATTERN);
 		requireTextArray(supervisedCode.get("theFollowingClassesAreTestClasses"),
-				"$.regardingTheSupervisedCode.theFollowingClassesAreTestClasses");
+				"$.regardingTheSupervisedCode.theFollowingClassesAreTestClasses",
+				PolicyValueValidator.JAVA_CLASS_PATH_PATTERN);
 
 		JsonNode resources = supervisedCode.get("theFollowingResourceAccessesArePermitted");
 		requireObject(resources, "$.regardingTheSupervisedCode.theFollowingResourceAccessesArePermitted",
@@ -56,12 +71,15 @@ final class SecurityPolicySchemaValidator {
 				FILE_FIELDS, FILE_FIELDS);
 		for (JsonNode permission : resources.get("regardingFileSystemInteractions")) {
 			requireText(permission, "onThisPathAndAllPathsBelow", "file permission");
+			requirePattern(permission, "onThisPathAndAllPathsBelow", "file permission",
+					PolicyValueValidator.FILE_PATH_PATTERN);
 			requireBooleans(permission, FILE_FIELDS, Set.of("onThisPathAndAllPathsBelow"), "file permission");
 		}
 		validateObjectArray(resources.get("regardingNetworkConnections"), "regardingNetworkConnections", NETWORK_FIELDS,
 				NETWORK_FIELDS);
 		for (JsonNode permission : resources.get("regardingNetworkConnections")) {
 			requireText(permission, "onTheHost", "network permission");
+			requirePattern(permission, "onTheHost", "network permission", PolicyValueValidator.HOST_PATTERN);
 			requireIntegral(permission, "onThePort", "network permission");
 			requireBooleans(permission, NETWORK_FIELDS, Set.of("onTheHost", "onThePort"), "network permission");
 		}
@@ -71,11 +89,16 @@ final class SecurityPolicySchemaValidator {
 		for (JsonNode permission : resources.get("regardingThreadCreations")) {
 			requireIntegral(permission, "createTheFollowingNumberOfThreads", "thread permission");
 			requireText(permission, "ofThisClass", "thread permission");
+			requirePattern(permission, "ofThisClass", "thread permission", PolicyValueValidator.THREAD_CLASS_PATTERN);
 		}
 		validateObjectArray(resources.get("regardingPackageImports"), "regardingPackageImports", PACKAGE_FIELDS,
 				PACKAGE_FIELDS);
 		for (JsonNode permission : resources.get("regardingPackageImports")) {
 			requireText(permission, "importTheFollowingPackage", "package permission");
+			if (!PolicyValueValidator.matchesPackageImport(permission.get("importTheFollowingPackage").textValue())) {
+				fail("package permission.importTheFollowingPackage must match "
+						+ PolicyValueValidator.JAVA_PACKAGE_PATTERN.pattern() + " or *");
+			}
 		}
 		validateObjectArray(resources.get("regardingTimeouts"), "regardingTimeouts", TIMEOUT_FIELDS, TIMEOUT_FIELDS);
 		for (JsonNode permission : resources.get("regardingTimeouts")) {
@@ -167,6 +190,10 @@ final class SecurityPolicySchemaValidator {
 	}
 
 	private static void requireTextArray(JsonNode node, String path) throws MismatchedInputException {
+		requireTextArray(node, path, null);
+	}
+
+	private static void requireTextArray(JsonNode node, String path, Pattern pattern) throws MismatchedInputException {
 		if (node == null || !node.isArray()) {
 			fail(path + " must be an array of strings");
 		}
@@ -174,6 +201,24 @@ final class SecurityPolicySchemaValidator {
 			if (!element.isTextual() || element.textValue().isBlank()) {
 				fail(path + " must contain only non-blank strings");
 			}
+			if (pattern != null && !PolicyValueValidator.matches(element.textValue(), pattern)) {
+				fail(path + " entries must match " + pattern.pattern());
+			}
+		}
+	}
+
+	private static void requirePattern(JsonNode parent, String field, String path, Pattern pattern)
+			throws MismatchedInputException {
+		if (!PolicyValueValidator.matches(parent.get(field).textValue(), pattern)) {
+			fail(path + "." + field + " must match " + pattern.pattern());
+		}
+	}
+
+	private static void requireOptionalPattern(JsonNode parent, String field, String path, Pattern pattern)
+			throws MismatchedInputException {
+		JsonNode node = parent.get(field);
+		if (node != null && !node.isNull() && !PolicyValueValidator.matches(node.textValue(), pattern)) {
+			fail(path + "." + field + " must match " + pattern.pattern() + " or be null");
 		}
 	}
 

--- a/src/main/resources/ExampleConfiguration.yaml
+++ b/src/main/resources/ExampleConfiguration.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.aresUI"

--- a/src/test/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceCommandSystemToolboxTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceCommandSystemToolboxTest.java
@@ -16,6 +16,24 @@ import example.student.InstrumentationSecurityProbe;
 
 class JavaInstrumentationAdviceCommandSystemToolboxTest {
 
+	@Test
+	void wildcardCommandAndArgumentsMatchAnyRuntimeValues() throws Exception {
+		Method commandMatches = JavaInstrumentationAdviceCommandSystemToolbox.class.getDeclaredMethod("commandMatches",
+				String.class, String.class);
+		commandMatches.setAccessible(true);
+		Method argumentsMatch = JavaInstrumentationAdviceCommandSystemToolbox.class.getDeclaredMethod("argumentsMatch",
+				String[].class, String[].class);
+		argumentsMatch.setAccessible(true);
+
+		assertTrue((boolean) commandMatches.invoke(null, "java", "*"));
+		assertTrue((boolean) argumentsMatch.invoke(null, (Object) new String[] { "*" },
+				(Object) new String[] { "--version", "--help" }));
+		assertTrue((boolean) argumentsMatch.invoke(null, (Object) new String[] { "run", "*" },
+				(Object) new String[] { "run", "anything" }));
+		assertFalse((boolean) argumentsMatch.invoke(null, (Object) new String[] { "run", "*" },
+				(Object) new String[] { "run", "anything", "else" }));
+	}
+
 	/**
 	 * Loads the localization bundle while still unrestricted, so that building a
 	 * denial message under INSTRUMENTATION mode hits the cached bundle instead of

--- a/src/test/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceFileSystemToolboxTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceFileSystemToolboxTest.java
@@ -21,6 +21,22 @@ import example.student.InstrumentationSecurityProbe;
 
 class JavaInstrumentationAdviceFileSystemToolboxTest {
 
+	@Test
+	void pathWildcardAllowsEveryPath(@TempDir Path tempDir) throws Exception {
+		try {
+			resetSettings();
+			configureInstrumentationMode();
+			Path file = tempDir.resolve("anywhere.txt");
+			Files.writeString(file, "allowed by wildcard");
+			JavaAOPTestCase.setJavaAdviceSettingValue("pathsAllowedToBeRead", new String[] { "*" }, "ARCH",
+					"INSTRUMENTATION");
+
+			assertDoesNotThrow(() -> InstrumentationSecurityProbe.checkFileUrlOpenStream(file.toUri().toURL()));
+		} finally {
+			resetSettings();
+		}
+	}
+
 	/**
 	 * Loads the localization bundle while still unrestricted, so that building a
 	 * denial message under INSTRUMENTATION mode hits the cached bundle instead of

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/archunit/JavaArchunitTestCaseCollectionTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/archunit/JavaArchunitTestCaseCollectionTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.lang.ArchRule;
 
 import de.tum.cit.ase.ares.api.localization.Messages;
@@ -41,6 +42,14 @@ public class JavaArchunitTestCaseCollectionTest {
 		ArchRule rule = JavaArchunitTestCaseCollection.noClassMustImportForbiddenPackages(allowedPackages);
 		String expectedDescription = Messages.localized("security.architecture.package.import");
 		assertEquals(expectedDescription, rule.getDescription());
+	}
+
+	@Test
+	void packageWildcardAllowsEveryImportedPackage() {
+		ArchRule rule = JavaArchunitTestCaseCollection
+				.noClassMustImportForbiddenPackages(Set.of(new PackagePermission("*")));
+		assertDoesNotThrow(
+				() -> rule.check(new ClassFileImporter().importClasses(JavaArchunitTestCaseCollectionTest.class)));
 	}
 
 	@Test

--- a/src/test/java/de/tum/cit/ase/ares/api/policy/SecurityPolicyPipelineIntegrationTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/policy/SecurityPolicyPipelineIntegrationTest.java
@@ -65,6 +65,7 @@ class SecurityPolicyPipelineIntegrationTest {
 		String configuration = mode == BuildMode.MAVEN ? "JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ"
 				: "JAVA_USING_GRADLE_ARCHUNIT_AND_ASPECTJ";
 		return """
+				thisPolicyFileCompliesToThePolicyVersion: 1
 				regardingTheSupervisedCode:
 				  theFollowingProgrammingLanguageConfigurationIsUsed: %s
 				  theSupervisedCodeUsesTheFollowingPackage: com.example

--- a/src/test/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueContractTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueContractTest.java
@@ -30,6 +30,8 @@ class PolicyValueContractTest {
 		assertThrows(NullPointerException.class, () -> new ClassPermission(null));
 		assertThrows(IllegalArgumentException.class, () -> new ClassPermission(" "));
 		assertThrows(IllegalArgumentException.class, () -> new FilePermission(" ", false, false, false, false, false));
+		assertThrows(IllegalArgumentException.class,
+				() -> new FilePermission("../outside", false, false, false, false, false));
 		assertThrows(IllegalArgumentException.class, () -> new NetworkPermission("host", -1, false, false, false));
 		assertEquals(0, new NetworkPermission("host", 0, true, true, true).onThePort());
 		assertEquals(65535, new NetworkPermission("host", 65535, true, true, true).onThePort());

--- a/src/test/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueContractTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueContractTest.java
@@ -17,6 +17,15 @@ import de.tum.cit.ase.ares.api.policy.SecurityPolicy;
 
 class PolicyValueContractTest {
 	@Test
+	void requiresExactlyTheCurrentPolicyVersion() {
+		SecurityPolicy policy = SecurityPolicy
+				.createRestrictive(ProgrammingLanguageConfiguration.JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ);
+		assertEquals(SecurityPolicy.CURRENT_POLICY_VERSION, policy.thisPolicyFileCompliesToThePolicyVersion());
+		assertThrows(IllegalArgumentException.class, () -> new SecurityPolicy(0, policy.regardingTheSupervisedCode()));
+		assertThrows(IllegalArgumentException.class, () -> new SecurityPolicy(2, policy.regardingTheSupervisedCode()));
+	}
+
+	@Test
 	void validatesNamesNumericBoundariesAndRestrictiveFactories() {
 		assertThrows(NullPointerException.class, () -> new ClassPermission(null));
 		assertThrows(IllegalArgumentException.class, () -> new ClassPermission(" "));
@@ -133,7 +142,8 @@ class PolicyValueContractTest {
 		map.put(second, "second");
 		assertEquals(1, map.size());
 		assertTrue(first.toString().contains("example.PolicyTest"));
-		assertEquals(new SecurityPolicy(first), new SecurityPolicy(second));
+		assertEquals(new SecurityPolicy(SecurityPolicy.CURRENT_POLICY_VERSION, first),
+				new SecurityPolicy(SecurityPolicy.CURRENT_POLICY_VERSION, second));
 		assertThrows(NullPointerException.class, () -> supervisedCode(java.util.Arrays.asList((String) null)));
 		assertThrows(IllegalArgumentException.class, () -> supervisedCode(List.of(" ")));
 	}

--- a/src/test/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueValidatorTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueValidatorTest.java
@@ -1,0 +1,124 @@
+package de.tum.cit.ase.ares.api.policy.policySubComponents;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PolicyValueValidatorTest {
+
+	@Test
+	void acceptsEverySupportedProgrammingLanguageConfiguration() {
+		for (ProgrammingLanguageConfiguration configuration : ProgrammingLanguageConfiguration.values()) {
+			assertTrue(PolicyValueValidator.matches(configuration.name(),
+					PolicyValueValidator.PROGRAMMING_LANGUAGE_CONFIGURATION_PATTERN));
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "JAVA_MAVEN_ARCHUNIT_ASPECTJ", "JAVA_USING_MAVEN_ARCHUNIT_ASPECTJ",
+			"JAVA_USING_MAVEN_ARCHUNIT_AND_BYTEBUDDY", "KOTLIN_USING_GRADLE_ARCHUNIT_AND_ASPECTJ" })
+	void rejectsUnsupportedProgrammingLanguageConfigurations(String value) {
+		assertFalse(
+				PolicyValueValidator.matches(value, PolicyValueValidator.PROGRAMMING_LANGUAGE_CONFIGURATION_PATTERN));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "com.example", "de.übung.例", "$generated._internal" })
+	void acceptsCompleteJavaPackageIdentifiers(String value) {
+		assertTrue(PolicyValueValidator.matches(value, PolicyValueValidator.JAVA_PACKAGE_PATTERN));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "", ".example", "com..example", "com.example.", "com.class.example", "1example" })
+	void rejectsInvalidJavaPackageIdentifiers(String value) {
+		assertFalse(PolicyValueValidator.matches(value, PolicyValueValidator.JAVA_PACKAGE_PATTERN));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "Main", "Übung", "$Generated", "Outer$Inner" })
+	void acceptsCompleteJavaClassNames(String value) {
+		assertTrue(PolicyValueValidator.matches(value, PolicyValueValidator.JAVA_CLASS_NAME_PATTERN));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "", "com.example.Main", "1Main", "class", "record", "sealed", "permits", "yield", "var",
+			"Main-Class" })
+	void rejectsInvalidJavaClassNames(String value) {
+		assertFalse(PolicyValueValidator.matches(value, PolicyValueValidator.JAVA_CLASS_NAME_PATTERN));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "MainTest", "com.example.MainTest", "de.übung.例Test", "com.example.Outer$Inner" })
+	void acceptsJavaClassPaths(String value) {
+		assertTrue(PolicyValueValidator.matches(value, PolicyValueValidator.JAVA_CLASS_PATH_PATTERN));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "com.example.", "com..example.Test", "com.example.class", "com/example/Test" })
+	void rejectsInvalidJavaClassPaths(String value) {
+		assertFalse(PolicyValueValidator.matches(value, PolicyValueValidator.JAVA_CLASS_PATH_PATTERN));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "*", "/var/lib/ares", "src/main/java", "../relative/path", "C:\\Users\\Ares",
+			"C:/Users/Ares", "\\\\server\\share\\file", "${PROJECT_ROOT}/target", "${java.home}/bin",
+			"${user.home}/.ares", "${java.io.tmpdir}/ares" })
+	void acceptsSupportedPathsAndPlaceholders(String value) {
+		assertTrue(PolicyValueValidator.matches(value, PolicyValueValidator.FILE_PATH_PATTERN));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "", " ", "${UNKNOWN}/target", "/tmp/*", "src/*/java" })
+	void rejectsInvalidPathsAndEmbeddedWildcards(String value) {
+		assertFalse(PolicyValueValidator.matches(value, PolicyValueValidator.FILE_PATH_PATTERN));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "*", "localhost", "example.org", "api.example.org.", "127.0.0.1", "255.255.255.255", "::1",
+			"2001:db8::1", "::ffff:192.0.2.128" })
+	void acceptsSupportedHostForms(String value) {
+		assertTrue(PolicyValueValidator.matches(value, PolicyValueValidator.HOST_PATTERN));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "", "-example.org", "example..org", "256.1.1.1", "2001:db8:::1", "host name" })
+	void rejectsInvalidHosts(String value) {
+		assertFalse(PolicyValueValidator.matches(value, PolicyValueValidator.HOST_PATTERN));
+	}
+
+	@Test
+	void acceptsPackageAndThreadWildcardsAndRecognisedThreadTokens() {
+		assertDoesNotThrow(() -> new PackagePermission("*"));
+		assertThrows(IllegalArgumentException.class, () -> new PackagePermission("java.*"));
+		Stream.of("*", "Lambda-Expression", "<implicit-thread-op:parallelStream>", "<implicit-thread-op:parallel>",
+				"<implicit-thread-op:Thread.sleep>", "<implicit-thread-op:SubmissionPublisher.submit>",
+				"<implicit-thread-op:SubmissionPublisher.offer>", "java.lang.Thread")
+				.forEach(value -> assertDoesNotThrow(() -> new ThreadPermission(1, value)));
+		assertThrows(IllegalArgumentException.class, () -> new ThreadPermission(1, "<implicit-thread-op:unknown>"));
+	}
+
+	@Test
+	void appliesJavaValidationToSupervisedCode() {
+		ResourceAccesses resources = ResourceAccesses.createRestrictive();
+		assertDoesNotThrow(
+				() -> new SupervisedCode(ProgrammingLanguageConfiguration.JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ,
+						"de.übung", "Main", List.of("de.übung.MainTest"), resources));
+		assertThrows(IllegalArgumentException.class,
+				() -> new SupervisedCode(ProgrammingLanguageConfiguration.JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ,
+						"de.class", "Main", List.of("de.übung.MainTest"), resources));
+		assertThrows(IllegalArgumentException.class,
+				() -> new SupervisedCode(ProgrammingLanguageConfiguration.JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ,
+						"de.übung", "main.Class", List.of("de.übung.MainTest"), resources));
+		assertThrows(IllegalArgumentException.class,
+				() -> new SupervisedCode(ProgrammingLanguageConfiguration.JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ,
+						"de.übung", "Main", List.of("de.übung."), resources));
+	}
+}

--- a/src/test/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueValidatorTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/policy/policySubComponents/PolicyValueValidatorTest.java
@@ -68,15 +68,17 @@ class PolicyValueValidatorTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "*", "/var/lib/ares", "src/main/java", "../relative/path", "C:\\Users\\Ares",
-			"C:/Users/Ares", "\\\\server\\share\\file", "${PROJECT_ROOT}/target", "${java.home}/bin",
-			"${user.home}/.ares", "${java.io.tmpdir}/ares" })
+	@ValueSource(strings = { "*", "/var/lib/ares", "src/main/java", "relative/path", "archive..bak", "path/.../file",
+			"path/..suffix", "C:\\Users\\Ares", "C:/Users/Ares", "\\\\server\\share\\file", "${PROJECT_ROOT}/target",
+			"${java.home}/bin", "${user.home}/.ares", "${java.io.tmpdir}/ares" })
 	void acceptsSupportedPathsAndPlaceholders(String value) {
 		assertTrue(PolicyValueValidator.matches(value, PolicyValueValidator.FILE_PATH_PATTERN));
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "", " ", "${UNKNOWN}/target", "/tmp/*", "src/*/java" })
+	@ValueSource(strings = { "", " ", "${UNKNOWN}/target", "/tmp/*", "src/*/java", "..", "../relative/path",
+			"..\\relative\\path", "path/../file", "path\\..\\file", "path/..", "path\\..", "/../etc", "C:\\..\\Windows",
+			"${PROJECT_ROOT}/../outside" })
 	void rejectsInvalidPathsAndEmbeddedWildcards(String value) {
 		assertFalse(PolicyValueValidator.matches(value, PolicyValueValidator.FILE_PATH_PATTERN));
 	}

--- a/src/test/java/de/tum/cit/ase/ares/api/policy/reader/yaml/SecurityPolicyStrictSchemaTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/policy/reader/yaml/SecurityPolicyStrictSchemaTest.java
@@ -119,7 +119,7 @@ class SecurityPolicyStrictSchemaTest {
 	}
 
 	static Stream<String> everyRequiredField() {
-		return Stream.of("/regardingTheSupervisedCode",
+		return Stream.of("/thisPolicyFileCompliesToThePolicyVersion", "/regardingTheSupervisedCode",
 				"/regardingTheSupervisedCode/theFollowingProgrammingLanguageConfigurationIsUsed",
 				"/regardingTheSupervisedCode/theFollowingClassesAreTestClasses",
 				"/regardingTheSupervisedCode/theFollowingResourceAccessesArePermitted",
@@ -238,14 +238,14 @@ class SecurityPolicyStrictSchemaTest {
 					@Override
 					public ProgrammingLanguageConfiguration deserialize(JsonParser parser,
 							DeserializationContext context) throws IOException {
-						assertEquals("CUSTOM", parser.getText());
-						return ProgrammingLanguageConfiguration.JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ;
+						assertEquals("JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ", parser.getText());
+						return ProgrammingLanguageConfiguration.JAVA_USING_GRADLE_WALA_AND_INSTRUMENTATION;
 					}
 				});
 		mapper.registerModule(module);
-		Path file = write(validYaml().replace("JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ", "CUSTOM"));
+		Path file = write(validYaml());
 		SecurityPolicy policy = new SecurityPolicyYAMLReader(mapper, tempDirectory).readSecurityPolicyFrom(file);
-		assertEquals(ProgrammingLanguageConfiguration.JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ,
+		assertEquals(ProgrammingLanguageConfiguration.JAVA_USING_GRADLE_WALA_AND_INSTRUMENTATION,
 				policy.regardingTheSupervisedCode().theFollowingProgrammingLanguageConfigurationIsUsed());
 	}
 
@@ -263,14 +263,33 @@ class SecurityPolicyStrictSchemaTest {
 	}
 
 	@Test
-	void expandsRepeatedPlaceholdersAndLeavesUnknownTokensAsScalarText() throws IOException {
+	void rejectsUnknownPathPlaceholders() throws IOException {
 		Path file = write(validYaml().replace("/tmp/data", "${PROJECT_ROOT}/${PROJECT_ROOT}/${UNKNOWN}"));
-		SecurityPolicy policy = new SecurityPolicyYAMLReader(new YAMLMapper(), tempDirectory)
-				.readSecurityPolicyFrom(file);
-		String path = policy.regardingTheSupervisedCode().theFollowingResourceAccessesArePermitted()
-				.regardingFileSystemInteractions().get(0).onThisPathAndAllPathsBelow();
-		assertEquals(tempDirectory.toAbsolutePath().normalize() + "/" + tempDirectory.toAbsolutePath().normalize()
-				+ "/${UNKNOWN}", path);
+		assertThrows(SecurityException.class,
+				() -> new SecurityPolicyYAMLReader(new YAMLMapper(), tempDirectory).readSecurityPolicyFrom(file));
+	}
+
+	static Stream<Arguments> invalidPolicyValues() {
+		return Stream.of(
+				Arguments.of("thisPolicyFileCompliesToThePolicyVersion: 1",
+						"thisPolicyFileCompliesToThePolicyVersion: 2"),
+				Arguments.of("JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ", "JAVA_MAVEN_ARCHUNIT_ASPECTJ"),
+				Arguments.of("theSupervisedCodeUsesTheFollowingPackage: com.example",
+						"theSupervisedCodeUsesTheFollowingPackage: com.class"),
+				Arguments.of("theMainClassInsideThisPackageIs: Main",
+						"theMainClassInsideThisPackageIs: com.example.Main"),
+				Arguments.of("theFollowingClassesAreTestClasses: [com.example.MainTest]",
+						"theFollowingClassesAreTestClasses: [com.example.]"),
+				Arguments.of("onThisPathAndAllPathsBelow: /tmp/data", "onThisPathAndAllPathsBelow: '${UNKNOWN}/data'"),
+				Arguments.of("onTheHost: localhost", "onTheHost: 256.1.1.1"),
+				Arguments.of("ofThisClass: java.lang.Thread", "ofThisClass: java.lang."),
+				Arguments.of("importTheFollowingPackage: java.util", "importTheFollowingPackage: java.*"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("invalidPolicyValues")
+	void rejectsValuesThatDoNotMatchTheirPolicyRegex(String original, String replacement) {
+		assertThrows(SecurityException.class, () -> read(validYaml().replace(original, replacement)));
 	}
 
 	@Test
@@ -305,6 +324,7 @@ class SecurityPolicyStrictSchemaTest {
 
 	private static String validYaml() {
 		return """
+				thisPolicyFileCompliesToThePolicyVersion: 1
 				regardingTheSupervisedCode:
 				  theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
 				  theSupervisedCodeUsesTheFollowingPackage: com.example

--- a/src/test/java/de/tum/cit/ase/ares/api/policy/reader/yaml/SecurityPolicyStrictSchemaTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/policy/reader/yaml/SecurityPolicyStrictSchemaTest.java
@@ -281,6 +281,7 @@ class SecurityPolicyStrictSchemaTest {
 				Arguments.of("theFollowingClassesAreTestClasses: [com.example.MainTest]",
 						"theFollowingClassesAreTestClasses: [com.example.]"),
 				Arguments.of("onThisPathAndAllPathsBelow: /tmp/data", "onThisPathAndAllPathsBelow: '${UNKNOWN}/data'"),
+				Arguments.of("onThisPathAndAllPathsBelow: /tmp/data", "onThisPathAndAllPathsBelow: '../tmp/data'"),
 				Arguments.of("onTheHost: localhost", "onTheHost: 256.1.1.1"),
 				Arguments.of("ofThisClass: java.lang.Thread", "ofThisClass: java.lang."),
 				Arguments.of("importTheFollowingPackage: java.util", "importTheFollowingPackage: java.*"));

--- a/src/test/java/de/tum/cit/ase/ares/api/policy/reader/yaml/SecurityPolicyYAMLReaderTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/policy/reader/yaml/SecurityPolicyYAMLReaderTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -108,6 +109,16 @@ public class SecurityPolicyYAMLReaderTest {
 	class ReadSecurityPolicyFromTests {
 
 		@Test
+		void shouldReadEveryCheckedInSecurityPolicy() throws IOException {
+			Path examplePolicy = Path.of("src/main/resources/ExampleConfiguration.yaml");
+			Path testPolicies = Path.of("src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies");
+			try (Stream<Path> files = Stream.concat(Stream.of(examplePolicy), Files.walk(testPolicies))) {
+				files.filter(Files::isRegularFile).filter(path -> path.getFileName().toString().endsWith(".yaml"))
+						.forEach(path -> assertDoesNotThrow(() -> reader.readSecurityPolicyFrom(path), path::toString));
+			}
+		}
+
+		@Test
 		@DisplayName("Should throw NullPointerException when path is null")
 		void shouldThrowNullPointerExceptionWhenPathIsNull() {
 			// Act & Assert
@@ -128,6 +139,7 @@ public class SecurityPolicyYAMLReaderTest {
 			// Arrange
 			Path policyFile = tempDir.resolve("security-policy.yaml");
 			String yamlContent = """
+					thisPolicyFileCompliesToThePolicyVersion: 1
 					regardingTheSupervisedCode:
 					  theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
 					  theSupervisedCodeUsesTheFollowingPackage: "com.example"
@@ -163,6 +175,7 @@ public class SecurityPolicyYAMLReaderTest {
 			// Arrange
 			Path policyFile = tempDir.resolve("minimal-policy.yaml");
 			String yamlContent = """
+					thisPolicyFileCompliesToThePolicyVersion: 1
 					regardingTheSupervisedCode:
 					  theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
 					  theFollowingClassesAreTestClasses: []
@@ -255,6 +268,7 @@ public class SecurityPolicyYAMLReaderTest {
 				// Arrange
 				Path policyFile = tempDir.resolve("policy-" + config.name() + ".yaml");
 				String yamlContent = String.format("""
+						thisPolicyFileCompliesToThePolicyVersion: 1
 						regardingTheSupervisedCode:
 						  theFollowingProgrammingLanguageConfigurationIsUsed: %s
 						  theFollowingClassesAreTestClasses: []
@@ -289,6 +303,7 @@ public class SecurityPolicyYAMLReaderTest {
 			// Arrange
 			Path policyFile = tempDir.resolve("integration-test.yaml");
 			String yamlContent = """
+					thisPolicyFileCompliesToThePolicyVersion: 1
 					regardingTheSupervisedCode:
 					  theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
 					  theFollowingClassesAreTestClasses: []
@@ -321,6 +336,7 @@ public class SecurityPolicyYAMLReaderTest {
 			// Arrange
 			Path incompleteFile = tempDir.resolve("incomplete.yaml");
 			String incompleteYaml = """
+					thisPolicyFileCompliesToThePolicyVersion: 1
 					regardingTheSupervisedCode:
 					  # Missing required fields
 					  theSupervisedCodeUsesTheFollowingPackage: "com.example"
@@ -363,6 +379,7 @@ public class SecurityPolicyYAMLReaderTest {
 
 	private static String minimalPolicy() {
 		return """
+				thisPolicyFileCompliesToThePolicyVersion: 1
 				regardingTheSupervisedCode:
 				  theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
 				  theFollowingClassesAreTestClasses: []

--- a/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/creator/JavaCreatorTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/creator/JavaCreatorTest.java
@@ -139,7 +139,7 @@ public class JavaCreatorTest {
 			when(architectureMode.getJavaClasses(classpath)).thenReturn(javaClasses);
 			when(architectureMode.getCallGraph(classpath)).thenReturn(callGraph);
 			when(resourceAccesses.regardingPackageImports())
-					.thenReturn(List.of(new PackagePermission("allowed.package")));
+					.thenReturn(List.of(new PackagePermission("allowed.example")));
 
 			// Act
 			assertDoesNotThrow(() -> javaCreator.createTestCases(buildMode, architectureMode, aopMode,

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/PolicyOneThreadAllowedCreate.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/PolicyOneThreadAllowedCreate.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/PolicyPomAllowedRead.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/PolicyPomAllowedRead.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyAllThreadOperationsAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyAllThreadOperationsAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyCompletableFutureAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyCompletableFutureAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyDynamicsUser.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyDynamicsUser.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"
@@ -5,7 +6,7 @@ regardingTheSupervisedCode:
   theFollowingClassesAreTestClasses:
     - "de.tum.cit.ase.ares.integration.testuser.DynamicsUser"
     - "de.tum.cit.ase.ares.integration.DynamicsTest"
-    - "de.tum.cit.ase.ares.testutilities."
+    - "de.tum.cit.ase.ares.testutilities"
   # The former @WhitelistPath("") of DynamicsUser specified an empty path and therefore granted
   # no concrete file access; the equivalent is an active policy with no permitted resource accesses.
   theFollowingResourceAccessesArePermitted:

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyEverythingForbidden.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyEverythingForbidden.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyExceptionFailureUser.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyExceptionFailureUser.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"
@@ -5,7 +6,7 @@ regardingTheSupervisedCode:
   theFollowingClassesAreTestClasses:
     - "de.tum.cit.ase.ares.integration.testuser.ExceptionFailureUser"
     - "de.tum.cit.ase.ares.integration.ExceptionFailureTest"
-    - "de.tum.cit.ase.ares.testutilities."
+    - "de.tum.cit.ase.ares.testutilities"
   # Captures the former @WhitelistPath(value = "target/**") and @AllowThreads(maxActiveCount = 100)
   # of ExceptionFailureUser. The former @BlacklistPath has no allow-list equivalent: the
   # Ares 2 model is allow-list based, so a path that is not permitted is forbidden by default.

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyHelloWorld.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyHelloWorld.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"
@@ -5,7 +6,7 @@ regardingTheSupervisedCode:
   theFollowingClassesAreTestClasses:
     - "de.tum.cit.ase.ares.integration.testuser.HelloWorldUser"
     - "de.tum.cit.ase.ares.integration.HelloWorldTest"
-    - "de.tum.cit.ase.ares.testutilities."
+    - "de.tum.cit.ase.ares.testutilities"
     - "de.tum.cit.ase.ares.integration.aop.allowed.SystemAccessTest"
     - "de.tum.cit.ase.ares.integration.aop.forbidden.SystemAccessTest"
     - "de.tum.cit.ase.ares.integration.architecture.forbidden.SystemAccessTest"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyInputOutputUser.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyInputOutputUser.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"
@@ -5,7 +6,7 @@ regardingTheSupervisedCode:
   theFollowingClassesAreTestClasses:
     - "de.tum.cit.ase.ares.integration.testuser.InputOutputUser"
     - "de.tum.cit.ase.ares.integration.InputOutputTest"
-    - "de.tum.cit.ase.ares.testutilities."
+    - "de.tum.cit.ase.ares.testutilities"
   # Captures the former @WhitelistPath(value = "target/**") of InputOutputUser.
   # The former @BlacklistPath has no allow-list equivalent (Ares 2 forbids by default).
   theFollowingResourceAccessesArePermitted:

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyInternalErrorLeakage.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyInternalErrorLeakage.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"
@@ -5,7 +6,7 @@ regardingTheSupervisedCode:
   theFollowingClassesAreTestClasses:
     - "de.tum.cit.ase.ares.integration.testuser.InternalErrorLeakageTemporaryUser"
     - "de.tum.cit.ase.ares.integration.InternalErrorLeakageTemporaryTest"
-    - "de.tum.cit.ase.ares.testutilities."
+    - "de.tum.cit.ase.ares.testutilities"
   theFollowingResourceAccessesArePermitted:
     regardingFileSystemInteractions: []
     regardingNetworkConnections: []

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyJqwickUser.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyJqwickUser.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"
@@ -5,7 +6,7 @@ regardingTheSupervisedCode:
   theFollowingClassesAreTestClasses:
     - "de.tum.cit.ase.ares.integration.testuser.JqwickUser"
     - "de.tum.cit.ase.ares.integration.JqwickTest"
-    - "de.tum.cit.ase.ares.testutilities."
+    - "de.tum.cit.ase.ares.testutilities"
   # Captures JqwickUser's former @TrustedThreads(ALL_THREADS), @WhitelistPath("target/{classes,test-classes}/de/tum**")
   # and @WhitelistPath("**/*jdk*/**/bin/**"). The Ares 2 file model uses a path-and-below prefix rather
   # than a glob, so the jdk-bin glob is approximated by permitting the build-output tree; the trusted-threads

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyLoopbackEchoConnectionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyLoopbackEchoConnectionAllowed.yaml
@@ -1,10 +1,11 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"
   theMainClassInsideThisPackageIs: "Main"
   theFollowingClassesAreTestClasses:
     - "de.tum.cit.ase.ares.integration.testuser.NetworkUser"
-    - "de.tum.cit.ase.ares.testutilities.TestUserExtension"
+    - "de.tum.cit.ase.ares.testutilitiesTestUserExtension"
   theFollowingResourceAccessesArePermitted:
     regardingFileSystemInteractions: [ ]
     regardingNetworkConnections:

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyLoopbackEchoConnectionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyLoopbackEchoConnectionAllowed.yaml
@@ -5,7 +5,7 @@ regardingTheSupervisedCode:
   theMainClassInsideThisPackageIs: "Main"
   theFollowingClassesAreTestClasses:
     - "de.tum.cit.ase.ares.integration.testuser.NetworkUser"
-    - "de.tum.cit.ase.ares.testutilitiesTestUserExtension"
+    - "de.tum.cit.ase.ares.testutilities.TestUserExtension"
   theFollowingResourceAccessesArePermitted:
     regardingFileSystemInteractions: [ ]
     regardingNetworkConnections:

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOneCommandExecutionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOneCommandExecutionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOneNetworkConnectionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOneNetworkConnectionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedDelete.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedDelete.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedDeleteOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedDeleteOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedExecute.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedExecute.yaml
@@ -1,4 +1,4 @@
-
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedExecuteOneCommandExecutionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedExecuteOneCommandExecutionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedOverwrite.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedOverwrite.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedOverwriteOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedOverwriteOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedRead.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedRead.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedReadOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedReadOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedReadOverwriteDelete.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOnePathAllowedReadOverwriteDelete.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOneThreadAllowedCreate.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyOneThreadAllowedCreate.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyPrivilegedExceptionUser.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyPrivilegedExceptionUser.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"
@@ -5,7 +6,7 @@ regardingTheSupervisedCode:
   theFollowingClassesAreTestClasses:
     - "de.tum.cit.ase.ares.integration.testuser.PrivilegedExceptionUser"
     - "de.tum.cit.ase.ares.integration.PrivilegedExceptionTest"
-    - "de.tum.cit.ase.ares.testutilities."
+    - "de.tum.cit.ase.ares.testutilities"
   # Captures the former @WhitelistPath(value = "target/**") of PrivilegedExceptionUser.
   # The former @BlacklistPath has no allow-list equivalent (Ares 2 forbids by default).
   theFollowingResourceAccessesArePermitted:

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyReflectionTestUtilsUser.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/aspectj/PolicyReflectionTestUtilsUser.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"
@@ -5,7 +6,7 @@ regardingTheSupervisedCode:
   theFollowingClassesAreTestClasses:
     - "de.tum.cit.ase.ares.integration.testuser.ReflectionTestUtilsUser"
     - "de.tum.cit.ase.ares.integration.ReflectionTestUtilsTest"
-    - "de.tum.cit.ase.ares.testutilities."
+    - "de.tum.cit.ase.ares.testutilities"
   # The former @WhitelistPath("") of ReflectionTestUtilsUser specified an empty path and
   # therefore granted no concrete file access; the equivalent is an active policy with no
   # permitted resource accesses (these tests exercise ReflectionTestUtils, not governed I/O).

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyAllThreadOperationsAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyAllThreadOperationsAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyCompletableFutureAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyCompletableFutureAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyEverythingForbidden.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyEverythingForbidden.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOneCommandExecutionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOneCommandExecutionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOneNetworkConnectionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOneNetworkConnectionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedDelete.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedDelete.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedDeleteOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedDeleteOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedExecute.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedExecute.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedExecuteOneCommandExecutionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedExecuteOneCommandExecutionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedOverwrite.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedOverwrite.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedOverwriteOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedOverwriteOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedRead.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedRead.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedReadOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedReadOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedReadOverwriteDelete.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOnePathAllowedReadOverwriteDelete.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOneThreadAllowedCreate.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/archunit/instrumentation/PolicyOneThreadAllowedCreate.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_ARCHUNIT_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyAllThreadOperationsAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyAllThreadOperationsAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyCompletableFutureAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyCompletableFutureAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyEverythingForbidden.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyEverythingForbidden.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyHelloWorld.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyHelloWorld.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"
@@ -5,7 +6,7 @@ regardingTheSupervisedCode:
   theFollowingClassesAreTestClasses:
     - "de.tum.cit.ase.ares.integration.testuser.HelloWorldUser"
     - "de.tum.cit.ase.ares.integration.HelloWorldTest"
-    - "de.tum.cit.ase.ares.testutilities."
+    - "de.tum.cit.ase.ares.testutilities"
     - "de.tum.cit.ase.ares.integration.aop.allowed.SystemAccessTest"
     - "de.tum.cit.ase.ares.integration.aop.forbidden.SystemAccessTest"
     - "de.tum.cit.ase.ares.integration.architecture.forbidden.SystemAccessTest"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOneCommandExecutionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOneCommandExecutionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOneNetworkConnectionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOneNetworkConnectionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedDelete.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedDelete.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedDeleteOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedDeleteOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedExecute.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedExecute.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedExecuteOneCommandExecutionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedExecuteOneCommandExecutionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedOverwrite.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedOverwrite.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedOverwriteOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedOverwriteOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedRead.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedRead.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedReadOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedReadOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedReadOverwriteDelete.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOnePathAllowedReadOverwriteDelete.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOneThreadAllowedCreate.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/aspectj/PolicyOneThreadAllowedCreate.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_ASPECTJ
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyAllThreadOperationsAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyAllThreadOperationsAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyCompletableFutureAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyCompletableFutureAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyEverythingForbidden.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyEverythingForbidden.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOneCommandExecutionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOneCommandExecutionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOneNetworkConnectionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOneNetworkConnectionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedDelete.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedDelete.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedDeleteOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedDeleteOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedExecute.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedExecute.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedExecuteOneCommandExecutionAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedExecuteOneCommandExecutionAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedOverwrite.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedOverwrite.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedOverwriteOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedOverwriteOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedRead.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedRead.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedReadOneThreadAllowed.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedReadOneThreadAllowed.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedReadOverwriteDelete.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOnePathAllowedReadOverwriteDelete.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOneThreadAllowedCreate.yaml
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/securitypolicies/java/maven/wala/instrumentation/PolicyOneThreadAllowedCreate.yaml
@@ -1,3 +1,4 @@
+thisPolicyFileCompliesToThePolicyVersion: 1
 regardingTheSupervisedCode:
   theFollowingProgrammingLanguageConfigurationIsUsed: JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION
   theSupervisedCodeUsesTheFollowingPackage: "de.tum.cit.ase.ares"


### PR DESCRIPTION
## Summary

- require the root-level `thisPolicyFileCompliesToThePolicyVersion: 1` setting and migrate all 73 checked-in policy files
- validate programming configurations, Java packages/classes, file paths and recognised placeholders, hosts, ports, and thread-class values against explicit regular expressions
- implement wildcard enforcement consistently across instrumentation, AspectJ, ArchUnit, and WALA-backed package checks
- add contract, schema, enforcement, and all-policy compatibility tests

## Wildcard semantics

- `onThePort: 0` permits every port
- `onThisPathAndAllPathsBelow: "*"`, `executeTheCommand: "*"`, and `importTheFollowingPackage: "*"` each act as exact any-value sentinels
- a sole `withTheseArguments: ["*"]` permits any argument list; within a longer list, `"*"` matches exactly one argument at that position
- existing host and thread wildcards, plus all recognised implicit thread-operation tokens, remain supported

## Compatibility notes

Nine policy fixtures used the prefix `de.tum.cit.ase.ares.testutilities.` as a test-class value. The trailing dot was removed so the value follows Java qualified-identifier rules while preserving the existing prefix-matching behaviour.

## Checks

- `mvn -q test`
- `mvn -q -DskipTests verify`