### PR TITLE
Add a release notes template

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,91 @@
+<!--
+  Release notes template for Ares 2.
+
+  GitHub does not prefill release notes the way it prefills a pull request, so copy the
+  body of this file into the release description and fill it in. Keep the five headings
+  and their order, so that consecutive releases stay comparable.
+
+  Scope: everything merged since the previous release tag. List them with
+  `git log --oneline <previous-tag>..main` and read the bodies of the pull requests it
+  names, since each one already answers sections 3 to 5 for its own change.
+
+  Sections 3, 4 and 5 carry the same meaning as in PULL_REQUEST_TEMPLATE.md, aggregated
+  over the whole release rather than a single change. Each section states what to write
+  when it does not apply.
+
+  Write in British English. State figures you have verified, and leave out those you
+  have not: a release note is read as a record.
+-->
+
+<!--
+  At most three lines: what this release changes, and why it matters. No implementation
+  detail, and no list of pull requests.
+  Say plainly whether the release is breaking. If the public API under
+  de.tum.cit.ase.ares.api, the security policy file format, the generated security test
+  code or the minimum JDK, Maven or Gradle version changed, that belongs here rather
+  than further down, together with what an instructor has to do to upgrade.
+  This section is always required and has no heading, so that it renders as the opening
+  paragraph of the release.
+-->
+
+## Linked issues
+
+<!--
+  The issues this release closes or relates to, for example "Closes #123" or
+  "Relates to #456", each with a few words on what it was.
+  If no issue is involved, write "None".
+-->
+
+## Problems
+
+<!--
+  What was wrong before this release, in enough depth that a reader can judge whether it
+  affected them. One block per problem, most significant first.
+
+  For each, useful to cover:
+  - What behaviour was observed, and under which configuration (Java version, build
+    tool, AOP mode: AspectJ or instrumentation, architecture mode: ArchUnit or WALA,
+    operating system)?
+  - Where the root cause sits. Ares is itself the security boundary, so say whether it
+    was in the policy layer, the generated security test, the enforcement (AOP or
+    architecture) layer, or the build integration.
+  - Which way it failed. A false negative let forbidden student code through, a false
+    positive failed a correct submission. Say which, because the two carry very
+    different weight for anyone deciding whether to upgrade.
+
+  Group the routine maintenance (dependency bumps, CI configuration, documentation) into
+  one short block rather than one block each.
+
+  If a release fixes no defect, describe the gaps, limitations or maintenance burden it
+  addresses instead. Never write "None" here: a release with nothing to say under
+  Problems does not need notes.
+-->
+
+## Improvements from the user's perspective
+
+<!--
+  Users are everyone who consumes Ares: students whose submissions run under a security
+  policy, and instructors who author policies and ship Ares inside an exercise test
+  repository.
+  Describe the concrete benefit, for example clearer failure messages, fewer false
+  positives, a policy option that was previously impossible to express, a faster test
+  run, or a newly supported language or build tool.
+
+  State any limitation that bounds what the improvement is worth, in particular where a
+  hardening is partial. A reader who upgrades expecting a guarantee that does not hold
+  is worse off than one who was told the boundary.
+
+  If this side does not benefit from this release, write "No Improvement".
+-->
+
+## Improvements from the maintainer's perspective
+
+<!--
+  Maintainers are those who develop Ares itself.
+  Describe the benefit for them, for example reduced duplication, a clearer abstraction,
+  a flaky test removed, better diagnostics, less manual release work, or a dependency or
+  CI simplification.
+  Close with the dependency and tooling updates in one line.
+
+  If this side does not benefit from this release, write "No Improvement".
+-->

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,17 +1,29 @@
+<!-- markdownlint-configure-file { "MD041": false } -->
 <!--
+  MD041 (first line in a file should be a top-level heading) is disabled above, because
+  this file opens with an unheaded summary paragraph on purpose: see the note before
+  "Linked issues". A top-level heading here would be copied into every release
+  description and duplicate the release title GitHub already shows.
+
   Release notes template for Ares 2.
 
   GitHub does not prefill release notes the way it prefills a pull request, so copy the
-  body of this file into the release description and fill it in. Keep the headings and
-  their order, so that consecutive releases stay comparable.
+  body of this file into the release description and fill it in. Keep every heading below
+  and their order, so that consecutive releases stay comparable, and keep the opening
+  summary unheaded.
 
   Scope: everything merged since the previous release tag. List them with
   `git log --oneline <previous-tag>..main` and read the bodies of the pull requests it
