### PR TITLE
Update README Java examples to Java 25

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ endif::env-github[]
 
 
 Ares 2 is a framework for easy and secure remote execution of student submissions on the interactive learning platform.
-It is the second Java-based implementation of the Secure COder Remote Execution (SCORE) framework and the first one supporting Java 17 and later versions.
+It is the second Java-based implementation of the Secure COder Remote Execution (SCORE) framework and the first one supporting Java 25 and later versions.
 
 Its main features are:
 
@@ -93,7 +93,7 @@ in production._
 
 === Setup
 
-Assume you have a Java 17 Maven project, and the inside of `pom.xml`
+Assume you have a Java 25 Maven project, and the inside of `pom.xml`
 looks like this:
 
 [source,xml]


### PR DESCRIPTION
## Summary

- update the stated supported Java version from Java 17 to Java 25
- update the Maven project example from Java 17 to Java 25
- retain the minimum requirement that Ares2 requires at least Java 17

## Impact

The README now presents Java 25 as the current supported and example version while preserving Java 17 as the minimum supported version.

## Validation

- verified that the two intended references now say `Java 25`
- verified that `Ares2 requires at least Java 17` remains unchanged
- ran `git diff --check`