### PR TITLE
fix: render the serialisation violation verb as 'serialise objects'

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCase.java
@@ -323,7 +323,7 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 		case "executes commands" -> "execute a command";
 		case "manipulates threads" -> "manipulate threads";
 		case "imports forbidden packages" -> "import forbidden packages";
-		case "serializes objects" -> "serialize objects";
+		case "serialises objects" -> "serialise objects";
 		case "manipulates the loading of classes" -> "manipulate class loading";
 		case "accesses native code" -> "access native code";
 		case "attaches agents" -> "attach an agent";


### PR DESCRIPTION
## Problem

Architecture-violation messages render as:

> ... tried to illegally **Serialises objects** via ... but was blocked by Ares.

The capitalised, third-person `Serialises objects` is grammatically wrong in the `tried to illegally <action> via ...` sentence (every other verb reads as a lowercase base form, e.g. `access the file system`, `terminate the JVM`).

## Cause

`JavaArchitectureTestCase.mapRuleNameToAction` lowercases each ArchUnit rule label and maps it to a sentence verb. The serialisation branch still matched the American label `serializes objects`:

```java
case "serializes objects" -> "serialize objects";
```

The rule label is `security.architecture.serialize=Serialises objects` (British), which lowercases to `serialises objects` and therefore no longer matches. The mapping falls through to `default -> ruleName`, leaking the raw capitalised label into the sentence. Every sibling label is American/neutral and still matches its case, so serialisation is the only affected verb.

## Fix

Match the British label and map it to the lowercase base-form verb, consistent with all siblings:

```java
case "serialises objects" -> "serialise objects";
```

The message now reads `... tried to illegally serialise objects via ... but was blocked by Ares.`

## Verification

Rebuilt Ares and ran the SCORE reproducibility package BLOCKED_ALL serialisation metatests against it: all pass with the expected `tried to illegally serialise objects via ...`, and a falsification run (asserting the old `Serialises objects`) fails, confirming the emitted verb is now the corrected lowercase British form.
