### PR TITLE
Fix dynamic-reflection and structural-discovery correctness issues found in the 2026-07-15 audit

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/dynamic/DynamicClass.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/dynamic/DynamicClass.java
@@ -205,7 +205,8 @@ public class DynamicClass<T> implements Checkable {
 			}
 			if (Modifier.isPublic(m.getModifiers())) {
 				String sig = DynamicMethod.signatureOf(m);
-				if (!"main(java.lang.String[])".equals(sig) && !publicMethods.contains(sig) //$NON-NLS-1$
+				if (!(Modifier.isStatic(m.getModifiers()) && m.getReturnType() == Void.TYPE
+						&& "main(java.lang.String[])".equals(sig)) && !publicMethods.contains(sig) //$NON-NLS-1$
 						&& !objectMethods.contains(sig)) {
 					throw localizedFailure("dynamics.class.method_public", sig); //$NON-NLS-1$
 				}

--- a/src/main/java/de/tum/cit/ase/ares/api/dynamic/DynamicClass.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/dynamic/DynamicClass.java
@@ -205,7 +205,7 @@ public class DynamicClass<T> implements Checkable {
 			}
 			if (Modifier.isPublic(m.getModifiers())) {
 				String sig = DynamicMethod.signatureOf(m);
-				if (!"main(java.lang.String[])".endsWith(sig) && !publicMethods.contains(sig) //$NON-NLS-1$
+				if (!"main(java.lang.String[])".equals(sig) && !publicMethods.contains(sig) //$NON-NLS-1$
 						&& !objectMethods.contains(sig)) {
 					throw localizedFailure("dynamics.class.method_public", sig); //$NON-NLS-1$
 				}

--- a/src/main/java/de/tum/cit/ase/ares/api/dynamic/DynamicField.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/dynamic/DynamicField.java
@@ -108,15 +108,26 @@ public class DynamicField<T> implements Checkable {
 	}
 
 	private List<Field> fieldsOf(Class<?> c) {
-		ArrayList<Field> al = new ArrayList<>();
-		Class<?> current = c;
-		while (current != Object.class) {
+		List<Field> al = new ArrayList<>();
+		Deque<Class<?>> toVisit = new ArrayDeque<>(List.of(c));
+		Set<Class<?>> visited = new HashSet<>();
+		while (!toVisit.isEmpty()) {
+			Class<?> current = toVisit.poll();
+			if (current == null || current == Object.class || !visited.add(current)) {
+				continue;
+			}
 			for (Field ff : current.getDeclaredFields()) {
 				if (type.toClass().isAssignableFrom(ff.getType())) {
 					al.add(ff);
 				}
 			}
-			current = current.getSuperclass();
+			var superclass = current.getSuperclass();
+			if (superclass != null) {
+				// ArrayDeque rejects null elements (interfaces, and Object.class itself,
+				// have no superclass) — only enqueue when there is one.
+				toVisit.add(superclass);
+			}
+			toVisit.addAll(List.of(current.getInterfaces()));
 		}
 		return al;
 	}

--- a/src/main/java/de/tum/cit/ase/ares/api/structural/StructuralTestProvider.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/structural/StructuralTestProvider.java
@@ -127,7 +127,10 @@ public abstract class StructuralTestProvider {
 				expectedClassStructure.getExpectedPackageName());
 		var scanResultEnum = classNameScanner.getScanResult().getResult();
 		var classNameScanMessage = classNameScanner.getScanResult().getMessage();
-		// please note: inner classes are not supported
+		// Note: a member/nested class is expected as its dot-separated
+		// qualified-within-file name (e.g. "Outer.Inner", see ClassNameScanner's
+		// walkProjectFileStructure) — getQualifiedClassName() below translates that
+		// into the JVM binary name ("Outer$Inner") needed to load it.
 		if (!ScanResultType.CORRECT_NAME_CORRECT_PLACE.equals(scanResultEnum)) {
 			throw failure(classNameScanMessage);
 		}
@@ -296,6 +299,13 @@ public abstract class StructuralTestProvider {
 	 * This method checks if the parameters of the actual structural element (in
 	 * this case method or constructor) match the ones in the expected structural
 	 * element.
+	 * <p>
+	 * Each expected parameter type name is matched against an observed parameter
+	 * type via {@link #checkExpectedType(Class, Type, String)} — the same
+	 * canonical-or-simple-name-aware comparison already used for
+	 * return/field/annotation types — rather than a raw
+	 * {@link Class#getSimpleName()} comparison, so an oracle entry such as
+	 * {@code java.lang.String} matches just as a plain {@code String} does.
 	 *
 	 * @param observedParameters The actual parameter types as a classes array.
 	 * @param expectedParameters The expected parameter type names as a JsonNode
@@ -323,25 +333,71 @@ public abstract class StructuralTestProvider {
 			expectedParameterTypeNames[i] = expectedParameters.get(i).asText();
 		}
 
-		var observedParameterTypeNames = new String[observedParameters.length];
-		for (var i = 0; i < observedParameters.length; i++) {
-			// TODO: Canonical names should be supported as well.
-			observedParameterTypeNames[i] = observedParameters[i].getSimpleName();
-		}
-
 		if (strictOrder) {
-			return Arrays.equals(expectedParameterTypeNames, observedParameterTypeNames);
+			for (var i = 0; i < observedParameters.length; i++) {
+				if (!checkExpectedType(observedParameters[i], observedParameters[i], expectedParameterTypeNames[i])) {
+					return false;
+				}
+			}
+			return true;
 		}
 
 		/*
-		 * Create hash tables to store how often a parameter type occurs. Checking the
-		 * occurrences of a certain parameter type is enough, since the parameter order
-		 * is not relevant to us.
+		 * Parameter order is not relevant to us: find a one-to-one pairing between
+		 * expected type names and observed parameters (a bipartite matching, since
+		 * which observed parameter satisfies which expected name isn't necessarily
+		 * unique when duplicate/ambiguous types are involved — a naive greedy pairing
+		 * could otherwise pick an observed parameter for one expected name that was the
+		 * only match for a different expected name).
 		 */
-		Map<String, Integer> expectedParametersHashtable = createParametersHashMap(expectedParameterTypeNames);
-		Map<String, Integer> observedParametersHashtable = createParametersHashMap(observedParameterTypeNames);
+		return hasMatchingPairingForEachExpectedParameter(observedParameters, expectedParameterTypeNames);
+	}
 
-		return expectedParametersHashtable.equals(observedParametersHashtable);
+	/**
+	 * Determines whether every expected parameter type name can be paired with a
+	 * distinct observed parameter satisfying it (order-independent), using
+	 * {@link #checkExpectedType(Class, Type, String)} as the per-pair compatibility
+	 * check. Implemented as Kuhn's algorithm for bipartite matching (augmenting
+	 * paths) so an ambiguous type doesn't cause an otherwise valid pairing to be
+	 * missed.
+	 *
+	 * @param observedParameters         The actual parameter types as a classes
+	 *                                   array.
+	 * @param expectedParameterTypeNames The expected parameter type names, same
+	 *                                   length as {@code observedParameters}.
+	 * @return True if a complete pairing exists, false otherwise.
+	 */
+	private static boolean hasMatchingPairingForEachExpectedParameter(Class<?>[] observedParameters,
+			String[] expectedParameterTypeNames) {
+		var parameterCount = observedParameters.length;
+		var matchedExpectedIndexOfObserved = new int[parameterCount];
+		Arrays.fill(matchedExpectedIndexOfObserved, -1);
+		for (var expectedIndex = 0; expectedIndex < parameterCount; expectedIndex++) {
+			var visitedObserved = new boolean[parameterCount];
+			if (!tryPairExpectedParameter(expectedIndex, observedParameters, expectedParameterTypeNames,
+					visitedObserved, matchedExpectedIndexOfObserved)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static boolean tryPairExpectedParameter(int expectedIndex, Class<?>[] observedParameters,
+			String[] expectedParameterTypeNames, boolean[] visitedObserved, int[] matchedExpectedIndexOfObserved) {
+		for (var observedIndex = 0; observedIndex < observedParameters.length; observedIndex++) {
+			if (visitedObserved[observedIndex] || !checkExpectedType(observedParameters[observedIndex],
+					observedParameters[observedIndex], expectedParameterTypeNames[expectedIndex])) {
+				continue;
+			}
+			visitedObserved[observedIndex] = true;
+			var previouslyMatchedExpectedIndex = matchedExpectedIndexOfObserved[observedIndex];
+			if (previouslyMatchedExpectedIndex == -1 || tryPairExpectedParameter(previouslyMatchedExpectedIndex,
+					observedParameters, expectedParameterTypeNames, visitedObserved, matchedExpectedIndexOfObserved)) {
+				matchedExpectedIndexOfObserved[observedIndex] = expectedIndex;
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -469,10 +525,16 @@ public abstract class StructuralTestProvider {
 		}
 
 		public String getQualifiedClassName() {
+			// A member/nested class is expressed in the oracle as a dot-separated
+			// qualified-within-file name (e.g. "Outer.Inner", matching what
+			// ClassNameScanner registers it under) — translate that into the JVM binary
+			// name ("Outer$Inner") Class.forName needs. Package-name dots are unaffected,
+			// since they're joined in separately below.
+			var binaryClassName = expectedClassName.replace(PACKAGE_PATH_SEPARATOR, "$"); //$NON-NLS-1$
 			if (!expectedPackageName.isEmpty()) {
-				return expectedPackageName + PACKAGE_PATH_SEPARATOR + expectedClassName;
+				return expectedPackageName + PACKAGE_PATH_SEPARATOR + binaryClassName;
 			}
-			return expectedClassName;
+			return binaryClassName;
 		}
 
 		public boolean hasProperty(String propertyName) {

--- a/src/main/java/de/tum/cit/ase/ares/api/structural/testutils/ClassNameScanner.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/structural/testutils/ClassNameScanner.java
@@ -58,19 +58,20 @@ public class ClassNameScanner {
 	private static final Logger LOG = LoggerFactory.getLogger(ClassNameScanner.class);
 
 	/*
-	 * A dedicated JavaParser instance configured for this project's Java 17
-	 * language level (records, pattern-matching instanceof, text blocks, ...),
-	 * rather than the bare StaticJavaParser entry point: StaticJavaParser's default
-	 * configuration only supports much older syntax and its shared static
+	 * A dedicated JavaParser instance per thread, configured for this project's
+	 * Java 17 language level (records, pattern-matching instanceof, text blocks,
+	 * ...), rather than the bare StaticJavaParser entry point: StaticJavaParser's
+	 * default configuration only supports much older syntax and its shared static
 	 * configuration is mutated as a side effect elsewhere (e.g.
 	 * UnwantedNodesAssert#withLanguageLevel), which would make parsing here depend
-	 * on unrelated test execution order. Mirrors the same pattern already used by
-	 * JavaProjectScanner. Shared/static: a JavaParser's parse() calls carry no
-	 * state beyond the (fixed, never-mutated-after-construction) configuration,
-	 * matching how a single instance is commonly reused across parses elsewhere.
+	 * on unrelated test execution order. Mirrors the same language-level setup
+	 * already used by JavaProjectScanner. Thread-local rather than a single shared
+	 * instance: StructuralTestProvider documents that provider subclasses for
+	 * different exercises may execute concurrently, and JavaParser does not
+	 * guarantee that a single instance can safely be reused across threads.
 	 */
-	private static final JavaParser JAVA_PARSER = new JavaParser(
-			new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17));
+	private static final ThreadLocal<JavaParser> JAVA_PARSER = ThreadLocal.withInitial(() -> new JavaParser(
+			new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)));
 
 	/*
 	 * Every ClassNameScanner instantiation re-walks and, since I-099, re-parses the
@@ -328,7 +329,7 @@ public class ClassNameScanner {
 
 	private static List<String> parseQualifiedTypeNames(File node) {
 		try {
-			var parseResult = JAVA_PARSER.parse(node.toPath());
+			var parseResult = JAVA_PARSER.get().parse(node.toPath());
 			var compilationUnit = parseResult.getResult()
 					.orElseThrow(() -> new ParseProblemException(parseResult.getProblems()));
 			List<String> qualifiedTypeNames = new ArrayList<>();
@@ -336,7 +337,7 @@ public class ClassNameScanner {
 				qualifiedNameWithinFile(type).ifPresent(qualifiedTypeNames::add);
 			}
 			return qualifiedTypeNames;
-		} catch (IOException | ParseProblemException e) {
+		} catch (IOException | ParseProblemException | StackOverflowError e) {
 			LOG.debug("Could not parse '{}' for nested-type discovery; falling back to its filename-derived type name", //$NON-NLS-1$
 					node, e);
 			return List.of(fileNameDerivedTypeName(node.getName()));

--- a/src/main/java/de/tum/cit/ase/ares/api/structural/testutils/ClassNameScanner.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/structural/testutils/ClassNameScanner.java
@@ -4,6 +4,7 @@ import static de.tum.cit.ase.ares.api.localization.Messages.localized;
 import static de.tum.cit.ase.ares.api.structural.testutils.ScanResultType.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.*;
@@ -12,7 +13,15 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.slf4j.*;
 
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.TypeDeclaration;
+
 import de.tum.cit.ase.ares.api.AresConfiguration;
+import de.tum.cit.ase.ares.api.util.LruCache;
 import de.tum.cit.ase.ares.api.util.ProjectSourcesFinder;
 import de.tum.cit.ase.ares.api.util.StringSimilarity;
 
@@ -47,6 +56,38 @@ import de.tum.cit.ase.ares.api.util.StringSimilarity;
 public class ClassNameScanner {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClassNameScanner.class);
+
+	/*
+	 * A dedicated JavaParser instance configured for this project's Java 17
+	 * language level (records, pattern-matching instanceof, text blocks, ...),
+	 * rather than the bare StaticJavaParser entry point: StaticJavaParser's default
+	 * configuration only supports much older syntax and its shared static
+	 * configuration is mutated as a side effect elsewhere (e.g.
+	 * UnwantedNodesAssert#withLanguageLevel), which would make parsing here depend
+	 * on unrelated test execution order. Mirrors the same pattern already used by
+	 * JavaProjectScanner. Shared/static: a JavaParser's parse() calls carry no
+	 * state beyond the (fixed, never-mutated-after-construction) configuration,
+	 * matching how a single instance is commonly reused across parses elsewhere.
+	 */
+	private static final JavaParser JAVA_PARSER = new JavaParser(
+			new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17));
+
+	/*
+	 * Every ClassNameScanner instantiation re-walks and, since I-099, re-parses the
+	 * whole assignment source tree from scratch (a pre-existing "one full scan per
+	 * expected class" design this fix doesn't change) — a single structural test
+	 * run constructs dozens of scanners across
+	 * testAttributes/testClasses/testConstructors/ testMethods. Caching each file's
+	 * discovered type names, keyed by absolute path and invalidated on
+	 * last-modified-time change, means only the *first* scan in a run actually
+	 * parses; every later scan of the same (unchanged) file reuses the result.
+	 * Follows the same LruCache + Collections.synchronizedMap pattern already used
+	 * for Messages' resource-bundle cache.
+	 */
+	private static final Map<Path, CachedFileTypes> JAVA_FILE_TYPE_CACHE = LruCache.synchronizedCache(4096);
+
+	private record CachedFileTypes(long lastModifiedMillis, List<String> qualifiedTypeNames) {
+	}
 
 	/*
 	 * The class name and package name of the expected class that is currently being
@@ -202,6 +243,19 @@ public class ClassNameScanner {
 	 * This method recursively walks the actual folder file structure starting from
 	 * the assignment folder and adds each type it finds e.g. filenames ending with
 	 * <code>.java</code> and <code>.kt</code> to the passed JSON object.
+	 * <p>
+	 * For <code>.java</code> files, every top-level type declared in the file (Java
+	 * permits more than one) and every member/nested type declared inside those
+	 * types is registered, not just the single type whose name matches the
+	 * filename. A nested type is registered under its dot-separated
+	 * qualified-within-file name (e.g. <code>Outer.Inner</code>), which
+	 * {@link de.tum.cit.ase.ares.api.structural.StructuralTestProvider.ExpectedClassStructure#getQualifiedClassName()}
+	 * translates into the corresponding JVM binary name (<code>Outer$Inner</code>)
+	 * when loading the class. Local and anonymous classes are not addressable this
+	 * way and are skipped. <code>.kt</code> files have no parser available here, so
+	 * they keep the previous filename-derived single-type behaviour, as does a
+	 * <code>.java</code> file that fails to parse (e.g. a submission that does not
+	 * currently compile) — falling back rather than aborting the whole scan.
 	 *
 	 * @param assignmentFolder The root folder where the method starts walking the
 	 *                         project structure.
@@ -215,22 +269,11 @@ public class ClassNameScanner {
 		// * fileName: assignment/src/de/tum/in/ase/eist/BubbleSort.java
 		// Required Package Name: de.tum.in.ase.eist
 		var fileName = node.getName();
-		// support Java and Kotlin files
-		if (fileName.endsWith(".java") || fileName.endsWith(".kt")) { //$NON-NLS-1$ //$NON-NLS-2$
-			var fileNameComponents = fileName.split("\\."); //$NON-NLS-1$
-			var className = fileNameComponents[fileNameComponents.length - 2];
-
-			Path packagePath = assignmentFolder.relativize(node.toPath().getParent());
-			var packageName = StreamSupport.stream(packagePath.spliterator(), false).map(Object::toString)
-					.collect(Collectors.joining(".")); //$NON-NLS-1$
-
-			if (foundClasses.containsKey(className)) {
-				foundClasses.get(className).add(packageName);
-			} else {
-				foundClasses.put(className, new ArrayList<>(List.of(packageName)));
-			}
+		if (fileName.endsWith(".java")) { //$NON-NLS-1$
+			registerJavaFileTypes(assignmentFolder, node, foundClasses);
+		} else if (fileName.endsWith(".kt")) { //$NON-NLS-1$
+			registerFoundClass(foundClasses, fileNameDerivedTypeName(fileName), packageNameOf(assignmentFolder, node));
 		}
-		// TODO: we should also support inner classes here
 		if (node.isDirectory()) {
 			String[] subNodes = node.list();
 			if (subNodes != null && subNodes.length > 0) {
@@ -239,6 +282,136 @@ public class ClassNameScanner {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Registers every top-level and nested/member type a <code>.java</code> file
+	 * declares (see {@link #qualifiedTypeNamesOf(File)}).
+	 *
+	 * @param assignmentFolder The root folder the package name is computed relative
+	 *                         to.
+	 * @param node             The <code>.java</code> file being visited.
+	 * @param foundClasses     The map the discovered type names and packages get
+	 *                         appended to.
+	 */
+	private void registerJavaFileTypes(Path assignmentFolder, File node, Map<String, List<String>> foundClasses) {
+		var packageName = packageNameOf(assignmentFolder, node);
+		for (String qualifiedName : qualifiedTypeNamesOf(node)) {
+			registerFoundClass(foundClasses, qualifiedName, packageName);
+		}
+	}
+
+	/**
+	 * Returns every top-level and nested/member type name a <code>.java</code> file
+	 * declares, dot-separated (e.g. <code>Outer.Inner</code>) via
+	 * {@link #qualifiedNameWithinFile(TypeDeclaration)}, falling back to the single
+	 * filename-derived type name if the file cannot be parsed (e.g. it does not
+	 * currently compile). Cached by absolute path and last-modified time (see
+	 * {@link #JAVA_FILE_TYPE_CACHE}) since a single structural test run constructs
+	 * many {@code ClassNameScanner}s, each re-walking the same assignment tree.
+	 *
+	 * @param node The <code>.java</code> file to determine the declared type names
+	 *             of.
+	 * @return The file's declared type names.
+	 */
+	private static List<String> qualifiedTypeNamesOf(File node) {
+		var absolutePath = node.toPath().toAbsolutePath().normalize();
+		var lastModifiedMillis = node.lastModified();
+		var cached = JAVA_FILE_TYPE_CACHE.get(absolutePath);
+		if (cached != null && cached.lastModifiedMillis() == lastModifiedMillis) {
+			return cached.qualifiedTypeNames();
+		}
+		var qualifiedTypeNames = parseQualifiedTypeNames(node);
+		JAVA_FILE_TYPE_CACHE.put(absolutePath, new CachedFileTypes(lastModifiedMillis, qualifiedTypeNames));
+		return qualifiedTypeNames;
+	}
+
+	private static List<String> parseQualifiedTypeNames(File node) {
+		try {
+			var parseResult = JAVA_PARSER.parse(node.toPath());
+			var compilationUnit = parseResult.getResult()
+					.orElseThrow(() -> new ParseProblemException(parseResult.getProblems()));
+			List<String> qualifiedTypeNames = new ArrayList<>();
+			for (TypeDeclaration<?> type : compilationUnit.findAll(TypeDeclaration.class)) {
+				qualifiedNameWithinFile(type).ifPresent(qualifiedTypeNames::add);
+			}
+			return qualifiedTypeNames;
+		} catch (IOException | ParseProblemException e) {
+			LOG.debug("Could not parse '{}' for nested-type discovery; falling back to its filename-derived type name", //$NON-NLS-1$
+					node, e);
+			return List.of(fileNameDerivedTypeName(node.getName()));
+		}
+	}
+
+	/**
+	 * Computes the dot-separated name of a type declaration relative to its
+	 * enclosing file, e.g. <code>Outer.Inner</code> for a member type
+	 * <code>Inner</code> declared inside top-level type <code>Outer</code>, or just
+	 * <code>Outer</code> for a top-level type. Local and anonymous classes (whose
+	 * enclosing chain does not consist solely of type declarations up to the
+	 * compilation unit) have no such stable name and are reported as empty.
+	 *
+	 * @param type The type declaration to compute the qualified-within-file name
+	 *             for.
+	 * @return The dot-separated qualified-within-file name, or empty if
+	 *         {@code type} is a local or anonymous class.
+	 */
+	static Optional<String> qualifiedNameWithinFile(TypeDeclaration<?> type) {
+		Deque<String> parts = new ArrayDeque<>();
+		Node current = type;
+		while (current instanceof TypeDeclaration<?> currentType) {
+			parts.addFirst(currentType.getNameAsString());
+			current = currentType.getParentNode().orElse(null);
+		}
+		if (!(current instanceof CompilationUnit)) {
+			// the enclosing chain didn't resolve straight up to the compilation unit: a
+			// local class (nested inside a method body) or similar, which has no stable
+			// qualified-within-file name
+			return Optional.empty();
+		}
+		return Optional.of(String.join(".", parts)); //$NON-NLS-1$
+	}
+
+	/**
+	 * Derives a type's name from its source filename (the pre-existing behaviour,
+	 * kept as the <code>.kt</code> path and the <code>.java</code> parse-failure
+	 * fallback): the filename without its extension.
+	 *
+	 * @param fileName The source filename, e.g. <code>BubbleSort.java</code>.
+	 * @return The filename-derived type name, e.g. <code>BubbleSort</code>.
+	 */
+	private static String fileNameDerivedTypeName(String fileName) {
+		var fileNameComponents = fileName.split("\\."); //$NON-NLS-1$
+		return fileNameComponents[fileNameComponents.length - 2];
+	}
+
+	/**
+	 * Computes the dot-separated package name of a file from its path relative to
+	 * the assignment folder.
+	 *
+	 * @param assignmentFolder The root folder the package name is computed relative
+	 *                         to.
+	 * @param node             The file whose package name is being computed.
+	 * @return The dot-separated package name.
+	 */
+	private static String packageNameOf(Path assignmentFolder, File node) {
+		Path packagePath = assignmentFolder.relativize(node.toPath().getParent());
+		return StreamSupport.stream(packagePath.spliterator(), false).map(Object::toString)
+				.collect(Collectors.joining(".")); //$NON-NLS-1$
+	}
+
+	/**
+	 * Registers one discovered type name/package pairing in the found-classes map,
+	 * appending to any package names already recorded under the same type name.
+	 *
+	 * @param foundClasses The map the discovered type name and package get appended
+	 *                     to.
+	 * @param className    The (possibly dot-qualified, for nested types) type name.
+	 * @param packageName  The package the type was found in.
+	 */
+	private static void registerFoundClass(Map<String, List<String>> foundClasses, String className,
+			String packageName) {
+		foundClasses.computeIfAbsent(className, key -> new ArrayList<>()).add(packageName);
 	}
 
 	/**

--- a/src/test/java/de/tum/cit/ase/ares/api/dynamic/DynamicClassTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/dynamic/DynamicClassTest.java
@@ -45,4 +45,33 @@ class DynamicClassTest {
 		var dynamicClass = DynamicClass.toDynamic(OnlyLiteralMainFixture.class);
 		assertThat(dynamicClass.checkForPublicOrProtectedMethods()).isEqualTo(1);
 	}
+
+	static class InstanceMainFixture {
+		public void main(String[] args) {
+			// intentionally empty: same signature as the entry point, but an instance
+			// method, must NOT be exempt
+		}
+	}
+
+	@Test
+	void publicInstanceMainIsNotExempted() {
+		var dynamicClass = DynamicClass.toDynamic(InstanceMainFixture.class);
+		assertThatThrownBy(dynamicClass::checkForPublicOrProtectedMethods).isInstanceOf(AssertionFailedError.class)
+				.hasMessageContaining("main(java.lang.String[])");
+	}
+
+	static class NonVoidMainFixture {
+		public static int main(String[] args) {
+			// intentionally non-void: same signature as the entry point, but not
+			// void-returning, must NOT be exempt
+			return 0;
+		}
+	}
+
+	@Test
+	void publicStaticNonVoidMainIsNotExempted() {
+		var dynamicClass = DynamicClass.toDynamic(NonVoidMainFixture.class);
+		assertThatThrownBy(dynamicClass::checkForPublicOrProtectedMethods).isInstanceOf(AssertionFailedError.class)
+				.hasMessageContaining("main(java.lang.String[])");
+	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/api/dynamic/DynamicClassTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/dynamic/DynamicClassTest.java
@@ -1,0 +1,48 @@
+package de.tum.cit.ase.ares.api.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+/**
+ * Regression tests for
+ * {@link DynamicClass#checkForPublicOrProtectedMethods(DynamicMethod...)},
+ * guarding against I-094: the method previously exempted any public method
+ * whose signature was a textual <em>suffix</em> of
+ * {@code "main(java.lang.String[])"} (via {@code String.endsWith}) instead of
+ * only the literal {@code main} method.
+ */
+class DynamicClassTest {
+
+	static class MainSuffixFixture {
+		public static void main(String[] args) {
+			// intentionally empty: the literal main method must remain exempt
+		}
+
+		public void ain(String[] args) {
+			// intentionally empty: a suffix of "main(java.lang.String[])" must NOT be
+			// exempt
+		}
+	}
+
+	@Test
+	void publicMethodWhoseSignatureIsSuffixOfMainIsNotExempted() {
+		var dynamicClass = DynamicClass.toDynamic(MainSuffixFixture.class);
+		assertThatThrownBy(dynamicClass::checkForPublicOrProtectedMethods).isInstanceOf(AssertionFailedError.class)
+				.hasMessageContaining("ain(java.lang.String[])");
+	}
+
+	static class OnlyLiteralMainFixture {
+		public static void main(String[] args) {
+			// intentionally empty: the only public method, must remain exempt
+		}
+	}
+
+	@Test
+	void literalMainMethodRemainsExempt() {
+		var dynamicClass = DynamicClass.toDynamic(OnlyLiteralMainFixture.class);
+		assertThat(dynamicClass.checkForPublicOrProtectedMethods()).isEqualTo(1);
+	}
+}

--- a/src/test/java/de/tum/cit/ase/ares/api/dynamic/DynamicFieldTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/dynamic/DynamicFieldTest.java
@@ -51,8 +51,8 @@ class DynamicFieldTest {
 
 	@Test
 	void lookupStartingFromAnInterfaceDoesNotThrowOnNullSuperclass() {
-		assertThatCode(
-				() -> DynamicClass.toDynamic(FieldOwningInterface.class).field(int.class, "doesNotExist").exists())
-						.doesNotThrowAnyException();
+		var field = DynamicClass.toDynamic(FieldOwningInterface.class).field(int.class, "doesNotExist");
+		assertThatCode(field::exists).doesNotThrowAnyException();
+		assertThat(field.exists()).isFalse();
 	}
 }

--- a/src/test/java/de/tum/cit/ase/ares/api/dynamic/DynamicFieldTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/dynamic/DynamicFieldTest.java
@@ -1,0 +1,58 @@
+package de.tum.cit.ase.ares.api.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for {@link DynamicField}'s private {@code fieldsOf}
+ * traversal, guarding against I-094: {@code Class.getSuperclass()} returns
+ * {@code null} for an interface, which previously made the superclass-only walk
+ * NPE once it reached an interface, and the walk never visited
+ * implemented/extended superinterfaces at all, so an inherited interface
+ * constant could never be found.
+ */
+class DynamicFieldTest {
+
+	interface FieldOwningInterface {
+		int CONSTANT = 42;
+	}
+
+	interface ExtendingInterface extends FieldOwningInterface {
+		// declares no fields of its own: CONSTANT is only reachable via
+		// FieldOwningInterface
+	}
+
+	static class ImplementingClass implements ExtendingInterface {
+		// declares no fields of its own
+	}
+
+	@Test
+	void fieldDeclaredDirectlyOnInterfaceIsFound() {
+		var field = DynamicClass.toDynamic(FieldOwningInterface.class).field(int.class, "CONSTANT");
+		assertThat(field.exists()).isTrue();
+		assertThat(field.getStatic()).isEqualTo(42);
+	}
+
+	@Test
+	void fieldInheritedFromSuperinterfaceIsFound() {
+		var field = DynamicClass.toDynamic(ExtendingInterface.class).field(int.class, "CONSTANT");
+		assertThat(field.exists()).isTrue();
+		assertThat(field.getStatic()).isEqualTo(42);
+	}
+
+	@Test
+	void fieldInheritedFromImplementedInterfaceIsFoundOnClass() {
+		var field = DynamicClass.toDynamic(ImplementingClass.class).field(int.class, "CONSTANT");
+		assertThat(field.exists()).isTrue();
+		assertThat(field.getStatic()).isEqualTo(42);
+	}
+
+	@Test
+	void lookupStartingFromAnInterfaceDoesNotThrowOnNullSuperclass() {
+		assertThatCode(
+				() -> DynamicClass.toDynamic(FieldOwningInterface.class).field(int.class, "doesNotExist").exists())
+						.doesNotThrowAnyException();
+	}
+}

--- a/src/test/java/de/tum/cit/ase/ares/api/structural/StructuralTestProviderTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/structural/StructuralTestProviderTest.java
@@ -1,0 +1,79 @@
+package de.tum.cit.ase.ares.api.structural;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+/**
+ * Regression tests for
+ * {@link StructuralTestProvider#checkParameters(Class[], com.fasterxml.jackson.databind.JsonNode, boolean)},
+ * guarding against I-099: parameters were previously compared using
+ * {@link Class#getSimpleName()} only, so a canonical oracle entry such as
+ * {@code java.lang.String} could never match, even though
+ * {@link StructuralTestProvider#checkExpectedType(Class, java.lang.reflect.Type, String)}
+ * (used for return/field/annotation types) already accepted either form.
+ */
+class StructuralTestProviderTest {
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private static ArrayNode expectedParameterNames(String... names) {
+		var array = OBJECT_MAPPER.createArrayNode();
+		for (String name : names) {
+			array.add(name);
+		}
+		return array;
+	}
+
+	@Test
+	void strictOrderAcceptsCanonicalName() {
+		var observed = new Class<?>[] { String.class, int.class };
+		var expected = expectedParameterNames("java.lang.String", "int");
+		assertThat(StructuralTestProvider.checkParameters(observed, expected, true)).isTrue();
+	}
+
+	@Test
+	void strictOrderStillRejectsAMismatchedType() {
+		var observed = new Class<?>[] { String.class, int.class };
+		var expected = expectedParameterNames("java.lang.Integer", "int");
+		assertThat(StructuralTestProvider.checkParameters(observed, expected, true)).isFalse();
+	}
+
+	@Test
+	void unorderedMatchAcceptsCanonicalNameRegardlessOfPosition() {
+		var observed = new Class<?>[] { String.class, int.class };
+		var expected = expectedParameterNames("int", "java.lang.String");
+		assertThat(StructuralTestProvider.checkParameters(observed, expected, false)).isTrue();
+	}
+
+	@Test
+	void unorderedMatchStillRejectsAWrongDuplicateType() {
+		var observed = new Class<?>[] { int.class, int.class };
+		var expected = expectedParameterNames("int", "java.lang.String");
+		assertThat(StructuralTestProvider.checkParameters(observed, expected, false)).isFalse();
+	}
+
+	@Test
+	void unorderedMatchAcceptsRepeatedType() {
+		var observed = new Class<?>[] { int.class, int.class };
+		var expected = expectedParameterNames("int", "int");
+		assertThat(StructuralTestProvider.checkParameters(observed, expected, false)).isTrue();
+	}
+
+	@Test
+	void mismatchedParameterCountIsRejected() {
+		var observed = new Class<?>[] { String.class };
+		var expected = expectedParameterNames("java.lang.String", "int");
+		assertThat(StructuralTestProvider.checkParameters(observed, expected, false)).isFalse();
+	}
+
+	@Test
+	void noParametersMatch() {
+		var observed = new Class<?>[0];
+		var expected = expectedParameterNames();
+		assertThat(StructuralTestProvider.checkParameters(observed, expected, false)).isTrue();
+	}
+}

--- a/src/test/java/de/tum/cit/ase/ares/api/structural/testutils/ClassNameScannerTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/structural/testutils/ClassNameScannerTest.java
@@ -4,6 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.TypeDeclaration;
+
 /**
  * Tests the typo-detection threshold decisions of
  * {@link ClassNameScanner#isMisspelledWithHighProbability(String, String)}.
@@ -12,8 +16,53 @@ import org.junit.jupiter.api.Test;
  * string-similarity algorithms in
  * {@link de.tum.cit.ase.ares.api.util.StringSimilarity} cannot silently shift
  * the decisions.
+ * <p>
+ * Also tests {@link ClassNameScanner#qualifiedNameWithinFile(TypeDeclaration)},
+ * guarding against I-099: {@code walkProjectFileStructure} previously derived a
+ * file's single type name from its filename alone, so a member/nested type (or
+ * an additional top-level type declared alongside the filename-matching one)
+ * could never be discovered.
  */
 class ClassNameScannerTest {
+
+	private static TypeDeclaration<?> typeNamed(CompilationUnit compilationUnit, String simpleName) {
+		return compilationUnit.findAll(TypeDeclaration.class).stream()
+				.filter(type -> type.getNameAsString().equals(simpleName)).findFirst()
+				.orElseThrow(() -> new AssertionError("no type named " + simpleName + " in fixture source"));
+	}
+
+	@Test
+	void topLevelTypeQualifiedNameIsItsOwnSimpleName() {
+		var compilationUnit = StaticJavaParser.parse("class Outer {}");
+		assertThat(ClassNameScanner.qualifiedNameWithinFile(typeNamed(compilationUnit, "Outer"))).contains("Outer");
+	}
+
+	@Test
+	void additionalTopLevelTypeInTheSameFileIsItsOwnSimpleName() {
+		var compilationUnit = StaticJavaParser.parse("class Outer {} class SecondTopLevelType {}");
+		assertThat(ClassNameScanner.qualifiedNameWithinFile(typeNamed(compilationUnit, "SecondTopLevelType")))
+				.contains("SecondTopLevelType");
+	}
+
+	@Test
+	void memberTypeQualifiedNameIsDotSeparated() {
+		var compilationUnit = StaticJavaParser.parse("class Outer { static class Inner {} }");
+		assertThat(ClassNameScanner.qualifiedNameWithinFile(typeNamed(compilationUnit, "Inner")))
+				.contains("Outer.Inner");
+	}
+
+	@Test
+	void doublyNestedMemberTypeQualifiedNameJoinsEveryEnclosingName() {
+		var compilationUnit = StaticJavaParser.parse("class Outer { static class Middle { static class Inner {} } }");
+		assertThat(ClassNameScanner.qualifiedNameWithinFile(typeNamed(compilationUnit, "Inner")))
+				.contains("Outer.Middle.Inner");
+	}
+
+	@Test
+	void localClassHasNoQualifiedNameWithinFile() {
+		var compilationUnit = StaticJavaParser.parse("class Outer { void method() { class Local {} } }");
+		assertThat(ClassNameScanner.qualifiedNameWithinFile(typeNamed(compilationUnit, "Local"))).isEmpty();
+	}
 
 	@Test
 	void singleEditTyposAreMisspellings() {

--- a/src/test/java/de/tum/cit/ase/ares/integration/StructuralTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/StructuralTest.java
@@ -19,6 +19,11 @@ class StructuralTest {
 	private final String testAttributesSomeEnum = "testAttributes()/dynamic-test:#3";
 	private final String testAttributesSomeAbstractClass = "testAttributes()/dynamic-test:#4";
 	private final String testAttributesSomeFailingClass = "testAttributes()/dynamic-test:#5";
+	// I-099/TD-045: SomeClass.Nested is an existing member class of SomeClass (see
+	// SomeClass.java) newly discoverable now that ClassNameScanner parses nested
+	// types;
+	// it has attributes, so it also gains a testAttributes() entry.
+	private final String testAttributesSomeClassNested = "testAttributes()/dynamic-test:#6";
 	private final String testClassDoesNotExist = "testClasses()/dynamic-test:#1";
 	private final String testClassSomeInterface = "testClasses()/dynamic-test:#2";
 	private final String testClassMisspelledClas = "testClasses()/dynamic-test:#3";
@@ -28,15 +33,43 @@ class StructuralTest {
 	private final String testClassMisspelledclass = "testClasses()/dynamic-test:#7";
 	private final String testClassSomeFailingClass = "testClasses()/dynamic-test:#8";
 	private final String testClassDoesNotExistDefault = "testClasses()/dynamic-test:#9";
+	// I-099/TD-045: SomeClass.Nested/AdditionalTopLevelType deliberately do NOT add
+	// a
+	// "modifiers" (or other) class-level property, so ClassTestProvider's
+	// hasAdditionalProperties() filter excludes them from testClasses() entirely
+	// and
+	// that container's dynamic-test count stays at 9. JUnit Platform TestKit's
+	// EventConditions#test(String) matches a dynamic-test id via *substring*
+	// containment (uniqueIdSubstring), so "dynamic-test:#1" would otherwise also
+	// match "dynamic-test:#10"/"#11" once the container crosses into double digits
+	// —
+	// a latent fragility in every id constant below, first exposed here since no
+	// provider previously had 10+ entries. Their discovery/loading is still fully
+	// exercised (and would fail loudly if broken) via the testAttributes/
+	// testConstructors/testMethods entries below, none of which cross that
+	// boundary.
 	private final String testConstructorsSomeClass = "testConstructors()/dynamic-test:#1";
 	private final String testConstructorsSomeEnum = "testConstructors()/dynamic-test:#2";
 	private final String testConstructorsSomeAbstractClass = "testConstructors()/dynamic-test:#3";
 	private final String testConstructorsSomeFailingClass = "testConstructors()/dynamic-test:#4";
+	private final String testConstructorsSomeClassNested = "testConstructors()/dynamic-test:#5";
+	// I-099/TD-045: AdditionalTopLevelType's constructor is declared with a
+	// canonical
+	// (java.lang.String) oracle parameter type rather than the simple "String"
+	// form.
+	private final String testConstructorsAdditionalTopLevelType = "testConstructors()/dynamic-test:#6";
 	private final String testMethodsSomeInterface = "testMethods()/dynamic-test:#1";
 	private final String testMethodsSomeClass = "testMethods()/dynamic-test:#2";
 	private final String testMethodsSomeEnum = "testMethods()/dynamic-test:#3";
 	private final String testMethodsSomeAbstractClass = "testMethods()/dynamic-test:#4";
 	private final String testMethodsSomeFailingClass = "testMethods()/dynamic-test:#5";
+	private final String testMethodsSomeClassNested = "testMethods()/dynamic-test:#6";
+	// I-099/TD-045: AdditionalTopLevelType.acceptCanonicalParameter's oracle
+	// parameter type
+	// is also canonical (java.lang.String); checkParameters must accept it like it
+	// accepts
+	// the simple "String" form used everywhere else in this fixture.
+	private final String testMethodsAdditionalTopLevelType = "testMethods()/dynamic-test:#7";
 	private final String bothValid = "bothValid";
 	private final String invalidGradle = "invalidGradle";
 	private final String invalidMaven = "invalidMaven";
@@ -76,6 +109,11 @@ class StructuralTest {
 	void test_testAttributesSomeFailingClass() {
 		tests.assertThatEvents().haveExactly(COUNT, testFailedWith(testAttributesSomeFailingClass,
 				IllegalArgumentException.class, "Invalid entry for modifier: 'penguin: final'"));
+	}
+
+	@TestTest
+	void test_testAttributesSomeClassNested() {
+		tests.assertThatEvents().haveExactly(COUNT, finishedSuccessfully(testAttributesSomeClassNested));
 	}
 
 	@TestTest
@@ -160,6 +198,16 @@ class StructuralTest {
 	}
 
 	@TestTest
+	void test_testConstructorsSomeClassNested() {
+		tests.assertThatEvents().haveExactly(COUNT, finishedSuccessfully(testConstructorsSomeClassNested));
+	}
+
+	@TestTest
+	void test_testConstructorsAdditionalTopLevelType() {
+		tests.assertThatEvents().haveExactly(COUNT, finishedSuccessfully(testConstructorsAdditionalTopLevelType));
+	}
+
+	@TestTest
 	void test_testMethodsSomeInterface() {
 		tests.assertThatEvents().haveExactly(COUNT, finishedSuccessfully(testMethodsSomeInterface));
 	}
@@ -185,6 +233,16 @@ class StructuralTest {
 		tests.assertThatEvents().haveExactly(COUNT, testFailedWith(testMethodsSomeFailingClass,
 				AssertionFailedError.class,
 				"The parameters of the expected method 'someMethodWithWrongParameterOrder' of the class 'SomeFailingClass' with the parameters: [\"int\",\"double\"] are not implemented as expected."));
+	}
+
+	@TestTest
+	void test_testMethodsSomeClassNested() {
+		tests.assertThatEvents().haveExactly(COUNT, finishedSuccessfully(testMethodsSomeClassNested));
+	}
+
+	@TestTest
+	void test_testMethodsAdditionalTopLevelType() {
+		tests.assertThatEvents().haveExactly(COUNT, finishedSuccessfully(testMethodsAdditionalTopLevelType));
 	}
 
 	@TestTest

--- a/src/test/java/de/tum/cit/ase/ares/integration/testuser/DynamicsUser.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/testuser/DynamicsUser.java
@@ -197,7 +197,7 @@ public class DynamicsUser {
 	void field_setStaticSuccess() {
 		de.tum.cit.ase.ares.integration.testuser.subject.structural.SomeAbstractClass.someInt = 7;
 		var field = DynamicClass.toDynamic(SomeAbstractClass.class).field(int.class, "someInt");
-		assertThat(field.exists());
+		assertThat(field.exists()).isTrue();
 		field.setStatic(2);
 		assertThat(field.getStatic()).isEqualTo(2);
 	}

--- a/src/test/java/de/tum/cit/ase/ares/integration/testuser/StructuralUser.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/testuser/StructuralUser.java
@@ -33,7 +33,7 @@ public class StructuralUser {
 	private static final String TESTUSER_BUILD_GRADLE = "src/test/resources/de/tum/cit/ase/ares/integration/testuser/build.gradle";
 
 	@Nested
-	class Maven extends StrucuralTestSet {
+	class Maven extends StructuralTestSet {
 
 		@BeforeEach
 		void setupTest() {
@@ -43,7 +43,7 @@ public class StructuralUser {
 	}
 
 	@Nested
-	class Gradle extends StrucuralTestSet {
+	class Gradle extends StructuralTestSet {
 
 		@BeforeEach
 		void setupTest() {
@@ -113,7 +113,14 @@ public class StructuralUser {
 		}
 	}
 
-	class StrucuralTestSet {
+	// Abstract because it exists only to be extended by the @Nested Maven/Gradle
+	// containers below
+	// (never instantiated on its own) — Surefire's stray-test-class heuristic flags
+	// a class that
+	// declares @Nested/@TestFactory members but is itself neither static, @Nested,
+	// nor abstract,
+	// so marking it abstract also silences that false-positive warning at the root.
+	abstract class StructuralTestSet {
 
 		@AfterEach
 		void resetBuildToolConfiguration() {

--- a/src/test/java/de/tum/cit/ase/ares/integration/testuser/subject/structural/MisspelledClass.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/testuser/subject/structural/MisspelledClass.java
@@ -3,3 +3,25 @@ package de.tum.cit.ase.ares.integration.testuser.subject.structural;
 public class MisspelledClass {
 	// empty
 }
+
+/**
+ * A second, package-private top-level type declared alongside
+ * {@link MisspelledClass} in the same file — Java permits more than one
+ * top-level type per source file. Used to prove that {@code ClassNameScanner}
+ * discovers every top-level type a file declares, not just the one whose name
+ * matches the filename, and that {@code checkParameters} accepts a canonical
+ * parameter type name ({@code java.lang.String}) exactly as it accepts the
+ * simple form.
+ */
+class AdditionalTopLevelType {
+
+	@SuppressWarnings("unused")
+	public AdditionalTopLevelType(String someText) {
+		// nothing
+	}
+
+	@SuppressWarnings("unused")
+	public void acceptCanonicalParameter(String someText) {
+		// nothing
+	}
+}

--- a/src/test/resources/de/tum/cit/ase/ares/integration/testuser/test.json
+++ b/src/test/resources/de/tum/cit/ase/ares/integration/testuser/test.json
@@ -162,4 +162,37 @@
     "package" : "",
     "isInterface" : true
   }
+}, {
+  "class" : {
+    "name" : "SomeClass.Nested",
+    "package" : "de.tum.cit.ase.ares.integration.testuser.subject.structural"
+  },
+  "methods" : [ {
+    "name" : "publicMethod",
+    "modifiers" : [ "public", "static" ],
+    "returnType" : "void"
+  } ],
+  "constructors" : [ {
+    "modifiers" : [ "public" ]
+  } ],
+  "attributes" : [ {
+    "name" : "innerValue",
+    "modifiers" : [ "public" ],
+    "type" : "int"
+  } ]
+}, {
+  "class" : {
+    "name" : "AdditionalTopLevelType",
+    "package" : "de.tum.cit.ase.ares.integration.testuser.subject.structural"
+  },
+  "methods" : [ {
+    "name" : "acceptCanonicalParameter",
+    "modifiers" : [ "public" ],
+    "parameters" : [ "java.lang.String" ],
+    "returnType" : "void"
+  } ],
+  "constructors" : [ {
+    "modifiers" : [ "public" ],
+    "parameters" : [ "java.lang.String" ]
+  } ]
 } ]


### PR DESCRIPTION
<!--
  Thanks for contributing to Ares 2.
  Fill in every section. Each section states what to write when it does not apply.
  Tick boxes as [x], not [ x] and not [x ].
  If a checklist task does not apply, wrap that line in an HTML comment and state the
  reason inside the comment, so the diff still records that the task was considered.
-->

## Summary

Fixes four correctness issues from the 2026-07-15 audit (I-052, I-094, I-099, TD-043): two
reflection-validation bugs in the dynamic test-authoring API, a misconfigured Surefire test-container
class, and structural type-discovery/parameter-matching gaps that could fail correct submissions.

## Linked issues

None. (Findings I-052, I-094, I-099 and TD-043 come from an internal 2026-07-15 audit report, not
GitHub issues.)

## 1. Problem

This PR bundles four independent findings on one branch (explicit exception to one-branch-per-issue,
per the audit's own scope) — each has its own root cause, listed separately.

**I-094 — `DynamicClass`/`DynamicField` reflection validation.** Observed:
`DynamicClass.checkForPublicOrProtectedMethods` used `"main(java.lang.String[])".endsWith(sig)`
instead of `.equals(sig)`, so a public method whose signature happened to be a textual suffix of the
literal `main` signature (e.g. a public `ain(String[])`) was wrongly exempted from the public-method
check. Separately, `DynamicField.fieldsOf` walked only `Class.getSuperclass()` until `Object.class`;
since `getSuperclass()` returns `null` for an interface, it threw `NullPointerException` once the
walk reached one, and never visited implemented/extended superinterfaces at all. Expected: only the
literal `main(String[])` method is exempt; field lookup resolves uniformly across classes and
interfaces, including inherited superinterface fields, without throwing. Root cause layer: none of
policy/generated-security-test/enforcement/build-integration — `api/dynamic` is Ares' own
instructor-facing dynamic-reflection test-authoring API, used to write structural assertions against
student code shape, not the runtime sandbox boundary. Framing: the `main`-suffix bug is the
structural-test analogue of a false negative (a public-API violation that should have failed a
structural check was silently accepted); the field-lookup bug was a crash, not a false result.

**I-052 — `StructuralUser`'s shared nested-test base class.** Observed: `StrucuralTestSet`
(misspelt) was neither `static` nor `@Nested`, tripping Surefire's stray-test-class heuristic in the
build output, even though it functioned correctly (its members are inherited into the `Maven`/
`Gradle` `@Nested` subclasses via JUnit 5's nested-class inheritance). Expected: no spurious warning,
same test behaviour. Root cause layer: none — pure build/test-tooling hygiene, no runtime behaviour
involved. Framing: neither false positive nor false negative applies — this never affected any
test's pass/fail outcome, confirmed by `StructuralTest`'s pre-existing `COUNT = 2` assertions passing
identically before and after.

**I-099 — structural discovery and parameter matching.** Observed:
`ClassNameScanner.walkProjectFileStructure` derived a source file's one-and-only declared type from
its filename, so member/nested classes and additional top-level types declared in the same file were
undiscoverable (the pre-existing code even carried a `// TODO: we should also support inner classes
here` comment marking the gap); separately, `StructuralTestProvider.checkParameters` compared every
observed parameter via `Class.getSimpleName()` only, so a canonical oracle entry (`java.lang.String`)
could never match, unlike `checkExpectedType` (return/field/annotation types), which already accepted
either form. Expected: a structurally correct submission using a member class or canonical parameter
type name passes its exercise's structural checks. Root cause layer: none — `api/structural`
implements Ares' structural-conformance oracle (comparing submitted code shape against an
instructor-authored `test.json`), used by instructor-authored exercise structural tests, not the
runtime sandbox enforcement path. Framing: **false positive** — a structurally correct student
submission would incorrectly fail the exercise's structural test.

**TD-043 — non-asserting `assertThat` in a test fixture.** Observed:
`DynamicsUser.field_setStaticSuccess` called `assertThat(field.exists());` with no terminal predicate,
making the line a no-op regardless of outcome. Expected: the assertion genuinely fails if
`field.exists()` were ever false. Root cause layer: none — Ares' own regression-test fixture quality,
not an exercise-facing behaviour. Framing: neither applies — this reduced the trustworthiness of
Ares' own regression suite, it never affected a real exercise outcome.

## 2. Improvement from the user's perspective

Students: a submission using a member/nested class, or declaring a parameter with its fully-qualified
type name, is no longer incorrectly failed by a structural exercise's `test.json` oracle checks
(I-099). Instructors: dynamic-reflection-based structural assertions against interface-based fixtures
no longer crash with `NullPointerException` (I-094); Maven/Gradle build output for structural test
modules no longer carries a spurious Surefire stray-test-class warning (I-052).

## 3. Improvement from the maintainer's perspective

New unit test coverage for `api/dynamic` (previously zero unit tests, only indirect coverage via the
`DynamicsTest` integration suite). `checkParameters`'s matching is now a correct bipartite algorithm
instead of a simple-name-only multiset comparison — every structural test provider
(`ClassTestProvider`, `MethodTestProvider`, `ConstructorTestProvider`) that compares parameters
benefits from the same fix. TD-043's non-asserting test now genuinely protects the behaviour it
claims to. A related latent fragility (`ast/model/JavaFile.java`'s implicit dependence on
`StaticJavaParser`'s shared global configuration rather than an explicitly-configured instance) was
found while debugging this PR's own `ClassNameScanner` change and has been raised with the maintainer
separately — it is not touched here.

## 4. Testing manual

**Prerequisites**

1. Local Maven ≥ 3.9 (`pom.xml`'s `RequireMavenVersion` enforcer rule) and JDK 17+ (CI builds/tests
   on JDK 21). No external exercise repository or policy file is needed: every fixture this PR
   touches lives inside this repo's own simulated exercise at
   `src/test/resources/de/tum/cit/ase/ares/integration/testuser/` (a `pom.xml` + `build.gradle` pair,
   a `test.json` structural oracle, and fixture "student" classes under
   `testuser/subject/structural/`), which the `StructuralTest`/`DynamicsTest` integration suites
   already drive end-to-end exactly as an instructor's real exercise repository would.

**Steps**

1. `mvn test -Punit-core-tests -f pom.xml -Dtest=DynamicClassTest,DynamicFieldTest,ClassNameScannerTest,StructuralTestProviderTest`
2. `mvn test -Pintegration-core-tests -f pom.xml -Dtest=de.tum.cit.ase.ares.integration.DynamicsTest`
3. `mvn test -Pintegration-core-tests -f pom.xml -Dtest=de.tum.cit.ase.ares.integration.StructuralTest`

**Expected result**

- Step 1: 24/24 unit tests pass.
- Step 2: 34/34 `DynamicsTest` cases pass, including `test_class_searchPublicOrProtectedMethods` and
  every `test_field_*` case.
- Step 3: 32/32 `StructuralTest` cases pass, including the new `test_testAttributesSomeClassNested`,
  `test_testConstructorsSomeClassNested`, `test_testConstructorsAdditionalTopLevelType`,
  `test_testMethodsSomeClassNested` and `test_testMethodsAdditionalTopLevelType` assertions proving
  the previously-undiscoverable `SomeClass.Nested` member class and the canonical-parameter
  `AdditionalTopLevelType` fixture are now found and checked correctly.

**Negative case (what must still be rejected)**

- `test_testClassMisspelledClas`/`test_testClassMisspelledclass` must still fail with the same
  typo/case-mismatch messages as before — the discovery rewrite must not become lenient about
  genuinely wrong class names.
- `test_class_searchPublicOrProtectedMethods` must still fail (reject) a real public-API violation
  (`doSomething(String)` wrongly declared public) — confirms the `main`-suffix fix didn't
  over-correct into exempting unrelated public methods.
- `test_testConstructorsSomeFailingClass`/`test_testMethodsSomeFailingClass` must still fail on
  genuinely mismatched parameter lists — confirms the new bipartite parameter matching didn't become
  permissive about real mismatches.

**Modes exercised**

No mode-specific behaviour changed — this PR touches only `api/dynamic` and `api/structural`
(reflection/structural-oracle utilities behind Ares' own test-authoring API), not `aop/` or
`architecture/` enforcement code.

- [ ] ArchUnit + AspectJ
- [ ] ArchUnit + instrumentation
- [ ] WALA + AspectJ
- [ ] WALA + instrumentation

## 5. Test case coverage regarding this PR

Instruction, Branch, Line and Method coverage for every production class changed in this PR, read from the aggregated JaCoCo report produced by the "Coverage Report" job of this PR's Maven workflow run. Nested classes (for example a record's `Builder`) are listed as their own rows. `n/a` means the class has no executable lines of that counter (for example an annotation or interface) or was not present in the report.

<!-- ARES-COVERAGE:START -->
| Class | Instruction | Branch | Line | Method |
| --- | ---: | ---: | ---: | ---: |
| `DynamicClass` | 85.4% (461/540) | 76.4% (55/72) | 86.7% (98/113) | 88.5% (23/26) |
| `DynamicField` | 83.4% (372/446) | 84.4% (27/32) | 88.9% (64/72) | 100.0% (14/14) |
| `StructuralTestProvider` | 83.0% (504/607) | 79.8% (67/84) | 82.7% (105/127) | 94.1% (16/17) |
| `StructuralTestProvider.ExpectedClassStructure` | 96.6% (57/59) | 50.0% (1/2) | 93.3% (14/15) | 100.0% (8/8) |
| `StructuralTestProvider.ModifierSpecification` | 100.0% (57/57) | 100.0% (6/6) | 100.0% (12/12) | 100.0% (4/4) |
| `ClassNameScanner` | 77.1% (567/735) | 77.9% (60/77) | 84.3% (113/134) | 92.0% (23/25) |
| `ClassNameScanner.CachedFileTypes` | 100.0% (9/9) | n/a | 100.0% (1/1) | 100.0% (1/1) |
| **Total (changed classes)** | **82.6% (2027/2453)** | **79.1% (216/273)** | **85.9% (407/474)** | **93.7% (89/95)** |
<!-- ARES-COVERAGE:END -->

## Breaking changes and migration

None. None of these four fixes change the shape of the public API under
`de.tum.cit.ase.ares.api.dynamic`/`de.tum.cit.ase.ares.api.structural` (no signatures added or
removed), the security policy file format/schema, or the generated security test code.
`checkParameters` accepting canonical type names is strictly more permissive than before (nothing
that previously matched now fails to match); the `DynamicField`/`DynamicClass` fixes correct a crash
and a false exemption without altering any existing method signature. Minimum JDK/Maven/Gradle
versions are unchanged.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
<!-- I have self-reviewed the diff of this pull request: left for the human author's own pass before opening the PR. -->
- [x] Tests were added or updated for the behaviour changed here.
- [x] Documentation (`docs/`, `README.adoc`, Javadoc) was updated where the change is user-facing — no `docs/` file describes the specific matching/discovery behaviour that changed (`docs/Overview.md`'s existing high-level description of `api/dynamic`/`api/structural` remains accurate), so nothing needed updating.
- [x] CI is green, or every remaining failure is explained above. The "Java CI with Maven" run on the current head is green, and its aggregated "Coverage Report" job confirms the §5 per-class figures.
- [x] No secrets, tokens or absolute local paths are contained in the diff (checked via `grep` against the actual diff, not assumed).

## Review progress

- [ ] Code review
- [ ] Manual test

