### PR TITLE
Configurable termination grace, structured network receiver check and a serialisation regression test

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/StrictTimeout.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/StrictTimeout.java
@@ -47,4 +47,15 @@ public @interface StrictTimeout {
 	 * @see TimeUnit
 	 */
 	TimeUnit unit() default TimeUnit.SECONDS;
+
+	/**
+	 * The bounded period allowed for an interrupted test to terminate before Ares
+	 * treats the test worker as contaminated.
+	 */
+	long terminationGrace() default 50;
+
+	/**
+	 * The unit of the termination grace period, <b>defaults to milliseconds</b>.
+	 */
+	TimeUnit terminationGraceUnit() default TimeUnit.MILLISECONDS;
 }

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
@@ -293,7 +293,14 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 		}
 		if (value instanceof URLConnection urlConnection) {
 			requireTrustedRuntimeType(value);
-			return variableToTarget(urlConnection.getURL());
+			try {
+				return variableToTarget(urlConnection.getURL());
+			} catch (RuntimeException ignored) {
+				// Some JDK URLConnection implementations delegate getURL() to an object
+				// that is not assigned until construction has completed. Advice may observe
+				// such an instance while its constructor is still running.
+				return null;
+			}
 		}
 		if (value instanceof DatagramPacket datagramPacket) {
 			requireTrustedRuntimeType(value);
@@ -843,15 +850,28 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 		// </editor-fold>
 		// <editor-fold desc="Check receiver instance">
 		@Nullable
-		String networkIllegallyInteractedThroughReceiver = instance == null ? null
-				: checkIfVariableCriteriaIsViolated(new Object[] { instance }, allowedHosts, allowedPorts,
-						IgnoreValues.NONE);
-		if (networkIllegallyInteractedThroughReceiver != null) {
-			throw new SecurityException(localize("security.advice.illegal.network.execution",
-					networkSystemMethodToCheck, action, networkIllegallyInteractedThroughReceiver,
-					fullMethodSignature
-							+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")") + " | "
-							+ buildDenialReason(noAllowRuleConfigured)));
+		NetworkTarget targetFromReceiver = variableToTarget(instance);
+		if (targetFromReceiver != null) {
+			if (checkIfNetworkIsForbidden(targetFromReceiver, allowedHosts, allowedPorts)) {
+				throw new SecurityException(localize("security.advice.illegal.network.execution",
+						networkSystemMethodToCheck, action, targetFromReceiver.toDisplayString(),
+						fullMethodSignature
+								+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")") + " | "
+								+ buildDenialReason(noAllowRuleConfigured)));
+			}
+		} else if (instance != null) {
+			// Fall back to the criteria scan for receivers that cannot be resolved into a
+			// structured target, so no receiver type loses its check.
+			@Nullable
+			String networkIllegallyInteractedThroughReceiver = checkIfVariableCriteriaIsViolated(
+					new Object[] { instance }, allowedHosts, allowedPorts, IgnoreValues.NONE);
+			if (networkIllegallyInteractedThroughReceiver != null) {
+				throw new SecurityException(localize("security.advice.illegal.network.execution",
+						networkSystemMethodToCheck, action, networkIllegallyInteractedThroughReceiver,
+						fullMethodSignature
+								+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")") + " | "
+								+ buildDenialReason(noAllowRuleConfigured)));
+			}
 		}
 		// </editor-fold>
 		// <editor-fold desc="Check attributes">

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
@@ -851,27 +851,16 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 		// <editor-fold desc="Check receiver instance">
 		@Nullable
 		NetworkTarget targetFromReceiver = variableToTarget(instance);