-  names, since each one already answers sections 3 to 5 for its own change.
+  names, since each one already answers "Problem" and both "Improvement" sections for its
+  own change.
 
-  Sections 3, 4 and 5 carry the same meaning as in PULL_REQUEST_TEMPLATE.md, aggregated
-  over the whole release rather than a single change. Each section states what to write
-  when it does not apply.
+  "Problems", "Improvements from the user's perspective" and "Improvements from the
+  maintainer's perspective" carry the same meaning as sections 1, 2 and 3 of
+  PULL_REQUEST_TEMPLATE.md, aggregated over the whole release rather than a single
+  change. That template's sections 4 and 5 (the testing manual and the coverage table)
+  have no counterpart here: they describe how one change was verified, which is a
+  reviewer's concern rather than a reader's. Each section below states what to write when
+  it does not apply.
 
   Write in British English. State figures you have verified, and leave out those you
   have not: a release note is read as a record.

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -2,8 +2,8 @@
   Release notes template for Ares 2.
 
   GitHub does not prefill release notes the way it prefills a pull request, so copy the
-  body of this file into the release description and fill it in. Keep the five headings
-  and their order, so that consecutive releases stay comparable.
+  body of this file into the release description and fill it in. Keep the headings and
+  their order, so that consecutive releases stay comparable.
 
   Scope: everything merged since the previous release tag. List them with
   `git log --oneline <previous-tag>..main` and read the bodies of the pull requests it
@@ -20,10 +20,10 @@
 <!--
   At most three lines: what this release changes, and why it matters. No implementation
   detail, and no list of pull requests.
-  Say plainly whether the release is breaking. If the public API under
-  de.tum.cit.ase.ares.api, the security policy file format, the generated security test
-  code or the minimum JDK, Maven or Gradle version changed, that belongs here rather
-  than further down, together with what an instructor has to do to upgrade.
+  Say plainly whether the release is breaking, in a clause, and leave the detail and the
+  upgrade steps to "Breaking changes and migration" below. A reader who sees "breaking"
+  in the opening paragraph knows to read on; one who only finds out at the bottom has
+  usually decided already.
   This section is always required and has no heading, so that it renders as the opening
   paragraph of the release.
 -->
@@ -89,3 +89,65 @@
 
   If this side does not benefit from this release, write "No Improvement".
 -->
