### PR TITLE
fix(phobos): correct copy helper quoting

### DIFF
--- a/src/main/resources/de/tum/cit/ase/ares/api/templates/phobos/PhobosCopyTool.sh
+++ b/src/main/resources/de/tum/cit/ase/ares/api/templates/phobos/PhobosCopyTool.sh
@@ -2,6 +2,6 @@
 # Script to copy required files to /var/tmp/opt/core/
 set -e  # Exit immediately if a command exits with a non-zero status
 set -u  # Treat unset variables as an error
-TARGET_DIR=“/var/tmp/opt/core”
+TARGET_DIR="/var/tmp/opt/core"
 # Copy SpecificExercise.cfg to target directory
 cp -v SpecificExercise.cfg "$TARGET_DIR/"

--- a/src/test/java/de/tum/cit/ase/ares/api/phobos/PhobosShellContractTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/phobos/PhobosShellContractTest.java
@@ -1,6 +1,7 @@
 package de.tum.cit.ase.ares.api.phobos;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -45,6 +46,24 @@ class PhobosShellContractTest {
 				+ TEMPLATES.resolve("phobos-filesystem.sh") + "' '" + specification + "' -- true");
 		assertEquals(15, missingRuntime.exitCode());
 		assertTrue(missingRuntime.output().contains("PHB-ERUNTIME"));