-		if (targetFromReceiver != null) {
-			if (checkIfNetworkIsForbidden(targetFromReceiver, allowedHosts, allowedPorts)) {
-				throw new SecurityException(localize("security.advice.illegal.network.execution",
-						networkSystemMethodToCheck, action, targetFromReceiver.toDisplayString(),
-						fullMethodSignature
-								+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")") + " | "
-								+ buildDenialReason(noAllowRuleConfigured)));
-			}
-		} else if (instance != null) {
-			// Fall back to the criteria scan for receivers that cannot be resolved into a
-			// structured target, so no receiver type loses its check.
-			@Nullable
-			String networkIllegallyInteractedThroughReceiver = checkIfVariableCriteriaIsViolated(
-					new Object[] { instance }, allowedHosts, allowedPorts, IgnoreValues.NONE);
-			if (networkIllegallyInteractedThroughReceiver != null) {
-				throw new SecurityException(localize("security.advice.illegal.network.execution",
-						networkSystemMethodToCheck, action, networkIllegallyInteractedThroughReceiver,
-						fullMethodSignature
-								+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")") + " | "
-								+ buildDenialReason(noAllowRuleConfigured)));
-			}
+		// No separate criteria scan is needed for a receiver that does not resolve into
+		// a structured target: the scan would route this same instance back through
+		// variableToTarget, which just returned null, so it could never throw. Only the
+		// resolved-target check below can flag a forbidden receiver.
+		if (targetFromReceiver != null && checkIfNetworkIsForbidden(targetFromReceiver, allowedHosts, allowedPorts)) {
+			throw new SecurityException(localize("security.advice.illegal.network.execution",
+					networkSystemMethodToCheck, action, targetFromReceiver.toDisplayString(),
+					fullMethodSignature
+							+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")") + " | "
+							+ buildDenialReason(noAllowRuleConfigured)));
 		}
 		// </editor-fold>
 		// <editor-fold desc="Check attributes">

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolbox.java
@@ -295,6 +295,11 @@ public final class JavaInstrumentationAdviceNetworkSystemToolbox extends JavaIns
 			requireTrustedRuntimeType(value);
 			try {
 				return variableToTarget(urlConnection.getURL());
+			} catch (SecurityException denied) {
+				// A SecurityException here is an Ares enforcement denial, not a resolution
+				// failure. Swallowing it would turn a denial into a null target and skip the
+				// receiver check, so it must propagate rather than fail open.
+				throw denied;
 			} catch (RuntimeException ignored) {
 				// Some JDK URLConnection implementations delegate getURL() to an object
 				// that is not assigned until construction has completed. Advice may observe

--- a/src/main/java/de/tum/cit/ase/ares/api/internal/TimeoutUtils.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/internal/TimeoutUtils.java
@@ -30,8 +30,14 @@ public final class TimeoutUtils {
 		return strictTimeout.map(st -> Duration.of(st.value(), st.unit().toChronoUnit()));
 	}
 
+	static Optional<Duration> findTerminationGracePeriod(TestContext context) {
+		var strictTimeout = TestContextUtils.findAnnotationIn(context, StrictTimeout.class);
+		return strictTimeout.map(st -> Duration.of(st.terminationGrace(), st.terminationGraceUnit().toChronoUnit()));
+	}
+
 	public static <T> T performTimeoutExecution(ThrowingSupplier<T> execution, TestContext context) throws Throwable {
-		return performTimeoutExecution(execution, context, DEFAULT_TERMINATION_GRACE_PERIOD);
+		Duration terminationGracePeriod = findTerminationGracePeriod(context).orElse(DEFAULT_TERMINATION_GRACE_PERIOD);
+		return performTimeoutExecution(execution, context, terminationGracePeriod);
 	}
 
 	public static <T> T performTimeoutExecution(ThrowingSupplier<T> execution, TestContext context,

--- a/src/test/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolboxTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/aop/java/instrumentation/advice/JavaInstrumentationAdviceNetworkSystemToolboxTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.FileDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -21,6 +22,7 @@ import java.net.URLConnection;
 import java.net.UnixDomainSocketAddress;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.nio.channels.DatagramChannel;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
@@ -202,6 +204,58 @@ class JavaInstrumentationAdviceNetworkSystemToolboxTest {
 			toDisplayString.setAccessible(true);
 			assertEquals("127.0.0.1:" + serverSocket.getLocalPort(), toDisplayString.invoke(target));
 		}
+	}
+
+	@Test
+	void toTarget_extractsRemoteHostAndPortFromConnectedDatagramSocket() throws Exception {
+		Method toTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("toTarget",
+				Object.class);
+		toTarget.setAccessible(true);
+
+		try (DatagramSocket socket = new DatagramSocket()) {
+			socket.connect(new InetSocketAddress("127.0.0.1", 12345));
+			Object target = toTarget.invoke(null, socket);
+			assertNotNull(target);
+
+			Method toDisplayString = target.getClass().getDeclaredMethod("toDisplayString");
+			toDisplayString.setAccessible(true);
+			assertEquals("127.0.0.1:12345", toDisplayString.invoke(target));
+		}
+	}
+
+	@Test
+	void toTarget_extractsRemoteHostAndPortFromConnectedDatagramChannel() throws Exception {
+		Method toTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("toTarget",
+				Object.class);
+		toTarget.setAccessible(true);
+
+		try (DatagramChannel channel = DatagramChannel.open()) {
+			channel.connect(new InetSocketAddress("127.0.0.1", 12345));
+			Object target = toTarget.invoke(null, channel);
+			assertNotNull(target);
+
+			Method toDisplayString = target.getClass().getDeclaredMethod("toDisplayString");
+			toDisplayString.setAccessible(true);
+			assertEquals("127.0.0.1:12345", toDisplayString.invoke(target));
+		}
+	}
+
+	@Test
+	void toTarget_returnsNullWhenUrlConnectionCannotExposeUrlDuringConstruction() throws Exception {
+		Method toTarget = JavaInstrumentationAdviceNetworkSystemToolbox.class.getDeclaredMethod("toTarget",
+				Object.class);
+		toTarget.setAccessible(true);
+		Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+		var unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+		unsafeField.setAccessible(true);
+		Object unsafe = unsafeField.get(null);
+		Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
+		Object connection = allocateInstance.invoke(unsafe,
+				Class.forName("sun.net.www.protocol.https.HttpsURLConnectionImpl"));
+
+		Object target = toTarget.invoke(null, connection);
+
+		assertNull(target);
 	}
 
 	@Test

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCaseTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCaseTest.java
@@ -106,4 +106,17 @@ public class JavaArchitectureTestCaseTest {
 						|| thrown.getMessage().contains("Ares Sicherheitsfehler"),
 				"Exception message should contain Ares Security Error prefix");
 	}
