### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1167,7 +1167,7 @@ tasks.register('buildInstrumentationAgent', Jar) {
     description 'Builds a proper Java agent from the Ares JAR with correct manifest'
     archiveFileName = 'ares-agent.jar'
     destinationDirectory = layout.buildDirectory.dir("agents")
-    from zipTree(layout.buildDirectory.file("agents/ares-2.1.0.jar").get().asFile)
+    from zipTree(configurations.aresAgent.filter { it.name.startsWith('ares-') }.singleFile)
     manifest {
         attributes(
                 'Manifest-Version': '1.0',

--- a/README.adoc
+++ b/README.adoc
@@ -64,7 +64,7 @@ environment of a Maven project, include
 <dependency>
     <groupId>de.tum.cit.ase</groupId>
     <artifactId>ares</artifactId>
-    <version>2.0.1-Beta9</version>
+    <version>2.1.0</version>
 </dependency>
 ----
 
@@ -73,7 +73,7 @@ in the `dependencies` section.
 For Gradle projects, include
 [source,groovy]
 ----
-implementation("de.tum.cit.ase:ares:2.0.1-Beta9")
+implementation("de.tum.cit.ase:ares:2.1.0")
 ----
 
 in the `dependencies` section.
@@ -107,7 +107,7 @@ looks like this:
     <dependency>
         <groupId>de.tum.cit.ase</groupId>
         <artifactId>ares</artifactId>
-        <version>2.0.1-Beta9</version>
+        <version>2.1.0</version>
     </dependency>
 </dependencies>
 ----
@@ -992,7 +992,7 @@ Maven:
 ----
 <properties>
         <studentOutputDir>${project.basedir}/build/classes/java/main</studentOutputDir>
-        <ares.version>2.0.1-Beta9</ares.version>
+        <ares.version>2.1.0</ares.version>
         <agent.dir>${project.build.directory}/agents</agent.dir>
     </properties>
 
@@ -1129,8 +1129,8 @@ configurations {
 }
 
 dependencies {
-    aresAgent 'de.tum.cit.ase:ares:2.0.1-Beta9'
-    testImplementation("de.tum.cit.ase:ares:2.0.1-Beta9")
+    aresAgent 'de.tum.cit.ase:ares:2.1.0'
+    testImplementation("de.tum.cit.ase:ares:2.1.0")
 }
 
 def forbiddenPackageFolders = [
@@ -1167,7 +1167,7 @@ tasks.register('buildInstrumentationAgent', Jar) {
     description 'Builds a proper Java agent from the Ares JAR with correct manifest'
     archiveFileName = 'ares-agent.jar'
     destinationDirectory = layout.buildDirectory.dir("agents")
-    from zipTree(layout.buildDirectory.file("agents/ares-2.0.1-Beta9.jar").get().asFile)
+    from zipTree(layout.buildDirectory.file("agents/ares-2.1.0.jar").get().asFile)
     manifest {
         attributes(
                 'Manifest-Version': '1.0',
@@ -1396,7 +1396,7 @@ repositories {
 <dependency>
     <groupId>de.tum.cit.ase</groupId>
     <artifactId>ares</artifactId>
-    <version>2.0.1-Beta9</version>
+    <version>2.1.0</version>
 </dependency>
 ----
 

--- a/docs/HowToMakeAProjectAnAresProject.md
+++ b/docs/HowToMakeAProjectAnAresProject.md
@@ -2,7 +2,7 @@
 
 > **Audience:** IT-Education experts with no security background.
 > **Scope:** The `build.gradle` and `pom.xml` files.
-> **Ares Version:** 2.0.1-Beta9
+> **Ares Version:** 2.1.0
 
 > **Note:** This guide is a **setup guide**. It covers adding the Ares dependency, attaching the agent, and configuring the build tool so that Ares can run. For writing security policies that control what student code can do, see the [Security Policy Manual](policy/SecurityPolicyManual.md).
 
@@ -106,10 +106,10 @@ Add the Ares library to both the agent configuration and test implementation, as
 
 ```gradle
 dependencies {
-    aresAgent "de.tum.cit.ase:ares:2.0.1-Beta9:agent"
+    aresAgent "de.tum.cit.ase:ares:2.1.0:agent"
     aresAgent "org.aspectj:aspectjrt:1.9.25.1"
-    testImplementation "de.tum.cit.ase:ares:2.0.1-Beta9"
-    aspect "de.tum.cit.ase:ares:2.0.1-Beta9"
+    testImplementation "de.tum.cit.ase:ares:2.1.0"
+    aspect "de.tum.cit.ase:ares:2.1.0"
     implementation "org.aspectj:aspectjrt:1.9.25.1"
 }
 ```
@@ -117,7 +117,7 @@ dependencies {
 > **Tip (Gradle version catalog):** If your project uses a Gradle version catalog file (for example `gradle/<versions-catalog>.toml`), you can declare the version centrally:
 > ```toml
 > [versions]
-> ares = "2.0.1-Beta9"
+> ares = "2.1.0"
 > aspectjrt = "1.9.25.1"
 > [libraries]
 > ares = { module = "de.tum.cit.ase:ares", version.ref = "ares" }
@@ -222,7 +222,7 @@ Include Ares in your test dependencies, as well as the AspectJ runtime library:
 <dependency>
     <groupId>de.tum.cit.ase</groupId>
     <artifactId>ares</artifactId>
-    <version>2.0.1-Beta9</version>
+    <version>2.1.0</version>
     <scope>test</scope>
 </dependency>
 <dependency>
@@ -250,7 +250,7 @@ Configure the Surefire test plugin to load the agent during test execution:
     <artifactId>maven-surefire-plugin</artifactId>
     <configuration>
         <argLine>
-            -javaagent:${settings.localRepository}/de/tum/cit/ase/ares/2.0.1-Beta9/ares-2.0.1-Beta9-agent.jar
+            -javaagent:${settings.localRepository}/de/tum/cit/ase/ares/2.1.0/ares-2.1.0-agent.jar
             -Xbootclasspath/a:${settings.localRepository}/org/aspectj/aspectjrt/1.9.25.1/aspectjrt-1.9.25.1.jar
             --add-exports java.base/java.lang=ALL-UNNAMED
             --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
@@ -288,7 +288,7 @@ Configure the Surefire test plugin to load the agent during test execution:
 > **Tip (avoid hardcoded version):** Define a Maven property so the version appears in one place only:
 > ```xml
 > <properties>
->     <ares.version>2.0.1-Beta9</ares.version>
+>     <ares.version>2.1.0</ares.version>
 > </properties>
 > ```
 > Then use `${ares.version}` in both the dependency and the `<argLine>`:

--- a/docs/HowToMakeAProjectAnAresProject.md
+++ b/docs/HowToMakeAProjectAnAresProject.md
@@ -115,6 +115,7 @@ dependencies {
 ```
 
 > **Tip (Gradle version catalog):** If your project uses a Gradle version catalog file (for example `gradle/<versions-catalog>.toml`), you can declare the version centrally:
+>
 > ```toml
 > [versions]
 > ares = "2.1.0"
@@ -123,6 +124,7 @@ dependencies {
 > ares = { module = "de.tum.cit.ase:ares", version.ref = "ares" }
 > aspectjrt = { module = "org.aspectj:aspectjrt", version.ref = "aspectjrt" }
 > ```
+>
 > Then reference `libs.ares` and `libs.aspectjrt` in `build.gradle`. Note that Gradle version catalogs do not natively support Maven classifiers, so the `aresAgent` dependency with the `:agent` classifier must remain as a direct dependency string in `build.gradle`.
 
 **Explanation:**

--- a/docs/architecture/BlockCommandSystemAccessArchitecture.md
+++ b/docs/architecture/BlockCommandSystemAccessArchitecture.md
@@ -883,7 +883,7 @@ java.lang.ProcessBuilder.startPipeline
     <dependency>
         <groupId>de.tum.cit.ase</groupId>
         <artifactId>ares</artifactId>
-        <version>2.0.1-Beta9</version>
+        <version>2.1.0</version>
     </dependency>
 </dependencies>
 ```

--- a/docs/architecture/BlockThreadSystemAccessArchitecture.md
+++ b/docs/architecture/BlockThreadSystemAccessArchitecture.md
@@ -1111,7 +1111,7 @@ java.util.Collection.parallelStream()
     <dependency>
         <groupId>de.tum.cit.ase</groupId>
         <artifactId>ares</artifactId>
-        <version>2.0.1-Beta9</version>
+        <version>2.1.0</version>
     </dependency>
 </dependencies>
 ```

--- a/docs/policy/SecurityPolicyManual.md
+++ b/docs/policy/SecurityPolicyManual.md
@@ -2,7 +2,7 @@
 
 > **Audience:** IT-Education experts with no security background.
 > **Scope:** All classes inside `SecurityPolicy.java`, and the `policySubComponents` package.
-> **Ares Version:** 2.0.1-Beta9
+> **Ares Version:** 2.1.0
 
 **Related documentation:**
 - [How to Make a Project an Ares Project](../HowToMakeAProjectAnAresProject.md), project setup (build.gradle / pom.xml)

--- a/docs/policy/SecurityPolicyReaderAndDirectorManual.md
+++ b/docs/policy/SecurityPolicyReaderAndDirectorManual.md
@@ -2,7 +2,7 @@
 
 > **Audience:** IT-Education experts with no security background.
 > **Scope:** All classes inside `SecurityPolicyReaderAndDirector.java`, the `reader` and `director` packages.
-> **Ares Version:** 2.0.1-Beta9
+> **Ares Version:** 2.1.0
 
 **Related documentation:**
 - [Security Policy Manual](SecurityPolicyManual.md), how to write a security policy YAML file

--- a/docs/securitytest/TestCaseFactoryAndBuilderManual.md
+++ b/docs/securitytest/TestCaseFactoryAndBuilderManual.md
@@ -2,7 +2,7 @@
 
 > **Audience:** IT-Education experts with no security background.
 > **Scope:** All classes inside `de.tum.cit.ase.ares.api.securitytest` — the abstract factory/builder, the Java-specific factory, and the `creator`, `essentialModel`, `executer`, `writer`, `projectScanner`, and `specific` sub-packages.
-> **Ares Version:** 2.0.1-Beta9
+> **Ares Version:** 2.1.0
 
 **Related documentation:**
 - [Security Policy Manual](../policy/SecurityPolicyManual.md) — how to write a security policy YAML file

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.tum.cit.ase</groupId>
 	<artifactId>ares</artifactId>
-	<version>2.0.1-Beta9</version>
+	<version>2.1.0</version>
 	<properties>
 		<!-- 0. General Project Settings -->
 		<maven.compiler.source>17</maven.compiler.source>


### PR DESCRIPTION
## Summary

- bump the Maven project version from `2.0.1-Beta9` to `2.1.0`
- update dependency, agent JAR, and version examples in the README and manuals
- update documentation version banners to `2.1.0`

## Motivation and impact

This promotes Ares from the Beta9 prerelease version to the `2.1.0` release. Consumers can use the new release coordinates consistently across Maven, Gradle, and Java agent configuration examples.

## Validation

- `mvn -DskipTests package`
- Checkstyle: passed
- PMD/CPD: passed
- SpotBugs: passed
- verified that no `2.0.1-Beta9` references remain