+	}
+
+	@Test
+	void copyToolAssignsTargetDirectoryWithAsciiQuotes() throws Exception {
+		Path copyTool = TEMPLATES.resolve("PhobosCopyTool.sh");
+		String contents = Files.readString(copyTool, java.nio.charset.StandardCharsets.UTF_8);
+
+		assertTrue(contents.contains("TARGET_DIR=\"/var/tmp/opt/core\""),
+				"PhobosCopyTool.sh must assign TARGET_DIR using ASCII double quotes");
+		assertFalse(contents.indexOf('“') >= 0 || contents.indexOf('”') >= 0,
+				"PhobosCopyTool.sh must not contain Unicode curly quotation marks");
+
+		ProcessResult syntax = run("bash -n '" + copyTool + "'");
+		assertEquals(0, syntax.exitCode(), syntax.output());
+
+		ProcessResult parsed = run(
+				"eval \"$(grep -m1 '^TARGET_DIR=' '" + copyTool + "')\"; printf '%s' \"${TARGET_DIR}\"");
+		assertEquals("/var/tmp/opt/core", parsed.output());
 	}
 
 	private ProcessResult run(String script) throws IOException, InterruptedException {

--- a/src/test/java/de/tum/cit/ase/ares/api/phobos/PhobosShellContractTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/phobos/PhobosShellContractTest.java
@@ -5,8 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -51,24 +56,46 @@ class PhobosShellContractTest {
 	@Test
 	void copyToolAssignsTargetDirectoryWithAsciiQuotes() throws Exception {
 		Path copyTool = TEMPLATES.resolve("PhobosCopyTool.sh");
-		String contents = Files.readString(copyTool, java.nio.charset.StandardCharsets.UTF_8);
+		String contents = Files.readString(copyTool, StandardCharsets.UTF_8);
 
-		assertTrue(contents.contains("TARGET_DIR=\"/var/tmp/opt/core\""),
-				"PhobosCopyTool.sh must assign TARGET_DIR using ASCII double quotes");
+		// The script must not contain Unicode curly quotation marks (U+201C / U+201D).
 		assertFalse(contents.indexOf('“') >= 0 || contents.indexOf('”') >= 0,
 				"PhobosCopyTool.sh must not contain Unicode curly quotation marks");
 
-		ProcessResult syntax = run("bash -n '" + copyTool + "'");
-		assertEquals(0, syntax.exitCode(), syntax.output());
+		// Parse the assignment purely in Java: the fixture is never executed and its
+		// path is never interpolated into a shell command. Exactly one TARGET_DIR
+		// assignment must exist so a malformed or duplicate line cannot satisfy the
+		// test.
+		List<String> assignments = contents.lines().map(String::stripLeading)
+				.filter(line -> line.startsWith("TARGET_DIR=")).toList();
+		assertEquals(1, assignments.size(), "PhobosCopyTool.sh must contain exactly one TARGET_DIR assignment");
 
-		ProcessResult parsed = run(
-				"eval \"$(grep -m1 '^TARGET_DIR=' '" + copyTool + "')\"; printf '%s' \"${TARGET_DIR}\"");
-		assertEquals("/var/tmp/opt/core", parsed.output());
+		// The assignment must use ASCII double quotes around exactly /var/tmp/opt/core.
+		Matcher matcher = Pattern.compile("^TARGET_DIR=\"(/var/tmp/opt/core)\"$").matcher(assignments.get(0));
+		assertTrue(matcher.matches(),
+				"TARGET_DIR must be assigned with ASCII double quotes as \"/var/tmp/opt/core\", but was: "
+						+ assignments.get(0));
+		assertEquals("/var/tmp/opt/core", matcher.group(1));
+
+		// Validate Bash syntax without building a shell command string or passing the
+		// fixture path to Bash: feed the already-read script content to `bash -n` via
+		// stdin.
+		ProcessResult syntax = runBashSyntaxCheck(contents);
+		assertEquals(0, syntax.exitCode(), syntax.output());
 	}
 
 	private ProcessResult run(String script) throws IOException, InterruptedException {
 		Process process = new ProcessBuilder("bash", "-c", script).redirectErrorStream(true).start();
 		String output = new String(process.getInputStream().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+		return new ProcessResult(process.waitFor(), output);
+	}
+
+	private ProcessResult runBashSyntaxCheck(String scriptContent) throws IOException, InterruptedException {
+		Process process = new ProcessBuilder("bash", "-n").redirectErrorStream(true).start();
+		try (OutputStream stdin = process.getOutputStream()) {
+			stdin.write(scriptContent.getBytes(StandardCharsets.UTF_8));
+		}
+		String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 		return new ProcessResult(process.waitFor(), output);
 	}
 


### PR DESCRIPTION
## Summary

Correct the `PhobosCopyTool.sh` template so its target-directory assignment uses ASCII double quotes instead of Unicode curly quotation marks, and pin the fix with a regression test. Without this, the copy step in every generated Phobos exercise fails. (Audit finding I-002.)

## Linked issues

None. I-002 comes from an internal audit report, not a GitHub issue.

## 1. Problem

Observed under any configuration that generates a Phobos exercise (the script is a static template resource, so no Java version, build tool, AOP mode or architecture mode changes the defect). `PhobosCopyTool.sh` assigned the target directory with Unicode curly quotation marks:

```bash
TARGET_DIR=“/var/tmp/opt/core”
```

Bash does not treat `“` (U+201C) and `”` (U+201D) as quoting operators, so they stay literal in the value. `TARGET_DIR` resolves to `“/var/tmp/opt/core”` rather than `/var/tmp/opt/core`, and the following `cp -v SpecificExercise.cfg "$TARGET_DIR/"` then copies into a directory that does not exist and fails (the script also runs under `set -e`, so the failure aborts it).

The root cause sits in the build-integration layer: this script is copied verbatim into generated exercise artifacts (`PhobosCopyFiles.csv` -> `JavaWriter`), so the defect propagates into every generated exercise rather than staying local to the template. It is not a false negative or false positive of the security enforcement itself. It is a setup step that fails closed in the wrong place, breaking a correct exercise.

## 2. Improvement from the user's perspective

An instructor generating a Phobos exercise gets a copy step that works: `SpecificExercise.cfg` is copied into `/var/tmp/opt/core/` as intended, instead of the exercise breaking at the `cp` into a non-existent `“/var/tmp/opt/core”` directory.

## 3. Improvement from the maintainer's perspective

The authoritative template is now pinned by `PhobosShellContractTest.copyToolAssignsTargetDirectoryWithAsciiQuotes`, which parses the assignment in Java and rejects any reappearance of the curly quotation marks, so this class of typo cannot silently return. The check is deliberately self-contained: it never executes the fixture and never interpolates its path into a shell command (it reads the file, matches the assignment with a regex, and validates syntax by feeding the content to `bash -n` on stdin).

## 4. Testing manual

**Prerequisites**

1. JDK and Maven as for any Ares 2 build, plus a `bash` on `PATH` (the test shells out to `bash -n`). No exercise repository, policy file or echo server is needed: the fixture is the packaged template resource `src/main/resources/de/tum/cit/ase/ares/api/templates/phobos/PhobosCopyTool.sh`.
2. Check out this branch.

**Steps**

1. `mvn -o test -Dtest=PhobosShellContractTest -f pom.xml`
2. Optionally, open `PhobosCopyTool.sh` and confirm the assignment reads `TARGET_DIR="/var/tmp/opt/core"`.

**Expected result**

- `copyToolAssignsTargetDirectoryWithAsciiQuotes` passes: the script contains no `“`/`”`, contains exactly one `TARGET_DIR=` assignment, that assignment matches `^TARGET_DIR="(/var/tmp/opt/core)"$`, and `bash -n` on the script content exits 0.

**Negative case (what must still be rejected)**

- Reintroducing the curly quotation marks (or changing the value, or adding a second `TARGET_DIR=` line) makes the test fail: the `assertFalse` on U+201C/U+201D, the exactly-one-assignment `assertEquals(1, ...)`, and the anchored regex each reject the broken form. The test was confirmed to fail against the original curly-quote script before the fix.

**Modes exercised**

<!-- The change is a shell-script template resource plus a Java regression test that parses it. It cannot alter any of the four enforcement combinations. -->

No mode-specific behaviour changed.

- [ ] ArchUnit + AspectJ
- [ ] ArchUnit + instrumentation
- [ ] WALA + AspectJ
- [ ] WALA + instrumentation

## 5. Test case coverage regarding this PR

<!-- ARES-COVERAGE:START -->
No production Java changed. The corrected artefact is the shell-script template resource `PhobosCopyTool.sh`; the only Java added is the regression test `PhobosShellContractTest`, which pins that resource. There is therefore no production class with Instruction/Branch/Line/Method coverage to report.
<!-- ARES-COVERAGE:END -->

## Breaking changes and migration

None. The public API under `de.tum.cit.ase.ares.api`, the security policy file format, the generated security test code and the minimum JDK/Maven/Gradle versions are all unchanged. The only behavioural change is that the copy step in a newly generated exercise now succeeds where it previously failed.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
<!-- I have self-reviewed the diff of this pull request: this is the author's own confirmation to tick; left to @ShudongCai. -->
- [x] Tests were added or updated for the behaviour changed here.
<!-- Documentation was updated where the change is user-facing: the change is a template resource fix, no docs/, README.adoc or Javadoc describes the literal quoting of this script, so nothing needed updating. -->
- [x] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test
