### PR TITLE
Harden GitHub Actions supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      maven-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,19 +27,19 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: "17"
           distribution: "temurin"
           cache: "maven"
 
       - name: Initialise CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: java
           build-mode: manual
@@ -48,4 +48,4 @@ jobs:
         run: mvn -B -DskipTests package
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,12 +29,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -55,12 +55,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload analysis reports
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: static-analysis-reports
           path: |
@@ -108,12 +108,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -156,12 +156,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -184,12 +184,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
## Summary

Pins every GitHub Actions reference in this repository to an immutable commit SHA and groups Dependabot security updates per ecosystem.
A version tag such as `v7` is mutable and can be repointed by its upstream owner at any time, so a compromised action repository would execute inside Ares' CI without any change landing here.
This closes that gap for the pipeline that gates every change to a security-enforcement library.

## Linked issues

None.

## 1. Problem

This pull request is not driven by a defect in Ares' behaviour, so it changes neither a false negative nor a false positive. It closes a gap in the build integration layer, not in the policy layer, the generated security test or the enforcement layer.

Before this change, 16 of the 18 `uses:` references across `.github/workflows` named a mutable Git tag, for example `actions/checkout@v7` and `github/codeql-action/init@v4`. Only `pullrequest-labeler.yml` and `issue-labeler.yml` already pinned to a commit SHA.

A tag is a movable pointer owned by the action's publisher. Anyone who gains write access to one of those upstream repositories, or the publisher themselves, can repoint `v7` at a different commit, and the next CI run here executes that commit. The observed configuration does not matter, since this holds for every job in every workflow, on every operating system and JDK.

The expected behaviour is that a given commit of Ares always builds and tests with exactly the third-party code it was reviewed against, so that a CI run is reproducible and an upstream compromise cannot reach this repository without a visible diff.

Why it matters for Ares specifically: this CI is what decides whether a change to a security boundary is fit to merge. Its jobs hold a `GITHUB_TOKEN` and run on the runner alongside the checked-out source. An attacker controlling any action in the graph could alter test results, so a run could report green while the enforcement logic no longer rejects what it is meant to reject. The credibility of the merge gate depends on the integrity of the actions it runs.

A secondary, smaller problem: Dependabot currently opens one pull request per vulnerable dependency, which spreads a single security event across several reviews.

## 2. Improvement from the user's perspective

Instructors ship Ares inside an exercise test repository and students submit code that runs under it. Neither group interacts with this change directly, and no policy option, failure message or runtime behaviour changes.

The indirect benefit is the trustworthiness of the merge gate that protects them: from now on, a green CI run on Ares means the enforcement logic was verified by third-party code at commits that were reviewed when they were pinned, rather than by whatever those tags point at on the day of the run. Note that release publishing does not happen in this workflow, so this pull request hardens the pipeline that gates changes, not the release path itself.

## 3. Improvement from the maintainer's perspective

CI runs become reproducible. Re-running an old workflow now resolves the same third-party code it originally used, so a build that changes behaviour points at a change in this repository rather than at a silent upstream tag move.

Upstream changes become reviewable. Dependabot already tracks the `github-actions` ecosystem weekly, so each bump now arrives as an explicit diff of a SHA and its version comment, instead of arriving invisibly.

Review load for vulnerabilities drops. Grouping security updates per ecosystem turns a batch of vulnerability fixes into one pull request instead of several. Version updates deliberately stay ungrouped, so a routine bump that breaks the build can still be reverted on its own.

Finally, this makes the repository consistent: two workflows already pinned to SHAs and the rest did not.

## 4. Testing manual

**Prerequisites**

1. Nothing to install. The change is verified from this pull request's own workflow runs, not from an exercise.

**Steps**

Not reproducible from an exercise. This pull request changes only CI configuration, so a reviewer verifies it as follows:

