### PR TITLE
Report aggregated code coverage in CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -247,9 +247,8 @@ jobs:
     name: Coverage Report
     needs: [ unit-tests, tests, core-integration-tests ]
     # A failed slice still produced usable execution data, and the report is more useful
-    # then, not less, so this waits for the test jobs rather than requiring them to pass.
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-24.04
+    # than, not less, so this waits for the test jobs rather than requiring them to pass.
+    if: ${{ always() && !cancelled() }}
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -246,9 +246,13 @@ jobs:
   coverage-report:
     name: Coverage Report
     needs: [ unit-tests, tests, core-integration-tests ]
-    # A failed slice still produced usable execution data, and the report is more useful
-    # than, not less, so this waits for the test jobs rather than requiring them to pass.
-    if: ${{ always() && !cancelled() }}
+    # A failed slice still produced usable execution data, and the report is more useful in
+    # that case, not less, so this waits for the test jobs rather than requiring them to pass.
+    # `cancelled()` is a status check function, so naming it already suppresses the implicit
+    # `success()` on `needs`, and the job still runs after a failed slice. `always()` would
+    # be redundant here and GitHub discourages it.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -120,12 +120,22 @@ jobs:
           cache: 'maven'
 
       - name: Unit tests
-        run: mvn test -Punit-core-tests -f pom.xml
+        run: mvn test -Punit-core-tests,coverage -f pom.xml
 
       # Architecture unit tests exercise the same execution-scoped WALA lifecycle
       # used by the integration matrices.
       - name: Architecture unit tests
-        run: mvn test -Punit-architecture-tests -f pom.xml
+        run: mvn test -Punit-architecture-tests,coverage -f pom.xml
+
+      # Both steps append into the same execution-data file. Uploaded even when a test
+      # step failed, so the aggregate still reflects everything that did run.
+      - name: Upload coverage execution data
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: jacoco-exec-unit-tests
+          path: target/jacoco.exec
+          if-no-files-found: warn
 
   tests:
     name: Integration Tests (${{ matrix.name }})
@@ -136,19 +146,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # `slug` names the coverage artefact: `name` contains spaces and a plus sign,
+          # which make for awkward artefact names and awkward download patterns.
           - name: ArchUnit + AspectJ
+            slug: archunit-aspectj
             method-suffixes: '*MavenArchunitAspectJ+*_archunit_aspectj'
             architecture-method-suffixes: '*MavenArchunitAspectJ_test'
             reuse-forks: 'true'
           - name: ArchUnit + instrumentation
+            slug: archunit-instrumentation
             method-suffixes: '*MavenArchunitInstrumentation+*_archunit_instrumentation'
             architecture-method-suffixes: '*MavenArchunitInstrumentation_test'
             reuse-forks: 'true'
           - name: WALA + AspectJ
+            slug: wala-aspectj
             method-suffixes: '*MavenWalaAspectJ+*_wala_aspectj'
             architecture-method-suffixes: '*MavenWalaAspectJ_test'
             reuse-forks: 'true'
           - name: WALA + instrumentation
+            slug: wala-instrumentation
             method-suffixes: '*MavenWalaInstrumentation+*_wala_instrumentation'
             architecture-method-suffixes: '*MavenWalaInstrumentation_test'
             reuse-forks: 'true'
@@ -169,11 +185,22 @@ jobs:
 
       # Method-level selection starts only the classes belonging to this mode. All
       # mode combinations reuse one fork; WALA state remains policy-scoped.
+      # The `coverage` profile also lowers `surefire-reuse-forks`, but the command-line
+      # property below outranks a profile property, so fork reuse stays as the matrix
+      # declares it and coverage does not change how these tests are isolated.
       - name: Test mode combination
         run: >-
