### PR TITLE
Correct and extend the Ares project setup guide

### DIFF
--- a/docs/HowToMakeAProjectAnAresProject.md
+++ b/docs/HowToMakeAProjectAnAresProject.md
@@ -15,7 +15,7 @@
 ## Table of Contents
 
 1. [Prerequisites](#1-prerequisites)
-2. [Purpose: What Problem Does This Solve?](#2-purpose--what-problem-does-this-solve)
+2. [Purpose: What Problem Does This Solve?](#2-purpose-what-problem-does-this-solve)
 3. [Add Ares dependencies and agent setup](#3-add-ares-dependencies-and-agent-setup)
    - [3.1 Gradle (recommended)](#31-gradle-recommended)
      - [3.1.1 Configure repository lookup](#311-configure-repository-lookup)
@@ -29,9 +29,16 @@
      - [3.2.3 Attach agent via maven-surefire-plugin](#323-attach-agent-via-maven-surefire-plugin)
      - [3.2.4 Configure AspectJ compile-time weaving](#324-configure-aspectj-compile-time-weaving)
 4. [Verify your setup](#4-verify-your-setup)
-5. [Next steps](#5-next-steps)
-6. [Troubleshooting](#6-troubleshooting)
-7. [Glossary](#7-glossary)
+   - [4.1 Step 1: Confirm Ares is on the classpath](#41-step-1-confirm-ares-is-on-the-classpath)
+   - [4.2 Step 2: Prove that enforcement actually happens](#42-step-2-prove-that-enforcement-actually-happens)
+5. [Upgrading from Ares 1 to Ares 2.1.0](#5-upgrading-from-ares-1-to-ares-210)
+   - [5.1 Replace the dependency](#51-replace-the-dependency)
+   - [5.2 Rename the package](#52-rename-the-package)
+   - [5.3 Map the annotations](#53-map-the-annotations)
+   - [5.4 Add `@Policy` to every test class](#54-add-policy-to-every-test-class)
+6. [Next steps](#6-next-steps)
+7. [Troubleshooting](#7-troubleshooting)
+8. [Glossary](#8-glossary)
 
 ---
 
@@ -252,6 +259,7 @@ Configure the Surefire test plugin to load the agent during test execution:
     <artifactId>maven-surefire-plugin</artifactId>
     <configuration>
         <argLine>
+            @{argLine}
             -javaagent:${settings.localRepository}/de/tum/cit/ase/ares/2.1.0/ares-2.1.0-agent.jar
             -Xbootclasspath/a:${settings.localRepository}/org/aspectj/aspectjrt/1.9.25.1/aspectjrt-1.9.25.1.jar
             --add-exports java.base/java.lang=ALL-UNNAMED
@@ -278,6 +286,7 @@ Configure the Surefire test plugin to load the agent during test execution:
 
 **Explanation:**
 - `argLine`: JVM arguments passed to every test execution
+- `@{argLine}`: Preserves JVM arguments that other plugins contribute late in the build, most importantly the JaCoCo agent injected by `jacoco:prepare-agent`. Surefire's `argLine` is a single value, so a `<argLine>` that omits `@{argLine}` **replaces** those contributions instead of adding to them, and the other agent is dropped silently, with no warning and a still-green build. Verified with Surefire 3.5.2 and JaCoCo 0.8.12: without `@{argLine}` the JaCoCo agent was absent from the test JVM; with it, both agents were present. Ares's own `pom.xml` uses `@{argLine}` for this reason. Keep it as the first entry even if you do not use JaCoCo today, so that adding a coverage or profiling plugin later does not silently disable it
 - `-javaagent:${settings.localRepository}/...`: Path to the **agent** JAR (note the `-agent` suffix) in the local Maven repository (Maven resolves `${settings.localRepository}` to `~/.m2/repository`). When updating the Ares version, update both the `<version>` in the dependency and the version in this path.
 - `-Xbootclasspath/a:...`: Appends the AspectJ **runtime** JAR (`aspectjrt`) to the bootstrap classpath so that woven bytecode can resolve AspectJ runtime types at the bootstrap class-loader level. `aspectjrt` is a separate Maven artefact (`org.aspectj:aspectjrt`), so its repository path follows the standard Maven layout. You may need to adjust the version (`1.9.25.1`) if a newer AspectJ version is required.
 - **JVM Module Access Flags** (same as Gradle, see [Section 3.1.4](#314-attach-agent-to-test-execution) for the full per-flag explanation):
@@ -357,7 +366,11 @@ Your build must run the AspectJ compiler (`ajc`) to weave the Ares security aspe
 
 ## 4. Verify your setup
 
-Create a minimal test to confirm Ares is working. This test does **not** require a `SecurityPolicy.yaml` file. A passing run confirms that the Ares classes are available on the test classpath and that the test JVM starts with the configured arguments; it does **not** prove that the agent performed any instrumentation. Note that the test is not enforcement-free either: without a `@Policy` annotation, Ares's JUnit extension still applies its default, most restrictive security policy to the test:
+Verification has two steps, and **only the second one proves anything about security**.
+
+### 4.1 Step 1: Confirm Ares is on the classpath
+
+This test does **not** require a `SecurityPolicy.yaml` file:
 
 ```java
 import de.tum.cit.ase.ares.api.jupiter.Public;
@@ -370,22 +383,135 @@ public class AresSetupVerificationTest {
     @Public
     @Test
     void aresSetupIsAvailable() {
-        // If this test compiles and runs without errors, the Ares classes are on the
-        // test classpath and the default security policy could be applied.
+        // If this test compiles and runs, the Ares classes are on the test classpath
+        // and the test JVM started with the configured arguments.
         assertDoesNotThrow(() -> {});
     }
 }
 ```
 
-Run `./gradlew test` (or `mvn test`). If the test passes, the Ares dependency and JVM arguments are correctly set up. To verify that the agent and the weaving actually enforce restrictions, write a test whose code performs a forbidden operation (e.g., writing a file outside the allowed paths) and check that it fails with an Ares security error.
+Run `./gradlew test` (or `mvn test`). A pass confirms the dependency and the JVM arguments resolve. It confirms **nothing else**.
 
-> **Note:** To verify full policy enforcement, also create a `SecurityPolicy.yaml` and add `@Policy` to your test (see [Next steps](#5-next-steps)).
+> **Warning: a test without `@Policy` is not protected.**
+> A test class that has no `@Policy` annotation (directly, or inherited from a meta-annotation) runs with **no security enforcement at all**. Ares does not fall back to a restrictive default for such tests. Verified against Ares 2.1.0: in a test class shaped exactly like `AresSetupVerificationTest` above, student code called `Files.readString(Path.of("build.gradle"))` and read the file's full 4233 bytes without being blocked.
+>
+> Enforcement is opt-in per test class. See [Section 4.2](#42-step-2-prove-that-enforcement-actually-happens) and [Section 6](#6-next-steps).
+
+### 4.2 Step 2: Prove that enforcement actually happens
+
+This is the step that verifies security. Add a class in the supervised package that performs a forbidden operation, and a test **carrying `@Policy`** that calls it:
+
+```java
+// In the supervised (student) package, e.g. src/main/java/com/example/AresProbe.java
+package com.example;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class AresProbe {
+    public static String readSecret() throws Exception {
+        return Files.readString(Path.of("build.gradle"));
+    }
+}
+```
+
+```java
+// In the test sources
+import de.tum.cit.ase.ares.api.Policy;
+import de.tum.cit.ase.ares.api.jupiter.PublicTest;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Policy(value = "src/test/resources/SecurityPolicy.yaml", withinPath = "classes/java/main/com/example")
+class AresEnforcementTest {
+
+    @PublicTest
+    void forbiddenFileReadMustBeBlocked() {
+        try {
+            AresProbe.readSecret();
+            fail("Ares did not block the forbidden file read: enforcement is NOT active.");
+        } catch (SecurityException expected) {
+            // Ares blocked the call, the setup enforces the policy.
+        } catch (Exception e) {
+            fail("Unexpected non-security exception: " + e);
+        }
+    }
+}
+```
+
+With a policy whose `regardingFileSystemInteractions` list is empty, this must terminate with a `java.lang.SecurityException` mentioning the offending call. If the test instead reports that nothing was blocked, enforcement is not active: re-check `@Policy`, `withinPath`, and the agent arguments before trusting the setup.
+
+Remove the probe class once the setup is confirmed.
+
+> **Note:** Creating the `SecurityPolicy.yaml` used above is covered in the [Security Policy Manual](policy/SecurityPolicyManual.md); see also [Next steps](#6-next-steps).
 
 > **What happens without the agent?** If the `-javaagent` flag is missing, Ares's **static analysis** (ArchUnit/WALA architecture tests) still works, and **AspectJ enforcement** also still works, because the aspects are woven into the bytecode at compile time. Only the **ByteBuddy instrumentation** enforcement path is inactive, since it relies on the agent to transform classes at load time. If you use an `INSTRUMENTATION` configuration, students could then bypass security restrictions at runtime, so always ensure the agent is loaded.
 
 ---
 
-## 5. Next steps
+## 5. Upgrading from Ares 1 to Ares 2.1.0
+
+Skip this section for a new project. It applies when your project currently uses Ares 1 (`de.tum.in.ase:artemis-java-test-sandbox`) and you are moving it onto Ares 2.1.0.
+
+The build changes in [Section 3](#3-add-ares-dependencies-and-agent-setup) are **not sufficient on their own**: the test sources must be migrated too, because Ares 1 expressed its security rules as annotations, whereas Ares 2 expresses them in a `SecurityPolicy.yaml` file.
+
+### 5.1 Replace the dependency
+
+Remove the Ares 1 dependency and add the Ares 2 dependencies from [Section 3](#3-add-ares-dependencies-and-agent-setup):
+
+```diff
+- testImplementation 'de.tum.in.ase:artemis-java-test-sandbox:1.15.0'
++ testImplementation "de.tum.cit.ase:ares:2.1.0"
+```
+
+### 5.2 Rename the package
+
+Every Ares 1 import moves from `de.tum.in.test.api` to `de.tum.cit.ase.ares.api`:
+
+```diff
+- import de.tum.in.test.api.jupiter.Public;
++ import de.tum.cit.ase.ares.api.jupiter.Public;
+```
+
+### 5.3 Map the annotations
+
+| Ares 1 (current) | Ares 2.1.0 (target) | Notes |
+|---|---|---|
+| `@Public`, `@PublicTest`, `@Hidden`, `@HiddenTest` | unchanged, new package | `de.tum.cit.ase.ares.api.jupiter` |
+| `@StrictTimeout`, `@MirrorOutput`, `@Deadline`, `@ExtendedDeadline` | unchanged, new package | `de.tum.cit.ase.ares.api` |
+| `structural.*TestProvider`, `util.ReflectionTestUtils`, `io.IOTester` | unchanged, new package | API-compatible |
+| `@WhitelistPath` | **removed** | Express as `regardingFileSystemInteractions` entries in the policy file |
+| `@BlacklistPath` | **removed** | Ares 2 is default-deny, so anything not permitted is already denied |
+| `@WhitelistClass` | **removed** | Express as `theFollowingClassesAreTestClasses` in the policy file |
+| `PathType` (`GLOB`, `STARTS_WITH`) | **removed** | Policy paths use `onThisPathAndAllPathsBelow` |
+
+Delete the removed annotations and their imports, then write the equivalent `SecurityPolicy.yaml` as described in the [Security Policy Manual](policy/SecurityPolicyManual.md).
+
+### 5.4 Add `@Policy` to every test class
+
+This step is easy to miss and fails silently. In Ares 1, a test was protected by virtue of the sandbox being installed. In Ares 2, **a test class with no `@Policy` runs unprotected** (see the warning in [Section 4.1](#41-step-1-confirm-ares-is-on-the-classpath)).
+
+Annotate every test class, and remember that `@Policy` is inherited through **meta-annotations**: if your exercise defines a marker annotation that its test classes carry, putting `@Policy` on that marker covers all of them.
+
+```java
+@Policy(value = "test/de/tum/cit/aet/SecurityPolicy.yaml", withinPath = "classes/java/main/de/tum/cit/aet")
+@Public
+@StrictTimeout(3)
+@Retention(RUNTIME)
+@Target({TYPE, ANNOTATION_TYPE})
+public @interface E01 {
+}
+```
+
+After migrating, audit for stragglers, since these are the classes that will run without enforcement:
+
+```bash
+grep -rL "@Policy" src/test/java --include="*Test.java"
+```
+
+---
+
+## 6. Next steps
 
 1. **Create a security policy and annotate tests:** Follow the [Security Policy Manual](policy/SecurityPolicyManual.md), which explains how to write `SecurityPolicy.yaml` files and apply the `@Policy` annotation to your tests.
 2. **Choose the right configuration:** Select one of the 8 `ProgrammingLanguageConfiguration` values matching your build tool, architecture analysis, and runtime enforcement:
@@ -408,19 +534,22 @@ Run `./gradlew test` (or `mvn test`). If the test passes, the Ares dependency an
 
 ---
 
-## 6. Troubleshooting
+## 7. Troubleshooting
 
 | Problem | Possible Cause | Solution |
 |---------|---------------|----------|
 | `ClassNotFoundException: de.tum.cit.ase.ares.api.Policy` | Ares not on the test classpath | Verify `testImplementation` dependency is present |
 | `Failed to find premain agent` or agent-related errors | Agent JAR not found or wrong classifier | Ensure the `aresAgent` dependency uses the `:agent` classifier (Gradle) or the `-agent.jar` suffix (Maven) |
 | Tests pass but student code is not restricted | `-javaagent` JVM argument missing | Check that `jvmArgs` / `<argLine>` includes the `-javaagent:...` path |
+| Tests pass but student code is not restricted | Test class has no `@Policy` | The most common cause. A test class without `@Policy` (direct or meta-annotated) runs with **no** enforcement; Ares does not apply a restrictive default. Find them with `grep -rL "@Policy" src/test/java --include="*Test.java"`. See [Section 4.1](#41-step-1-confirm-ares-is-on-the-classpath) |
+| Enforcement silently inactive for some tests only | `withinPath` points at a directory that does not exist | A `withinPath` that does not match the compiled student package resolves to an empty directory, so nothing is analysed and no error is raised. Confirm the path exists under `build/classes/java/main` (Gradle) or `target/classes` (Maven) after a build |
+| Coverage report empty after adding Ares (Maven) | `<argLine>` overwrote the JaCoCo agent | Put `@{argLine}` first inside `<argLine>`, see [Section 3.2.3](#323-attach-agent-via-maven-surefire-plugin) |
 | `InaccessibleObjectException` at runtime | Missing `--add-opens` / `--add-exports` flags | Ensure the complete list of JVM module access flags from [Section 3.1.4](#314-attach-agent-to-test-execution) / [Section 3.2.3](#323-attach-agent-via-maven-surefire-plugin) is present |
 | Policy seems to have no effect | Wrong `withinPath` | Gradle: `classes/java/main/<package/path>`, Maven: `classes/<package/path>` |
 
 ---
 
-## 7. Glossary
+## 8. Glossary
 
 | Term | Meaning |
 |------|----------|

--- a/docs/HowToMakeAProjectAnAresProject.md
+++ b/docs/HowToMakeAProjectAnAresProject.md
@@ -383,8 +383,9 @@ public class AresSetupVerificationTest {
     @Public
     @Test
     void aresSetupIsAvailable() {
-        // If this test compiles and runs, the Ares classes are on the test classpath
-        // and the test JVM started with the configured arguments.
+        // If this test compiles and runs, the Ares classes resolve on the test
+        // classpath and the JVM starts. It does not prove that any particular JVM
+        // argument, the -javaagent in particular, was supplied; Step 2 checks that.
         assertDoesNotThrow(() -> {});
     }
 }
@@ -392,10 +393,12 @@ public class AresSetupVerificationTest {
 
 Run `./gradlew test` (or `mvn test`). A pass confirms the dependency and the JVM arguments resolve. It confirms **nothing else**.
 
-> **Warning: a test without `@Policy` is not protected.**
-> A test class that has no `@Policy` annotation (directly, or inherited from a meta-annotation) runs with **no security enforcement at all**. Ares does not fall back to a restrictive default for such tests. Verified against Ares 2.1.0: in a test class shaped exactly like `AresSetupVerificationTest` above, student code called `Files.readString(Path.of("build.gradle"))` and read the file's full 4233 bytes without being blocked.
+> **Warning: add `@Policy` to every test class you want enforced.**
+> A supervised test (one carrying an Ares annotation such as `@Public`, `@PublicTest`, `@Hidden` or `@HiddenTest`) that has no `@Policy` does not run without a policy: Ares falls back to a **default most-restricted policy** that denies every file, network, command, thread and package access. What the fallback does not supply is a `withinPath` scope for that policy to enforce, and in the AspectJ enforcement mode only main classes are woven, not the test class (see [Section 3.2.4](#324-configure-aspectj-compile-time-weaving)). So a forbidden call made from the test class itself is not intercepted. Verified against Ares 2.1.0: in a class shaped exactly like `AresSetupVerificationTest` above, `Files.readString(Path.of("build.gradle"))` read the file's full 4233 bytes without being blocked, for exactly that reason.
 >
-> Enforcement is opt-in per test class. See [Section 4.2](#42-step-2-prove-that-enforcement-actually-happens) and [Section 6](#6-next-steps).
+> A class carrying **no** Ares test annotation at all is a separate case: it is not supervised, so no policy applies to it.
+>
+> Either way, do not rely on the fallback. Add `@Policy` with a correct `withinPath` so you get a policy you control and a scope that is actually enforced. See [Section 4.2](#42-step-2-prove-that-enforcement-actually-happens) and [Section 6](#6-next-steps).
 
 ### 4.2 Step 2: Prove that enforcement actually happens
 
@@ -417,11 +420,13 @@ public class AresProbe {
 
 ```java
 // In the test sources
+import com.example.AresProbe;
 import de.tum.cit.ase.ares.api.Policy;
 import de.tum.cit.ase.ares.api.jupiter.PublicTest;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+// withinPath is the Gradle build layout; for Maven use "classes/com/example".
 @Policy(value = "src/test/resources/SecurityPolicy.yaml", withinPath = "classes/java/main/com/example")
 class AresEnforcementTest {
 
@@ -489,7 +494,7 @@ Delete the removed annotations and their imports, then write the equivalent `Sec
 
 ### 5.4 Add `@Policy` to every test class
 
-This step is easy to miss and fails silently. In Ares 1, a test was protected by virtue of the sandbox being installed. In Ares 2, **a test class with no `@Policy` runs unprotected** (see the warning in [Section 4.1](#41-step-1-confirm-ares-is-on-the-classpath)).
+This step is easy to miss and fails silently. In Ares 1, a test was protected by virtue of the sandbox being installed. In Ares 2, a supervised test with no `@Policy` falls back to a default most-restricted policy, but that fallback supplies no `withinPath` scope, so in practice **it may enforce nothing** (see the warning in [Section 4.1](#41-step-1-confirm-ares-is-on-the-classpath)). Add an explicit `@Policy` so you control the policy and give it a scope that is actually enforced.
 
 Annotate every test class, and remember that `@Policy` is inherited through **meta-annotations**: if your exercise defines a marker annotation that its test classes carry, putting `@Policy` on that marker covers all of them.
 
@@ -503,7 +508,7 @@ public @interface E01 {
 }
 ```
 
-After migrating, audit for stragglers, since these are the classes that will run without enforcement:
+After migrating, audit for stragglers. This is only a **direct-annotation heuristic**: it lists test files with no literal `@Policy`, so a class that inherits `@Policy` through a meta-annotation (such as the `E01` marker above) is reported even though it is covered. Treat the output as candidates and confirm each by following its annotations, rather than as proof of missing enforcement:
 
 ```bash
 grep -rL "@Policy" src/test/java --include="*Test.java"
@@ -538,10 +543,10 @@ grep -rL "@Policy" src/test/java --include="*Test.java"
 
 | Problem | Possible Cause | Solution |
 |---------|---------------|----------|
-| `ClassNotFoundException: de.tum.cit.ase.ares.api.Policy` | Ares not on the test classpath | Verify `testImplementation` dependency is present |
+| `ClassNotFoundException: de.tum.cit.ase.ares.api.Policy` | Ares not on the test classpath | Verify the Ares dependency is present: `testImplementation` (Gradle) or a test-scoped `<dependency>` (Maven) |
 | `Failed to find premain agent` or agent-related errors | Agent JAR not found or wrong classifier | Ensure the `aresAgent` dependency uses the `:agent` classifier (Gradle) or the `-agent.jar` suffix (Maven) |
 | Tests pass but student code is not restricted | `-javaagent` JVM argument missing | Check that `jvmArgs` / `<argLine>` includes the `-javaagent:...` path |
-| Tests pass but student code is not restricted | Test class has no `@Policy` | The most common cause. A test class without `@Policy` (direct or meta-annotated) runs with **no** enforcement; Ares does not apply a restrictive default. Find them with `grep -rL "@Policy" src/test/java --include="*Test.java"`. See [Section 4.1](#41-step-1-confirm-ares-is-on-the-classpath) |
+| Tests pass but student code is not restricted | Test class has no `@Policy` | A common cause. A supervised test without `@Policy` (direct or meta-annotated) does fall back to a default most-restricted policy, but the fallback supplies no `withinPath` scope, so it may enforce nothing in practice. Add an explicit `@Policy` with a correct `withinPath`; find candidates with `grep -rL "@Policy" src/test/java --include="*Test.java"`. See [Section 4.1](#41-step-1-confirm-ares-is-on-the-classpath) |
 | Enforcement silently inactive for some tests only | `withinPath` points at a directory that does not exist | A `withinPath` that does not match the compiled student package resolves to an empty directory, so nothing is analysed and no error is raised. Confirm the path exists under `build/classes/java/main` (Gradle) or `target/classes` (Maven) after a build |
 | Coverage report empty after adding Ares (Maven) | `<argLine>` overwrote the JaCoCo agent | Put `@{argLine}` first inside `<argLine>`, see [Section 3.2.3](#323-attach-agent-via-maven-surefire-plugin) |
 | `InaccessibleObjectException` at runtime | Missing `--add-opens` / `--add-exports` flags | Ensure the complete list of JVM module access flags from [Section 3.1.4](#314-attach-agent-to-test-execution) / [Section 3.2.3](#323-attach-agent-via-maven-surefire-plugin) is present |


### PR DESCRIPTION
## Summary

Correct and extend `docs/HowToMakeAProjectAnAresProject.md` after migrating eight Artemis ITP exercises from Ares 1 to Ares 2.1.0: fix a misleading no-policy enforcement claim, make the Section 4 verification actually able to fail, add an Ares 1 to Ares 2.1.0 upgrade section, and add the missing Maven `@{argLine}`.

## Linked issues

None.

## 1. Problem

This is a documentation defect, found by following the guide literally while migrating the eight "Sample Solution" exercises of the *ITP Ares 2 Test Course* (Artemis course 583) from Ares 1 (`de.tum.in.ase:artemis-java-test-sandbox`) to Ares 2.1.0. All eight now pass on Ares 2.1.0 with identical test counts to their Ares 1 baseline (10, 21, 18, 30, 14, 17, 20, 11), and a forbidden-file-read probe is blocked with a `SecurityException` in all eight. The guide had four problems.

1. **A misleading enforcement claim (security relevant).** Section 4 stated that "without a `@Policy` annotation, Ares's JUnit extension still applies its default, most restrictive security policy to the test", presenting that as protection. The reality is more subtle and was verified against Ares 2.1.0: a supervised test (one carrying an Ares annotation such as `@Public`/`@PublicTest`) without `@Policy` **does** fall back to a default most-restricted policy, but that fallback supplies **no `withinPath` scope**, and in the AspectJ enforcement mode only main classes are woven, not the test class. So a forbidden call made from the test class itself is not intercepted: `Files.readString(Path.of("build.gradle"))` read the full 4233 bytes unblocked. The page an instructor lands on to confirm their setup implied protection that, in practice, may enforce nothing.
2. **Section 4 could not distinguish a working setup from a broken one.** The verification asserted `assertDoesNotThrow(() -> {})`, which passes whether or not any policy is enforced.
3. **No Ares 1 upgrade path.** The guide covered only the build files, so it could not carry an existing Ares 1 project across. `@WhitelistPath`, `@BlacklistPath`, `@WhitelistClass` and `PathType` have no Ares 2 counterpart and must become a `SecurityPolicy.yaml`, documented nowhere here.
4. **Missing `@{argLine}` in the Maven snippet.** Surefire's `argLine` is a single value, so the documented `<argLine>` replaced rather than appended to what other plugins contribute, silently dropping the JaCoCo agent while the build stayed green. Verified with Surefire 3.5.2 and JaCoCo 0.8.12: the JaCoCo agent was absent from the test JVM without `@{argLine}` and present with it.

Root cause layer: documentation. It matters because Section 4 is where an instructor confirms enforcement, and the guide let a green run stand in for proof of security.

## 2. Improvement from the user's perspective

An instructor setting up or upgrading an exercise now gets:
- A Section 4 split into a classpath smoke test (4.1) and a real enforcement check (4.2) that fails loudly, with a probe class and a `@Policy`-carrying test, when nothing is blocked, and a warning that states precisely why a supervised test without `@Policy` may enforce nothing (no `withinPath` scope, and AspectJ weaves only main classes).
- A new Section 5 for the Ares 1 to Ares 2.1.0 upgrade: the dependency swap, the `de.tum.in.test.api` to `de.tum.cit.ase.ares.api` package rename, an annotation mapping table, and the requirement to add `@Policy` to every supervised test class (including via a shared meta-annotation).
- A Maven snippet that keeps `@{argLine}` first, so a coverage or profiling agent is not silently dropped.
- Three new troubleshooting rows (missing `@Policy`; a `withinPath` pointing at a non-existent directory, which analyses nothing; the `argLine` override), a fixed table-of-contents anchor, and consistent section renumbering.

## 3. Improvement from the maintainer's perspective

No Improvement. This is a documentation-only change with no effect on the Ares codebase, build or CI.

## 4. Testing manual

**Prerequisites**

1. A Markdown renderer (for example GitHub's rendering of the file on this branch). No Ares build is required to review the documentation change itself.
2. Optional, to reproduce the empirical findings behind the text: JDK 17, Gradle 9.0.0 (the enforcement and no-policy findings were reproduced on the Gradle path), and a minimal Maven project with Surefire 3.5.2 and JaCoCo 0.8.12 (the `@{argLine}` finding was verified there).

**Steps**

1. Not reproducible from an exercise (documentation change). Render `docs/HowToMakeAProjectAnAresProject.md` on this branch and read Sections 4, 5 and 7.
2. Confirm the table-of-contents links resolve, in particular the corrected `#2-purpose-what-problem-does-this-solve` anchor and the new 4.1/4.2 and 5.1 to 5.4 entries.
3. Confirm Section 4.2 contains a probe class plus a `@Policy`-carrying test that calls `fail(...)` when the forbidden read is not blocked, and that the Maven Surefire snippet lists `@{argLine}` as the first `<argLine>` entry.

**Expected result**

- The guide reads consistently: Section 4.1 claims only classpath resolution and JVM start, Section 4.2 is the step that proves enforcement, and the warning explains the no-`withinPath` / AspectJ-weaving reason a fallback may block nothing. Section 5 gives a complete Ares 1 to Ares 2.1.0 path. All table-of-contents anchors resolve.

**Negative case (what must still be rejected)**

- The guide must not again present a no-`@Policy` setup as sufficient protection: the Section 4.1 warning and the Section 7 troubleshooting row must keep directing the reader to add an explicit `@Policy` with a correct `withinPath`, and Section 4.2 must keep the probe that fails when nothing is blocked. The "What happens without the agent?" note is retained unchanged, because it was verified as correct: with `-javaagent` commented out, the forbidden read was still blocked by the ArchUnit static analysis.

**Modes exercised**

<!-- Documentation-only change; it cannot alter mode-specific behaviour. -->

No mode-specific behaviour changed.

- [ ] ArchUnit + AspectJ
- [ ] ArchUnit + instrumentation
- [ ] WALA + AspectJ
- [ ] WALA + instrumentation

## 5. Test case coverage regarding this PR

<!-- ARES-COVERAGE:START -->
No Java code changed.
<!-- ARES-COVERAGE:END -->

## Breaking changes and migration

None. This changes only `docs/HowToMakeAProjectAnAresProject.md`. It touches no public API, no policy file format, no generated security test code and no minimum JDK/Maven/Gradle version.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
<!-- Tests were added or updated for the behaviour changed here: documentation-only change, no code behaviour to test. The empirical claims in the text were verified manually against the eight migrated exercises and a minimal Maven project, as described in Section 1 and Section 4. -->
- [x] Documentation (`docs/`, `README.adoc`, Javadoc) was updated where the change is user-facing.
- [x] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test