1. Open the Checks tab of this pull request and confirm that all five workflows completed successfully, in particular `CodeQL`, which now resolves `github/codeql-action` from a commit SHA, and `Lint GitHub Workflows`.
2. Review the diff and confirm that every `+` line of the form `uses: …@<sha>` carries a 40-character hexadecimal SHA followed by a semver comment, matching the convention already used in `pullrequest-labeler.yml`.
3. Spot-check that a pinned SHA really belongs to the claimed version, for example `gh api repos/actions/checkout/tags --jq '.[] | select(.commit.sha=="3d3c42e5aac5ba805825da76410c181273ba90b1") | .name'`, which must list `v7.0.1`.
4. Confirm no mutable reference remains: `grep -rnE 'uses:[[:space:]]*[^[:space:]]+@(v[0-9]|main|master)' .github/` must print nothing.
5. Confirm `.github/dependabot.yml` declares one `applies-to: security-updates` group per ecosystem and leaves version updates ungrouped.

**Expected result**

All five checks are green. Every action reference resolves to a commit SHA whose version comment matches the tag that upstream actually points at, and no mutable reference is left in `.github/`.

**Negative case (what must still be rejected)**

1. The repository setting `allowed_actions` is now `selected`, permitting GitHub-owned actions plus the pattern `MaximilianAnzinger/issue-labeler@*` only. A workflow that introduces any other third-party action must be refused at run start rather than executed. A reviewer can confirm the policy with `gh api repos/ls1intum/Ares2/actions/permissions/selected-actions`, which must report `verified_allowed: false`.
2. After merge, once `sha_pinning_required` is enabled (see below), a workflow that reintroduces a mutable tag must fail to start. Until then, nothing enforces the pinning, so the reviewer's check in step 4 is what protects it.
3. This pull request must not have relaxed anything: `default_workflow_permissions` must still be `read` and `can_approve_pull_request_reviews` must still be `false`.

**Modes exercised**

No mode-specific behaviour changed. The change touches no Java code and cannot alter what the enforcement layer accepts or rejects. The full `Java CI with Maven` matrix nonetheless ran and passed on this branch.

<!-- Nothing ticked below, per the instruction above, because the change cannot alter mode-specific behaviour. -->

- [ ] ArchUnit + AspectJ
- [ ] ArchUnit + instrumentation
- [ ] WALA + AspectJ
- [ ] WALA + instrumentation

## 5. Test case coverage regarding this PR

No Java code changed.

## Breaking changes and migration

None.

The public API under `de.tum.cit.ase.ares.api`, the security policy file format and its schema, the generated security test code and the minimum JDK, Maven and Gradle versions are all untouched. Instructors need to do nothing.

## Accompanying repository settings

Not part of the diff, because these are repository settings rather than version-controlled files. Recorded here so the change is reviewable:

- `allowed_actions` set to `selected`, permitting GitHub-owned actions plus `MaximilianAnzinger/issue-labeler@*`, with `verified_allowed: false`.
- Approval for fork pull request workflows tightened from `first_time_contributors` to `all_external_contributors`.
- A new ruleset protecting all tags against deletion and force pushes.
- Confirmed already correct and left unchanged: `default_workflow_permissions: read` and `can_approve_pull_request_reviews: false`.

**Follow-up after merge:** the repository flag `sha_pinning_required` is still `false` and should be set to `true` once this lands. Enabling it beforehand would block every workflow run whose `uses:` still names a mutable tag, including runs on `main` and on open feature branches.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
<!-- - [ ] Tests were added or updated for the behaviour changed here. Not applicable: no behaviour of Ares changed. The change is CI configuration, and its correctness is asserted by the workflow runs themselves plus the actionlint job, not by a unit test. -->
<!-- - [ ] Documentation was updated where the change is user-facing. Not applicable: the change is not user-facing. Neither the API, the policy format nor the generated tests changed, so docs/, README.adoc and Javadoc are unaffected. -->
- [x] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test