-          mvn test -f pom.xml
+          mvn test -f pom.xml -Pcoverage
           -Dtest='de.tum.cit.ase.ares.integration.aop.allowed.*Test#${{ matrix.method-suffixes }},de.tum.cit.ase.ares.integration.aop.allowed.FileSystemAccessTest$*#${{ matrix.method-suffixes }},de.tum.cit.ase.ares.integration.aop.forbidden.*Test#${{ matrix.method-suffixes }},de.tum.cit.ase.ares.integration.architecture.forbidden.*Test#${{ matrix.architecture-method-suffixes }}'
           -Dsurefire-reuse-forks=${{ matrix.reuse-forks }}
+
+      - name: Upload coverage execution data
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: jacoco-exec-${{ matrix.slug }}
+          path: target/jacoco.exec
+          if-no-files-found: warn
 
   core-integration-tests:
     name: Core Integration Tests
@@ -196,7 +223,125 @@ jobs:
           cache: 'maven'
 
       - name: Core integration tests
-        run: mvn test -Pintegration-core-tests -f pom.xml
+        run: mvn test -Pintegration-core-tests,coverage -f pom.xml
 
       - name: jqwik integration tests
-        run: mvn test -f pom.xml -Dtest=de.tum.cit.ase.ares.integration.JqwickTest
+        run: mvn test -f pom.xml -Pcoverage -Dtest=de.tum.cit.ase.ares.integration.JqwickTest
+
+      - name: Upload coverage execution data
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: jacoco-exec-core-integration-tests
+          path: target/jacoco.exec
+          if-no-files-found: warn
+
+  # Each test job covers a disjoint slice of the suite, so no single one of them can be
+  # judged against the BUNDLE-level rule in pom.xml; only their merged execution data can.
+  #
+  # Advisory on purpose: the rule has never been measured against a complete run, so the
+  # check reports instead of failing (`-Djacoco.haltOnFailure=false`). Once the real
+  # figures are known, the minima in pom.xml are set to match and dropping that one flag
+  # makes the gate binding.
+  coverage-report:
+    name: Coverage Report
+    needs: [ unit-tests, tests, core-integration-tests ]
+    # A failed slice still produced usable execution data, and the report is more useful
+    # then, not less, so this waits for the test jobs rather than requiring them to pass.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      # Every artefact contains a file called jacoco.exec, so they must land in
+      # subdirectories of their own rather than being flattened onto each other. Left
+      # strict: if the test jobs ran but produced no execution data at all, that is a
+      # defect in the coverage wiring and should be visible rather than swallowed.
+      - name: Download coverage execution data
+        uses: actions/download-artifact@v7
+        with:
+          pattern: jacoco-exec-*
+          path: target/jacoco-exec
+
+      # The report needs compiled classes, hence a full `verify` rather than a bare goal
+      # invocation. Tests are skipped: they already ran in the jobs this one depends on.
+      - name: Merge execution data and evaluate thresholds
+        shell: bash
+        run: |
+          mvn verify -Pcoverage-aggregate -DskipTests -Djacoco.haltOnFailure=false -f pom.xml \
+            2>&1 | tee "${RUNNER_TEMP}/coverage-aggregate.log"
+
+      - name: Write coverage summary
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          report="target/site/jacoco/jacoco.csv"
+          if [ ! -f "${report}" ]; then
+            echo "No aggregated coverage report was produced." >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi
+
+          # Columns are fixed by JaCoCo's CSV format: 4/5 instruction, 6/7 branch,
+          # 8/9 line, 12/13 method, each as a missed/covered pair.
+          {
+            echo "## Aggregated code coverage"
+            echo
+            echo "| Counter | Covered | Missed | Ratio |"
+            echo "| --- | ---: | ---: | ---: |"
+            awk -F, '
+              function row(label, covered, missed,   total) {
+                total = covered + missed
+                printf "| %s | %d | %d | %s |\n", label, covered, missed, \
+                  (total > 0 ? sprintf("%.2f%%", 100 * covered / total) : "n/a")
+              }
+              NR > 1 {
+                im += $4; ic += $5
+                bm += $6; bc += $7
+                lm += $8; lc += $9
+                mm += $12; mc += $13
+              }
+              END {
+                row("Instruction", ic, im)
+                row("Branch", bc, bm)
+                row("Line", lc, lm)
+                row("Method", mc, mm)
+              }
+            ' "${report}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          # Thresholds live in pom.xml alone; repeating them here would let the two drift.
+          # JaCoCo already names every breach it found, so the log is the source of truth.
+          log="${RUNNER_TEMP}/coverage-aggregate.log"
+          if [ -f "${log}" ] && grep -q "Rule violated" "${log}"; then
+            {
+              echo
+              echo "### Thresholds not met (advisory, does not fail the build)"
+              echo
+              echo '```'
+              grep "Rule violated" "${log}"
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload coverage report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: |
+            target/site/jacoco/
+            target/jacoco.exec
+          if-no-files-found: warn

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,13 @@
 		<!-- Isolate test classes so WALA state and test-created threads cannot accumulate
 			in one long-lived JVM. The signed outcome cache preserves cross-fork reuse. -->
 		<surefire-reuse-forks>false</surefire-reuse-forks>
+		<jacoco-version>0.8.15</jacoco-version>
+		<!-- BUNDLE-level minima, shared by the `coverage` profile (one local full-suite
+			run) and the `coverage-aggregate` profile (the merged CI runs) so that the two
+			gates cannot drift apart. -->
+		<jacoco-line-coverage-minimum>0.55</jacoco-line-coverage-minimum>
+		<jacoco-branch-coverage-minimum>0.35</jacoco-branch-coverage-minimum>
+		<jacoco-method-coverage-minimum>0.65</jacoco-method-coverage-minimum>
 		<!-- full certificate fingerprint: 23E62BB282A473EE4DDA2F8763EFD39363D21A8D -->
 		<gpg.key.id>23E62BB282A473EE4DDA2F8763EFD39363D21A8D</gpg.key.id>
 	</properties>
@@ -1087,7 +1094,7 @@
 					<plugin>
 						<groupId>org.jacoco</groupId>
 						<artifactId>jacoco-maven-plugin</artifactId>
-						<version>0.8.15</version>
+						<version>${jacoco-version}</version>
 						<executions>
 							<execution>
 								<id>prepare-coverage-agent</id>
@@ -1097,8 +1104,21 @@
 								<configuration>
 									<append>true</append>
 									<inclBootstrapClasses>true</inclBootstrapClasses>
+									<!-- `api` is the only package under src/main/java, so this covers
+										everything the report is generated for, and nothing else. A new
+										top-level package under src/main/java has to be added here, or it
+										reports as entirely uncovered. That is the intended direction of
+										failure: an omission here is loud in the report, whereas the
+										opposite mistake is not. The wider
+										`de.tum.cit.ase.ares.*` also instrumented the integration test
+										subjects, which are the very classes Ares analyses and enforces
+										against. A second agent rewriting them changes the artefact under
+										test: three architecture tests of the ArchUnit/AspectJ combination
+										then observe a different violation than the one they expect.
+										Instrumenting test code yielded no coverage data in any case, as
+										only src/main/java is reported on. -->
 									<includes>
-										<include>de.tum.cit.ase.ares.*</include>
+										<include>de.tum.cit.ase.ares.api.*</include>
 									</includes>
 								</configuration>
 							</execution>
@@ -1123,17 +1143,105 @@
 												<limit>
 													<counter>LINE</counter>
 													<value>COVEREDRATIO</value>
-													<minimum>0.55</minimum>
+													<minimum>${jacoco-line-coverage-minimum}</minimum>
 												</limit>
 												<limit>
 													<counter>BRANCH</counter>
 													<value>COVEREDRATIO</value>
-													<minimum>0.35</minimum>
+													<minimum>${jacoco-branch-coverage-minimum}</minimum>
 												</limit>
 												<limit>
 													<counter>METHOD</counter>
 													<value>COVEREDRATIO</value>
-													<minimum>0.65</minimum>
+													<minimum>${jacoco-method-coverage-minimum}</minimum>
+												</limit>
+											</limits>
+										</rule>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<!-- Merges the per-job JaCoCo execution data collected by the `coverage` profile
+			into one report. CI splits the suite across seven jobs, each covering a
+			disjoint slice, so a single job's execution data says nothing about the
+			BUNDLE-level rule above; only the merged data does. The rule itself is shared
+			with the `coverage` profile through the threshold properties, so a local
+			full-suite run and the CI aggregate are measured against the same minima. -->
+		<profile>
+			<id>coverage-aggregate</id>
+			<properties>
+				<!-- Directory the CI job downloads the per-job execution-data artefacts into.
+					Each artefact unpacks into a subdirectory of its own, hence the recursive
+					include below rather than a flat one. -->
+				<jacoco-exec-directory>${project.build.directory}/jacoco-exec</jacoco-exec-directory>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>${jacoco-version}</version>
+						<executions>
+							<!-- The three executions share the verify phase and therefore run in
+								declaration order: merge, then report, then check. -->
+							<execution>
+								<id>merge-coverage-data</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>merge</goal>
+								</goals>
+								<configuration>
+									<fileSets>
+										<fileSet>
+											<directory>${jacoco-exec-directory}</directory>
+											<includes>
+												<include>**/*.exec</include>
+											</includes>
+										</fileSet>
+									</fileSets>
+									<destFile>${project.build.directory}/jacoco.exec</destFile>
+								</configuration>
+							</execution>
+							<execution>
+								<id>aggregated-coverage-report</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>report</goal>
+								</goals>
+								<configuration>
+									<dataFile>${project.build.directory}/jacoco.exec</dataFile>
+								</configuration>
+							</execution>
+							<execution>
+								<id>aggregated-coverage-threshold</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>check</goal>
+								</goals>
+								<configuration>
+									<dataFile>${project.build.directory}/jacoco.exec</dataFile>
+									<rules>
+										<rule>
+											<element>BUNDLE</element>
+											<limits>
+												<limit>
+													<counter>LINE</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>${jacoco-line-coverage-minimum}</minimum>
+												</limit>
+												<limit>
+													<counter>BRANCH</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>${jacoco-branch-coverage-minimum}</minimum>
+												</limit>
+												<limit>
+													<counter>METHOD</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>${jacoco-method-coverage-minimum}</minimum>
 												</limit>
 											</limits>
 										</rule>


### PR DESCRIPTION
## Summary

Activates the long-dormant `coverage` profile in CI and adds a `Coverage Report` job that merges the JaCoCo execution data of all seven test jobs into one aggregated report. Thresholds are advisory for now, because the project has never measured its own coverage.

## Linked issues

None.

## 1. Problem

The `coverage` profile has existed in `pom.xml` for a long time, complete with a BUNDLE-level `jacoco:check` rule of 55% lines, 35% branches and 65% methods. Nothing ever ran it: no workflow passes `-Pcoverage`, and no workflow reaches the `verify` phase, which is where the check is bound. The rule was therefore dead configuration, and the project had no coverage figures whatsoever, neither for a pull request nor for the repository as a whole.

The obvious fix, adding one coverage job, does not work here. CI deliberately splits the suite across seven jobs (`Unit Tests`, the four-way integration matrix, `Core Integration Tests`), each covering a disjoint slice. Any single slice measured on its own falls far below the BUNDLE minima and would fail a rule that is in fact working correctly. Only the union of the slices can be judged against it.

This is not a defect in the enforcement layer, so neither a false negative nor a false positive. It is a maintenance gap in the build integration.

## 2. Improvement from the user's perspective

No Improvement. Nothing an instructor or student observes at runtime changes: no policy behaviour, no generated test code, and no public API.

## 3. Improvement from the maintainer's perspective

Every pull request now gets an aggregated coverage table in the job summary of the `Coverage Report` job, plus a `coverage-report` artefact with the full HTML and CSV report, so per-class line coverage can be quoted in section 5 of this template without running anything locally. The threshold rule stops being decorative, and the two places that state the minima are collapsed into shared properties, so the local full-suite gate and the CI aggregate cannot drift apart.

It also documents a real trap: JaCoCo must not instrument the integration test subjects, see below.

## 4. Testing manual

**Prerequisites**

1. A checkout of this branch, JDK 21, Maven. No exercise repository and no echo server are needed.

**Steps**

Not reproducible from an exercise; this is a CI and build configuration change. A reviewer verifies it as follows.

1. Open the `Coverage Report` job of the Maven workflow run on this pull request.
2. Read the aggregated table in the job summary.
3. Download the `coverage-report` artefact and open `index.html` from it.
4. Confirm the six `jacoco-exec-*` artefacts exist on the run, one per test job.
5. Locally, reproduce a single slice and the aggregation:
   ```
   mvn test -Punit-core-tests,coverage -f pom.xml
   mvn verify -Pcoverage-aggregate -DskipTests -Djacoco.haltOnFailure=false -f pom.xml
   ```

**Expected result**

The summary shows one row each for instruction, branch, line and method coverage. Where a threshold is not met, the job summary additionally lists the `Rule violated` lines, and the job still succeeds, because the check is advisory for the moment.

**Negative case (what must still be rejected)**

Ares must not become more permissive by being measured. Every forbidden-access test must keep failing the student code exactly as before, in particular the architecture tests, since attaching a second agent is precisely what perturbed them. Confirm that all four matrix jobs are green on this pull request, and that `Tests run` per job matches a run on `main`. Locally, the ArchUnit/AspectJ selection of 302 tests passes with `-Pcoverage` and without it, with identical results.

**Modes exercised**

- [x] ArchUnit + AspectJ
- [ ] ArchUnit + instrumentation
- [ ] WALA + AspectJ
- [ ] WALA + instrumentation

ArchUnit + AspectJ was verified locally, because that is the combination whose three architecture tests broke when the agent instrumented the test subjects, and the same 302-test selection now passes with and without coverage. The remaining three combinations are exercised by this pull request's own CI run, which is the same code path with a different method selection.

## 5. Test case coverage regarding this PR

No Java code changed.

## Breaking changes and migration

None.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
<!-- Tests were added or updated: not applicable, no production code changed. The change alters how the existing suite is executed, and the suite itself is the test of it. -->
<!-- Documentation was updated: not applicable, nothing user-facing changed. -->
- [ ] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

CI cannot be ticked before this run completes; it is the first execution of the new job and the point of the exercise.

## Review progress

- [ ] Code review
- [ ] Manual test

## Note for the reviewer

Two findings are worth knowing about.

First, the agent's include pattern had to be narrowed from `de.tum.cit.ase.ares.*` to `de.tum.cit.ase.ares.api.*`. The wider pattern also instrumented the integration test subjects, which are the very classes Ares analyses and enforces against. Three architecture tests of the ArchUnit/AspectJ combination then observed a different violation than the one they expect. This was confirmed by bisection: the identical 302-test selection passes without `-Pcoverage`, fails three tests with it, and passes again once the includes are narrowed. Since only `src/main/java` is reported on, and `api` is its only package, instrumenting test code never produced any coverage data to begin with.

That sensitivity itself deserves a separate look, independently of this pull request: it means a third-party agent attached alongside Ares can change which violation Ares reports.

Second, the thresholds are advisory on purpose. Merging only the unit slice with one AOP slice locally already gives 54.24% lines against the 55% minimum and 56.98% methods against the 65% minimum. The full aggregate will be higher, but nobody knows by how much. Once this run publishes real figures, the minima in `pom.xml` should be set to match reality, and dropping `-Djacoco.haltOnFailure=false` makes the gate binding.
