### PR TITLE
fix: read forbidden-method lists through the jar-aware reader

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/ForbiddenMethodMatcher.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/ForbiddenMethodMatcher.java
@@ -13,6 +13,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import de.tum.cit.ase.ares.api.localization.Messages;
+import de.tum.cit.ase.ares.api.util.FileTools;
 
 /**
  * Loads and matches the shared ArchUnit/WALA forbidden-method policy.
@@ -88,28 +89,36 @@ public final class ForbiddenMethodMatcher {
 
 	@Nonnull
 	private static Set<String> loadValidated(@Nonnull Path path) {
+		List<String> lines;
 		try {
-			List<String> lines = Files.readAllLines(path, StandardCharsets.UTF_8);
-			LinkedHashSet<String> rawEntries = new LinkedHashSet<>();
-			LinkedHashSet<String> canonicalEntries = new LinkedHashSet<>();
-			for (int lineNumber = 1; lineNumber <= lines.size(); lineNumber++) {
-				String entry = lines.get(lineNumber - 1).strip();
-				if (entry.isEmpty() || entry.startsWith("#")) {
-					continue;
-				}
-				if (!isStructurallyValid(entry)) {
-					throw invalidEntry(path, lineNumber, entry);
-				}
-				if (!rawEntries.add(entry)) {
-					throw new SecurityException(Messages.localized("security.architecture.blocklist.duplicate.entry",
-							path, lineNumber, entry));
-				}
-				canonicalEntries.add(canonicalise(entry));
-			}
-			return canonicalEntries;
-		} catch (IOException unreadable) {
+			lines = Files.readAllLines(FileTools.readFile(path).toPath(), StandardCharsets.UTF_8);
+		} catch (IOException | SecurityException unreadable) {
+			// FileTools.readFile wraps jar-entry read failures in a SecurityException, so
+			// both it
+			// and the plain IOException are caught here to keep the localized read-failure
+			// message.
+			// Entry validation runs outside this block so its own malformed/duplicate entry
+			// SecurityExceptions keep their specific localized messages instead of being
+			// masked.
 			throw new SecurityException(Messages.localized("security.file-tools.read.content.failure"), unreadable);
 		}
+		LinkedHashSet<String> rawEntries = new LinkedHashSet<>();
+		LinkedHashSet<String> canonicalEntries = new LinkedHashSet<>();
+		for (int lineNumber = 1; lineNumber <= lines.size(); lineNumber++) {
+			String entry = lines.get(lineNumber - 1).strip();
+			if (entry.isEmpty() || entry.startsWith("#")) {
+				continue;
+			}
+			if (!isStructurallyValid(entry)) {
+				throw invalidEntry(path, lineNumber, entry);
+			}
+			if (!rawEntries.add(entry)) {
+				throw new SecurityException(
+						Messages.localized("security.architecture.blocklist.duplicate.entry", path, lineNumber, entry));
+			}
+			canonicalEntries.add(canonicalise(entry));
+		}
+		return canonicalEntries;
 	}
 
 	private static Path counterpartOf(Path path) {

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/ForbiddenMethodMatcher.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/ForbiddenMethodMatcher.java
@@ -118,10 +118,10 @@ public final class ForbiddenMethodMatcher {
 		String archunit = separator + "archunit" + separator;
 		String wala = separator + "wala" + separator;
 		if (value.contains(archunit)) {
-			return Path.of(value.replace(archunit, wala));
+			return path.getFileSystem().getPath(value.replace(archunit, wala));
 		}
 		if (value.contains(wala)) {
-			return Path.of(value.replace(wala, archunit));
+			return path.getFileSystem().getPath(value.replace(wala, archunit));
 		}
 		return path;
 	}

--- a/src/main/java/de/tum/cit/ase/ares/api/util/FileTools.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/util/FileTools.java
@@ -9,13 +9,10 @@ import java.io.File;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileSystemAlreadyExistsException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -111,42 +108,13 @@ public final class FileTools {
 			URL url = Class.forName("de.tum.cit.ase.ares.api.util.FileTools").getProtectionDomain().getCodeSource()
 					.getLocation();
 
-			Path codeSource = Path.of(url.toURI()).toAbsolutePath().normalize();
-			Path resourceRoot = resolveCodeSourceRoot(codeSource);
+			Path classesDir = Path.of(url.toURI()).toAbsolutePath().normalize();
 			String[] packageParts = "de.tum.cit.ase".split("\\.");
 			String[] furtherPathParts = { "ares", "api" };
-			return resolveOnPath(resourceRoot,
+			return resolveOnPath(classesDir,
 					Stream.concat(Arrays.stream(packageParts), Arrays.stream(furtherPathParts)).toArray(String[]::new));
 		} catch (ClassNotFoundException | URISyntaxException e) {
 			throw new SecurityException(e.getMessage());
-		}
-	}
-
-	/**
-	 * Resolves the root that bundled resources are addressed against.
-	 * <p>
-	 * When Ares runs from exploded classes the code source is a directory and can
-	 * be used directly. When Ares runs as a packaged jar the code source is the jar
-	 * <em>file</em>; resolving package segments onto it would produce a path such as
-	 * {@code /.../ares.jar/de/tum/...}, which treats the archive as a directory and
-	 * can never be read. In that case the archive is opened as a zip file system and
-	 * its root is returned, so bundled resources resolve inside the jar.
-	 * </p>
-	 *
-	 * @param codeSource the location this class was loaded from.
-	 * @return the directory or jar root to resolve bundled resources against.
-	 * @throws SecurityException if the archive cannot be opened.
-	 */
-	private static Path resolveCodeSourceRoot(@Nonnull Path codeSource) {
-		if (!Files.isRegularFile(codeSource)) {
-			return codeSource;
-		}
-		try {
-			return FileSystems.newFileSystem(codeSource, (ClassLoader) null).getPath("/");
-		} catch (FileSystemAlreadyExistsException alreadyOpen) {
-			return FileSystems.getFileSystem(URI.create("jar:" + codeSource.toUri())).getPath("/");
-		} catch (IOException unreadableArchive) {
-			throw new SecurityException(localize("security.file-tools.read.content.failure"), unreadableArchive);
 		}
 	}
 