+
+## Breaking changes and migration
+
+<!--
+  Ares is consumed as a released Maven artefact, so state explicitly whether this release
+  changes any of:
+  - the public API under de.tum.cit.ase.ares.api
+  - the security policy file format or its schema
+  - the generated security test code that exercise repositories rely on
+  - the minimum JDK, Maven or Gradle version
+
+  For each one that changed, say what an instructor has to do to upgrade an existing
+  exercise, and show the before and the after where a code or policy snippet makes it
+  concrete. An instructor reads this section to size the work, so an unquantified
+  "policies must be updated" is worth little.
+
+  A change that fails closed belongs here even when it is technically a fix: a policy
+  that used to be accepted and is now rejected breaks a working exercise, whatever the
+  reason. Removals belong here in full, listed by name, since a missing symbol is found
+  at compile time by the person least able to explain it.
+
+  If the release is fully backwards compatible, write "None".
+-->
+
+None.
+
+## Coordinates
+
+<!--
+  The dependency snippets for this version, so nobody has to construct them. Replace the
+  version in both, and keep the agent line: the Java agent ships under the `agent`
+  classifier, and an exercise that misses it repackages the agent by hand for nothing.
+
+  Publish these notes only once the artefacts are actually live on Maven Central, which
+  is a separate step from creating the GitHub release and can lag it. Confirm with
+  https://repo1.maven.org/maven2/de/tum/cit/ase/ares/maven-metadata.xml, which must list
+  this version under <release>. Notes that name coordinates nobody can resolve yet cost
+  more goodwill than they buy.
+
+  Close with the full changelog link, comparing the previous tag to this one.
+-->
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>de.tum.cit.ase</groupId>
+    <artifactId>ares</artifactId>
+    <version>REPLACE_WITH_THIS_VERSION</version>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+testImplementation "de.tum.cit.ase:ares:REPLACE_WITH_THIS_VERSION"
+aresAgent "de.tum.cit.ase:ares:REPLACE_WITH_THIS_VERSION:agent"
+```
+
+The Java agent is published under the `agent` classifier, so no manual repackaging is needed.
+
+**Full changelog:** https://github.com/ls1intum/Ares2/compare/REPLACE_WITH_PREVIOUS_TAG...REPLACE_WITH_THIS_TAG


### PR DESCRIPTION
## Summary

Adds `.github/RELEASE_TEMPLATE.md`, a release notes template beside the pull request template, so that consecutive releases answer the same questions in the same order.
It carries the problem and stakeholder sections of `PULL_REQUEST_TEMPLATE.md` over to the release level, aggregated over everything merged since the previous tag.

## Linked issues

None.

## 1. Problem

This pull request is not driven by a defect. It closes a gap in the release process.

Release notes were written from scratch every time, so what a release stated depended on who wrote it and on the day. The 2.1.0 notes lead with breaking changes, then group changes by area, and close with coordinates. The 2.1.1 notes lead with the problems fixed, then split the benefit between users and maintainers. Neither is wrong, and both were written carefully, but two consecutive releases that answer different questions cannot be read against each other. An instructor deciding whether to upgrade has to reconstruct, per release, whether a missing section means "nothing to report" or "not considered".

The same reasoning already applied to pull requests and was settled in #142. Releases are the point where the reasoning reaches the people who consume Ares as a Maven artefact rather than the people who develop it, so the argument is stronger there, not weaker.

The gap sits in the contribution and release process, not in any Ares layer, so it is neither a false negative nor a false positive.

## 2. Improvement from the user's perspective

Indirect, and only from the next release onwards. Instructors and students read release notes to decide whether to upgrade and what to change when they do. Fixing the headings means the answer to "does this affect me" is in the same place every time, and two of the template's instructions exist to protect exactly that reader: state the limitation that bounds a partial hardening, and leave out figures that have not been verified.

Nothing in the released artefact, the policy format or the enforcement behaviour changes.

## 3. Improvement from the maintainer's perspective

- The release author starts from a structure instead of a blank field, and the template says where the material comes from: `git log --oneline <previous-tag>..main`, then the bodies of the pull requests it names, which already answer sections 3 to 5 for their own change.
- Every section states what to write when it does not apply, so an empty section means "considered and not applicable" rather than "forgotten", matching `PULL_REQUEST_TEMPLATE.md`.
- Two failure modes this repository has actually hit are written down rather than rediscovered: overstating what a hardening closes, and quoting a figure from a pull request body without checking it.
- Sections 3, 4 and 5 deliberately mirror the pull request template, so aggregating a release out of its merged pull requests is mechanical. `Breaking changes and migration` mirrors it too, but asks for the upgrade steps rather than the fact alone, because a release reader is deciding whether to upgrade a working exercise rather than whether to approve a diff.
- `Coordinates` spares every reader the reconstruction of two dependency snippets and keeps the `agent` classifier visible, which is the part an exercise silently gets wrong. Its guidance also ties publishing the notes to the artefacts being resolvable, since deploying to Maven Central is a separate step from creating the GitHub release and can lag it.

## 4. Testing manual

**Prerequisites**

1. None beyond access to this repository. The change contains no Java code and alters no Ares behaviour, so it is not reproducible from an exercise.

**Steps**

Not reproducible from an exercise; this is a documentation change. A reviewer verifies it as follows.

1. Open `.github/RELEASE_TEMPLATE.md` on this branch and confirm it renders as an opening paragraph placeholder plus six headings, with all guidance inside HTML comments.
2. Confirm the file sits beside `PULL_REQUEST_TEMPLATE.md` in `.github/`, and that `.github/labeler.yml` already covers it through `.github/**/*`, so no labeler entry is needed.
3. Read it against the [2.1.1 release notes](https://github.com/ls1intum/Ares2/releases/tag/v2.1.1), which follow this structure, and confirm each heading has usable material.

**Expected result**

The template renders as the opening paragraph placeholder plus six headings, and GitHub does not prefill it anywhere, since it has no release template feature. It is a file to copy from.

**Negative case (what must still be rejected)**

Not applicable to a documentation file: it changes no code path, so there is nothing Ares could newly permit. The `Java CI with Maven` matrix nonetheless runs on this branch and must stay green.

**Modes exercised**

No mode-specific behaviour changed.

- [ ] ArchUnit + AspectJ
- [ ] ArchUnit + instrumentation
- [ ] WALA + AspectJ
- [ ] WALA + instrumentation

## 5. Test case coverage regarding this PR

No Java code changed.

## Breaking changes and migration

None.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
<!-- Tests were added or updated: not applicable, the change adds a documentation file and no code path. -->
- [x] Documentation (`docs/`, `README.adoc`, Javadoc) was updated where the change is user-facing.
- [x] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test