+
+	@Test
+	void testParseErrorMessage_withBritishSerializationRule_normalisesAction() {
+		String message = "Architecture Violation [Priority: MEDIUM] - Rule 'Serialises objects' was violated (1 time):\n"
+				+ "Method <com.example.Test.serialize()> calls method <java.io.ObjectOutputStream.writeObject(java.lang.Object)>";
+		AssertionError error = new AssertionError(message);
+
+		SecurityException thrown = assertThrows(SecurityException.class,
+				() -> JavaArchitectureTestCase.parseErrorMessage(error));
+
+		assertTrue(thrown.getMessage().contains("serialise objects"),
+				() -> "Exception message should use the normalised serialisation action: " + thrown.getMessage());
+	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCaseTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCaseTest.java
@@ -118,5 +118,7 @@ public class JavaArchitectureTestCaseTest {
 
 		assertTrue(thrown.getMessage().contains("serialise objects"),
 				() -> "Exception message should use the normalised serialisation action: " + thrown.getMessage());
+		assertFalse(thrown.getMessage().contains("Serialises objects"),
+				() -> "Exception message must not leak the original capitalised rule label: " + thrown.getMessage());
 	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/api/internal/TimeoutUtilsTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/internal/TimeoutUtilsTest.java
@@ -58,6 +58,40 @@ class TimeoutUtilsTest {
 	}
 
 	@Test
+	void interruptionAwareExecutionHasTimeForBoundedFrameworkCleanup() throws Exception {
+		AtomicBoolean workerFinished = new AtomicBoolean();
+		AtomicInteger requestedExitCode = new AtomicInteger(-1);
+		TestContext context = contextFor("strictTimeoutTarget"); //$NON-NLS-1$
+
+		assertThrows(AssertionFailedError.class, () -> TimeoutUtils.performTimeoutExecution(() -> {
+			try {
+				while (!Thread.currentThread().isInterrupted()) {
+					Thread.onSpinWait();
+				}
+			} finally {
+				long cleanupDeadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(200);
+				while (System.nanoTime() < cleanupDeadline) {
+					Thread.onSpinWait();
+				}
+				workerFinished.set(true);
+			}
+			return null;
+		}, context, Duration.ofSeconds(1), requestedExitCode::set));
+
+		assertThat(workerFinished).isTrue();
+		assertThat(requestedExitCode).hasValue(-1);
+	}
+
+	@Test
+	void resolvesInstructorConfiguredTerminationGracePeriod() throws Exception {
+		TestContext context = contextFor("strictTimeoutWithCustomTerminationGrace"); //$NON-NLS-1$
+
+		Optional<Duration> terminationGracePeriod = TimeoutUtils.findTerminationGracePeriod(context);
+
+		assertThat(terminationGracePeriod).contains(Duration.ofSeconds(10));
+	}
+
+	@Test
 	void interruptionIgnoringExecutionInvalidatesTheCurrentFork() throws Exception {
 		AtomicBoolean releaseWorker = new AtomicBoolean();
 		AtomicInteger requestedExitCode = new AtomicInteger(-1);
@@ -110,5 +144,10 @@ class TimeoutUtilsTest {
 	@StrictTimeout(value = 20, unit = TimeUnit.MILLISECONDS)
 	private static void strictTimeoutTarget() {
 		// Provides the annotation consumed through the mocked test context.
+	}
+
+	@StrictTimeout(value = 20, unit = TimeUnit.MILLISECONDS, terminationGrace = 10, terminationGraceUnit = TimeUnit.SECONDS)
+	private static void strictTimeoutWithCustomTerminationGrace() {
+		// Provides the custom termination grace consumed through the mocked context.
 	}
 }


### PR DESCRIPTION
## Summary

Three independent changes: make the post-interruption termination grace period configurable via `@StrictTimeout`, resolve the network receiver through the structured target path (with a fail-closed fix so an enforcement denial cannot be swallowed), and add a regression test pinning the British serialisation rule label.

## Linked issues

None.

## 1. Problem

Three separate items on one branch, each with its own root cause.

**Termination grace period was a fixed constant.** A timed-out test is interrupted once and then given a bounded period to leave its body before Ares treats the worker as contaminated and halts the fork. That period was a hard-coded 50 ms (`DEFAULT_TERMINATION_GRACE_PERIOD`), too short for interruption-aware cleanup in some exercises. Root cause layer: the timeout enforcement plumbing in `internal`/`api`. It matters as a false positive: a correct submission whose interruption-aware cleanup needs slightly longer than 50 ms is wrongly failed.

**The network receiver was checked only through the string-based criteria scan.** In the instrumentation network advice (`JavaInstrumentationAdviceNetworkSystemToolbox`), the receiver instance went through `checkIfVariableCriteriaIsViolated`, which reports a less precise display string than the structured parameter path. Separately, `variableToTarget` on a `URLConnection` called `getURL()` unconditionally, which can throw while the connection's constructor is still running (some JDK implementations delegate `getURL()` to an object not yet assigned). Root cause layer: the instrumentation (AOP) enforcement layer. The imprecise display string is a diagnostics weakness; the `getURL()` throw is a robustness gap.

**A subtle fail-open risk introduced while fixing the above.** The first cut of the `URLConnection` fix caught `RuntimeException` and returned `null` to tolerate the construction-time `getURL()` failure. A `SecurityException` is a `RuntimeException`, so an Ares enforcement denial raised while resolving the receiver would have been swallowed and turned into a `null` target, skipping the receiver check and failing open. This is the direction that matters for a security tool: it would let a forbidden receiver through.

**The serialisation rule label had no regression test.** The mapping that normalises the ArchUnit rule label `Serialises objects` to the action `serialise objects` was fixed upstream in `943a0cc0`; nothing pinned it, so a future casing leak into the reported sentence would go unnoticed.

## 2. Improvement from the user's perspective

- An instructor can now set `@StrictTimeout(terminationGrace = ..., terminationGraceUnit = ...)` so interruption-aware cleanup gets the time it needs, instead of being bounded to a fixed 50 ms. The defaults preserve the previous 50 ms, so nothing changes unless the attributes are set.
- A denied network interaction through the receiver is now reported with the more precise structured display string (for example `127.0.0.1:12345`) rather than the coarser criteria-scan string.
- A forbidden receiver can no longer slip through because an enforcement `SecurityException` was caught and turned into a `null` target during receiver resolution.

## 3. Improvement from the maintainer's perspective

- The termination grace period is now read from the annotation in one place (`TimeoutUtils.findTerminationGracePeriod`), mirroring the existing `findTimeout`.
- The receiver check has a single resolved-target path: the dead criteria-scan fallback (which routed the same instance back through `variableToTarget`, having just returned `null`, so it could never throw) was removed, taking a Checkstyle formatting violation with it.
- New unit tests pin the previously uncovered behaviours: structured resolution of a connected `DatagramSocket` and `DatagramChannel`, the `null` return when a `URLConnection` cannot expose its URL during construction, the instructor-configured grace period, bounded-cleanup completion, and the normalised serialisation label (including that the capitalised original label does not leak).

**Known gap, deliberately not addressed here:** `JqwikStrictTimeoutExtension` passes its own hard-coded one-second period to the three-argument overload, so the new `@StrictTimeout` attributes do not affect jqwik properties yet.

**Dropped from an earlier revision:** a commit that also disabled `StrictTimeout` for the JUnit lifecycle hooks was removed. It reproducibly broke `StrictTimeoutTest.test_time_testClassFailLoop` and would have left student code invoked from an instructor `@BeforeEach` unbounded.

## 4. Testing manual

**Prerequisites**

1. JDK 21 and Maven, as for any Ares 2 build. No exercise repository or policy file is needed; the added tests drive the advice and the timeout utilities directly. A loopback address is used by the datagram tests, no external echo server is required.
2. Check out this branch.

**Steps**

1. `mvn -o test -Dtest=TimeoutUtilsTest,JavaInstrumentationAdviceNetworkSystemToolboxTest,JavaArchitectureTestCaseTest -f pom.xml`
2. Full run for the mode combinations: `mvn test -f pom.xml`

**Expected result**

- Step 1: the targeted tests pass, including `resolvesInstructorConfiguredTerminationGracePeriod` (resolves 10 s from `@StrictTimeout(value = 20, unit = MILLISECONDS, terminationGrace = 10, terminationGraceUnit = SECONDS)`), `interruptionAwareExecutionHasTimeForBoundedFrameworkCleanup`, `toTarget_extractsRemoteHostAndPortFromConnectedDatagramSocket` / `...DatagramChannel` (both display `127.0.0.1:12345`), `toTarget_returnsNullWhenUrlConnectionCannotExposeUrlDuringConstruction`, and `testParseErrorMessage_withBritishSerializationRule_normalisesAction`.
- Step 2: `BUILD SUCCESS`. The full branch run was 2619 tests, 0 failures, 0 errors, 230 skipped.

**Negative case (what must still be rejected)**

- An untrusted runtime type is still rejected: `requireTrustedRuntimeType` stays outside the guarded block, so it is not swallowed by the `getURL()` tolerance.
- An enforcement `SecurityException` raised while resolving a `URLConnection` receiver must still propagate (fail closed), not be caught and turned into a `null` target: the `catch (SecurityException denied) { throw denied; }` before the broad `catch` guarantees this.
- The attribute scan stays unconditional: a target resolved from parameters or receiver must not suppress the attribute check, because attributes are a disjoint value set.
- The normalised serialisation message must contain `serialise objects` and must not leak the capitalised `Serialises objects` label.

**Modes exercised**

<!--
  The new tests are mode-independent: TimeoutUtilsTest and JavaArchitectureTestCaseTest
  drive the utilities directly, and the advice tests invoke JavaInstrumentationAdviceNetworkSystemToolbox
  by reflection. The receiver-resolution change lives in the instrumentation advice, so it is
  specific to the two instrumentation modes; the termination-grace and serialisation-label
  changes are mode-independent. The full `mvn test` run (green) exercises all four combinations.
-->

- [x] ArchUnit + AspectJ
- [x] ArchUnit + instrumentation
- [x] WALA + AspectJ
- [x] WALA + instrumentation

## 5. Test case coverage regarding this PR

Instruction, Branch, Line and Method coverage for every production class changed in this PR, read from the aggregated JaCoCo report produced by the "Coverage Report" job of this PR's Maven workflow run. Nested classes (for example a record's `Builder`) are listed as their own rows. `n/a` means the class has no executable lines of that counter (for example an annotation or interface) or was not present in the report.

<!-- ARES-COVERAGE:START -->
| Class | Instruction | Branch | Line | Method |
| --- | ---: | ---: | ---: | ---: |
| `TimeoutUtils` | 86.9% (245/282) | 83.3% (20/24) | 85.5% (59/69) | 94.1% (16/17) |
| `TimeoutUtils.WhitelistedThreadFactory` | 88.5% (23/26) | 50.0% (1/2) | 83.3% (5/6) | 100.0% (2/2) |
| `JavaInstrumentationAdviceNetworkSystemToolbox` | 70.5% (991/1405) | 65.4% (189/289) | 73.2% (227/310) | 91.7% (22/24) |
| `StrictTimeout` | n/a | n/a | n/a | n/a |
| **Total (changed classes)** | **73.5% (1259/1713)** | **66.7% (210/315)** | **75.6% (291/385)** | **93.0% (40/43)** |

_`StrictTimeout` is an annotation type with no executable lines; its two new attributes are exercised via `TimeoutUtilsTest.resolvesInstructorConfiguredTerminationGracePeriod`._
<!-- ARES-COVERAGE:END -->

## Breaking changes and migration

None. `@StrictTimeout` gains `terminationGrace` and `terminationGraceUnit`, both with defaults (`50` and `TimeUnit.MILLISECONDS`) that preserve the previous behaviour, so existing annotations are unaffected. This is an additive public-API change under `de.tum.cit.ase.ares.api`, not a break. No policy file format, generated security test code or minimum JDK/Maven/Gradle version changes.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
- [x] Tests were added or updated for the behaviour changed here.
- [x] Documentation (`docs/`, `README.adoc`, Javadoc) was updated where the change is user-facing. The new `@StrictTimeout` attributes carry Javadoc; no `docs/` page describes the fixed-50 ms grace period.
- [x] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test
