### PR TITLE
Align the documented Ares version with the released 2.1.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ environment of a Maven project, include
 <dependency>
     <groupId>de.tum.cit.ase</groupId>
     <artifactId>ares</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 </dependency>
 ----
 
@@ -61,7 +61,7 @@ in the `dependencies` section.
 For Gradle projects, include
 [source,groovy]
 ----
-implementation("de.tum.cit.ase:ares:2.1.0")
+implementation("de.tum.cit.ase:ares:2.1.1")
 ----
 
 in the `dependencies` section.
@@ -95,7 +95,7 @@ looks like this:
     <dependency>
         <groupId>de.tum.cit.ase</groupId>
         <artifactId>ares</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
     </dependency>
 </dependencies>
 ----
@@ -980,7 +980,7 @@ Maven:
 ----
 <properties>
         <studentOutputDir>${project.basedir}/build/classes/java/main</studentOutputDir>
-        <ares.version>2.1.0</ares.version>
+        <ares.version>2.1.1</ares.version>
         <agent.dir>${project.build.directory}/agents</agent.dir>
     </properties>
 
@@ -1117,8 +1117,8 @@ configurations {
 }
 
 dependencies {
-    aresAgent 'de.tum.cit.ase:ares:2.1.0'
-    testImplementation("de.tum.cit.ase:ares:2.1.0")
+    aresAgent 'de.tum.cit.ase:ares:2.1.1'
+    testImplementation("de.tum.cit.ase:ares:2.1.1")
 }
 
 def forbiddenPackageFolders = [
@@ -1384,7 +1384,7 @@ repositories {
 <dependency>
     <groupId>de.tum.cit.ase</groupId>
     <artifactId>ares</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 </dependency>
 ----
 

--- a/docs/HowToMakeAProjectAnAresProject.md
+++ b/docs/HowToMakeAProjectAnAresProject.md
@@ -2,7 +2,7 @@
 
 > **Audience:** IT-Education experts with no security background.
 > **Scope:** The `build.gradle` and `pom.xml` files.
-> **Ares Version:** 2.1.0
+> **Ares Version:** 2.1.1
 
 > **Note:** This guide is a **setup guide**. It covers adding the Ares dependency, attaching the agent, and configuring the build tool so that Ares can run. For writing security policies that control what student code can do, see the [Security Policy Manual](policy/SecurityPolicyManual.md).
 
@@ -106,10 +106,10 @@ Add the Ares library to both the agent configuration and test implementation, as
 
 ```gradle
 dependencies {
-    aresAgent "de.tum.cit.ase:ares:2.1.0:agent"
+    aresAgent "de.tum.cit.ase:ares:2.1.1:agent"
     aresAgent "org.aspectj:aspectjrt:1.9.25.1"
-    testImplementation "de.tum.cit.ase:ares:2.1.0"
-    aspect "de.tum.cit.ase:ares:2.1.0"
+    testImplementation "de.tum.cit.ase:ares:2.1.1"
+    aspect "de.tum.cit.ase:ares:2.1.1"
     implementation "org.aspectj:aspectjrt:1.9.25.1"
 }
 ```
@@ -118,7 +118,7 @@ dependencies {
 >
 > ```toml
 > [versions]
-> ares = "2.1.0"
+> ares = "2.1.1"
 > aspectjrt = "1.9.25.1"
 > [libraries]
 > ares = { module = "de.tum.cit.ase:ares", version.ref = "ares" }
@@ -224,7 +224,7 @@ Include Ares in your test dependencies, as well as the AspectJ runtime library:
 <dependency>
     <groupId>de.tum.cit.ase</groupId>
     <artifactId>ares</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <scope>test</scope>
 </dependency>
 <dependency>
@@ -252,7 +252,7 @@ Configure the Surefire test plugin to load the agent during test execution:
     <artifactId>maven-surefire-plugin</artifactId>
     <configuration>
         <argLine>
-            -javaagent:${settings.localRepository}/de/tum/cit/ase/ares/2.1.0/ares-2.1.0-agent.jar
+            -javaagent:${settings.localRepository}/de/tum/cit/ase/ares/2.1.1/ares-2.1.1-agent.jar
             -Xbootclasspath/a:${settings.localRepository}/org/aspectj/aspectjrt/1.9.25.1/aspectjrt-1.9.25.1.jar
             --add-exports java.base/java.lang=ALL-UNNAMED
             --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
@@ -290,7 +290,7 @@ Configure the Surefire test plugin to load the agent during test execution:
 > **Tip (avoid hardcoded version):** Define a Maven property so the version appears in one place only:
 > ```xml
 > <properties>
->     <ares.version>2.1.0</ares.version>
+>     <ares.version>2.1.1</ares.version>
 > </properties>
 > ```
 > Then use `${ares.version}` in both the dependency and the `<argLine>`:

--- a/docs/architecture/BlockCommandSystemAccessArchitecture.md
+++ b/docs/architecture/BlockCommandSystemAccessArchitecture.md
@@ -883,7 +883,7 @@ java.lang.ProcessBuilder.startPipeline
     <dependency>
         <groupId>de.tum.cit.ase</groupId>
         <artifactId>ares</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
     </dependency>
 </dependencies>
 ```

--- a/docs/architecture/BlockThreadSystemAccessArchitecture.md
+++ b/docs/architecture/BlockThreadSystemAccessArchitecture.md
@@ -1111,7 +1111,7 @@ java.util.Collection.parallelStream()
     <dependency>
         <groupId>de.tum.cit.ase</groupId>
         <artifactId>ares</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
     </dependency>
 </dependencies>
 ```

--- a/docs/policy/SecurityPolicyManual.md
+++ b/docs/policy/SecurityPolicyManual.md
@@ -2,7 +2,7 @@
 
 > **Audience:** IT-Education experts with no security background.
 > **Scope:** All classes inside `SecurityPolicy.java`, and the `policySubComponents` package.
-> **Ares Version:** 2.1.0
+> **Ares Version:** 2.1.1
 
 **Related documentation:**
 - [How to Make a Project an Ares Project](../HowToMakeAProjectAnAresProject.md), project setup (build.gradle / pom.xml)

--- a/docs/policy/SecurityPolicyReaderAndDirectorManual.md
+++ b/docs/policy/SecurityPolicyReaderAndDirectorManual.md
@@ -2,7 +2,7 @@
 
 > **Audience:** IT-Education experts with no security background.
 > **Scope:** All classes inside `SecurityPolicyReaderAndDirector.java`, the `reader` and `director` packages.
-> **Ares Version:** 2.1.0
+> **Ares Version:** 2.1.1
 
 **Related documentation:**
 - [Security Policy Manual](SecurityPolicyManual.md), how to write a security policy YAML file

--- a/docs/securitytest/TestCaseFactoryAndBuilderManual.md
+++ b/docs/securitytest/TestCaseFactoryAndBuilderManual.md
@@ -2,7 +2,7 @@
 
 > **Audience:** IT-Education experts with no security background.
 > **Scope:** All classes inside `de.tum.cit.ase.ares.api.securitytest` — the abstract factory/builder, the Java-specific factory, and the `creator`, `essentialModel`, `executer`, `writer`, `projectScanner`, and `specific` sub-packages.
-> **Ares Version:** 2.1.0
+> **Ares Version:** 2.1.1
 
 **Related documentation:**
 - [Security Policy Manual](../policy/SecurityPolicyManual.md) — how to write a security policy YAML file


### PR DESCRIPTION
## Summary

Bring every manual and both architecture documents up to the released 2.1.1, which the pom already carries.

## Linked issues

None.

## 1. Problem

`pom.xml` was bumped to 2.1.1 when that release was tagged (`v2.1.1` points at `b26fd151`), but the documentation was not. All four manuals still announced `> **Ares Version:** 2.1.0` in their header, and every dependency coordinate in the setup manual, the two architecture documents and the README still named 2.1.0.

An instructor following any of those documents therefore added a dependency one release behind the artefact the documentation was written for. This is a documentation defect, not a security defect: it produces neither a false negative nor a false positive, but the guidance does not describe the version it belongs to.

## 2. Improvement from the user's perspective

An instructor copying a coordinate out of the documentation gets the current release rather than the previous one, and the version stated in a manual's header matches the artefact the rest of that manual describes.

## 3. Improvement from the maintainer's perspective

Removes the drift between the pom and the documentation, so the next release starts from a consistent state instead of accumulating two versions of skew.

## 4. Testing manual

Not reproducible from an exercise: this pull request changes version strings in documentation only. A reviewer verifies it by inspection.

**Prerequisites**

1. None.

**Steps**

1. Run `grep -rn "2\.1\.0" --include="*.md" --include="*.adoc" docs README.adoc` and confirm it returns nothing.
2. Run `grep -n "<version>" pom.xml | head -1` and confirm the project version is `2.1.1`, so the documentation and the artefact now agree.
3. Open `docs/HowToMakeAProjectAnAresProject.md` and confirm the header reads `> **Ares Version:** 2.1.1`.

**Expected result**

- Step 1: no output. Every Ares coordinate and every version header names 2.1.1.
- Step 2: `<version>2.1.1</version>`, so no drift remains between pom and documentation.
- Step 3: the header matches the coordinates in the same document.

Only the Ares version changes. The AspectJ version (`1.9.25.1`) is deliberately untouched, so a reviewer should see exactly 20 changed lines across 7 files and nothing else.

**Negative case (what must still be rejected)**

Not applicable: no enforcement behaviour is involved. The change cannot make Ares more permissive, because it changes no code, no policy schema and no generated test.

**Merge gate**

Do not merge until `de.tum.cit.ase:ares:2.1.1` resolves from Maven Central, including the `agent` classifier. Merging while Central still returns 404 would replace working 2.1.0 instructions with unresolvable 2.1.1 ones. Check with:

`curl -o /dev/null -w "%{http_code}\n" https://repo1.maven.org/maven2/de/tum/cit/ase/ares/2.1.1/ares-2.1.1-agent.jar`

**Modes exercised**

No mode-specific behaviour changed.

- [ ] ArchUnit + AspectJ
- [ ] ArchUnit + instrumentation
- [ ] WALA + AspectJ
- [ ] WALA + instrumentation

## 5. Test case coverage regarding this PR

No Java code changed.

## Breaking changes and migration

None.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
- [ ] Tests were added or updated for the behaviour changed here.
<!-- No behaviour changed: this pull request edits version strings in documentation only. -->
- [x] Documentation (`docs/`, `README.adoc`, Javadoc) was updated where the change is user-facing.
- [x] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test