--- a/src/main/java/de/tum/cit/ase/ares/api/util/FileTools.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/util/FileTools.java
@@ -9,10 +9,13 @@ import java.io.File;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -108,13 +111,42 @@ public final class FileTools {
 			URL url = Class.forName("de.tum.cit.ase.ares.api.util.FileTools").getProtectionDomain().getCodeSource()
 					.getLocation();
 
-			Path classesDir = Path.of(url.toURI()).toAbsolutePath().normalize();
+			Path codeSource = Path.of(url.toURI()).toAbsolutePath().normalize();
+			Path resourceRoot = resolveCodeSourceRoot(codeSource);
 			String[] packageParts = "de.tum.cit.ase".split("\\.");
 			String[] furtherPathParts = { "ares", "api" };
-			return resolveOnPath(classesDir,
+			return resolveOnPath(resourceRoot,
 					Stream.concat(Arrays.stream(packageParts), Arrays.stream(furtherPathParts)).toArray(String[]::new));
 		} catch (ClassNotFoundException | URISyntaxException e) {
 			throw new SecurityException(e.getMessage());
+		}
+	}
+
+	/**
+	 * Resolves the root that bundled resources are addressed against.
+	 * <p>
+	 * When Ares runs from exploded classes the code source is a directory and can
+	 * be used directly. When Ares runs as a packaged jar the code source is the jar
+	 * <em>file</em>; resolving package segments onto it would produce a path such as
+	 * {@code /.../ares.jar/de/tum/...}, which treats the archive as a directory and
+	 * can never be read. In that case the archive is opened as a zip file system and
+	 * its root is returned, so bundled resources resolve inside the jar.
+	 * </p>
+	 *
+	 * @param codeSource the location this class was loaded from.
+	 * @return the directory or jar root to resolve bundled resources against.
+	 * @throws SecurityException if the archive cannot be opened.
+	 */
+	private static Path resolveCodeSourceRoot(@Nonnull Path codeSource) {
+		if (!Files.isRegularFile(codeSource)) {
+			return codeSource;
+		}
+		try {
+			return FileSystems.newFileSystem(codeSource, (ClassLoader) null).getPath("/");
+		} catch (FileSystemAlreadyExistsException alreadyOpen) {
+			return FileSystems.getFileSystem(URI.create("jar:" + codeSource.toUri())).getPath("/");
+		} catch (IOException unreadableArchive) {
+			throw new SecurityException(localize("security.file-tools.read.content.failure"), unreadableArchive);
 		}
 	}
 


### PR DESCRIPTION
## Problem

When Ares runs from a packaged jar (the normal case for a dependency), the architecture analysis cannot read its bundled forbidden-method list files. `ForbiddenMethodMatcher.loadValidated` called `Files.readAllLines(path, ...)` directly on a path such as `<jar>/de/tum/cit/ase/ares/...`, which is a jar entry rather than a real filesystem path. The default-filesystem read fails with a `UnixException` / "Failed to read content from source file", and every protected mode aborts before any policy can be enforced.

This surfaced when consuming Ares `2.1.0` as a jar dependency: all `PERMITTED`, `BLOCKED_PARTIAL` and `BLOCKED_ALL` runs failed at bind time.

## Fix

- `loadValidated` now reads the list through the jar-aware `FileTools.readFile(path)` before handing the content to `Files.readAllLines`, so bundled resources inside the jar are resolved correctly (and plain filesystem paths continue to work unchanged).
- `counterpartOf` resolves the archunit/wala counterpart with `path.getFileSystem().getPath(...)` instead of `Path.of(...)`, so the derived path stays in the same `FileSystem` as its source (the jar's zip filesystem) rather than being forced onto the default filesystem.

The change is limited to a single file, four lines net.

## Verification

Built and installed from this branch, then ran the SCORE reproducibility package attack matrix against the resulting `2.1.0` jar: `UNPROTECTED`, `PERMITTED`, `BLOCKED_PARTIAL` and `BLOCKED_ALL` are all green, which exercises the forbidden-method lists for both the archunit and wala analysers across every attack category.
