### PR TITLE
Report which classes the no-policy scan recognised as tests

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScanner.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScanner.java
@@ -17,6 +17,9 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ParserConfiguration;
@@ -35,6 +38,7 @@ import de.tum.cit.ase.ares.api.util.ProjectSourcesFinder;
 
 /** JavaParser-backed, deterministic Java project scanner. */
 public class JavaProjectScanner implements ProjectScanner {
+	private static final Logger LOG = LoggerFactory.getLogger(JavaProjectScanner.class);
 	// The test annotations Ares recognises, as fully-qualified type names. An
 	// annotation use counts only when it resolves to one of these types: a
 	// fully-qualified use names the type outright, and a bare simple name is
@@ -173,7 +177,36 @@ public class JavaProjectScanner implements ProjectScanner {
 				}
 			}
 		}
-		return classes.stream().sorted().toArray(String[]::new);
+		String[] recognised = classes.stream().sorted().toArray(String[]::new);
+		reportRecognisedTestClasses(recognised);
+		return recognised;
+	}
+
+	/**
+	 * Reports what the no-policy scan recognised as test classes.
+	 * <p>
+	 * Only this path derives the exempt test classes from project code; with a
+	 * policy present they come solely from
+	 * {@code theFollowingClassesAreTestClasses} and this scanner is never
+	 * consulted. Which classes the scan recognised is therefore the one thing an
+	 * exercise author needs to see when a test is unexpectedly supervised, or
+	 * unexpectedly exempt, and there was previously no way to observe it.
+	 * </p>
+	 * <p>
+	 * The count is safe to surface anywhere. The names are not: a build log that
+	 * reaches students would disclose the hidden-test structure. Hence the count at
+	 * INFO and the names at TRACE, which the shipped {@code logback.xml} does not
+	 * enable, its root level being {@code debug}. An instructor who needs the names
+	 * raises the level for this logger alone.
+	 * </p>
+	 *
+	 * @param recognised the recognised test classes, sorted.
+	 */
+	private static void reportRecognisedTestClasses(@Nonnull String[] recognised) {
+		LOG.info("No-policy scan recognised {} test class(es).", recognised.length);
+		if (LOG.isTraceEnabled()) {
+			LOG.trace("No-policy scan recognised these test classes: {}", String.join(", ", recognised));
+		}
 	}
 
 	/**

--- a/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScannerDiagnosticsTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScannerDiagnosticsTest.java
@@ -71,15 +71,22 @@ class JavaProjectScannerDiagnosticsTest {
 		// here so the assertion does not depend on ambient configuration.
 		scannerLogger.setLevel(Level.DEBUG);
 
-		scanner.scanForTestClasses();
+		String[] recognised = scanner.scanForTestClasses();
 
 		List<ILoggingEvent> events = List.copyOf(appender.list);
 		assertEquals(1, events.size(), "the scan should report itself exactly once");
 		assertEquals(Level.INFO, events.get(0).getLevel());
-		assertTrue(events.get(0).getFormattedMessage().contains("2 test class(es)"),
-				"the count belongs in the message, was: " + events.get(0).getFormattedMessage());
-		assertFalse(events.get(0).getFormattedMessage().contains("checks."),
-				"the class names must not appear below TRACE");
+		String message = events.get(0).getFormattedMessage();
+		assertTrue(message.contains("2 test class(es)"), "the count belongs in the message, was: " + message);
+		// Checked against what the scan actually recognised, and against the simple
+		// names too. Asserting only on the package prefix would still pass if a
+		// future change logged bare class names, which discloses the same structure.
+		for (String testClass : recognised) {
+			assertFalse(message.contains(testClass),
+					"the qualified name " + testClass + " must not appear below TRACE");
+			String simpleName = testClass.substring(testClass.lastIndexOf('.') + 1);
+			assertFalse(message.contains(simpleName), "the simple name " + simpleName + " must not appear below TRACE");
+		}
 	}
 
 	@Test

--- a/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScannerDiagnosticsTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScannerDiagnosticsTest.java
@@ -1,0 +1,122 @@
+package de.tum.cit.ase.ares.api.securitytest.java.projectScanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import de.tum.cit.ase.ares.api.buildtoolconfiguration.BuildMode;
+import de.tum.cit.ase.ares.api.buildtoolconfiguration.BuildToolConfiguration;
+
+/**
+ * Covers the diagnostic that the no-policy scan emits about the test classes it
+ * recognised.
+ * <p>
+ * The split matters for more than tidiness. The count tells an exercise author
+ * that the scan ran and how much it found, and is harmless wherever build
+ * output ends up. The fully-qualified names would disclose the hidden-test
+ * structure to anyone who can read that output, students included, so they must
+ * stay behind a level the shipped {@code logback.xml} does not enable.
+ * </p>
+ */
+class JavaProjectScannerDiagnosticsTest {
+	@TempDir
+	Path root;
+
+	private Logger scannerLogger;
+
+	private ListAppender<ILoggingEvent> appender;
+
+	private Level originalLevel;
+
+	@BeforeEach
+	void attachAppender() {
+		scannerLogger = (Logger) LoggerFactory.getLogger(JavaProjectScanner.class);
+		originalLevel = scannerLogger.getLevel();
+		appender = new ListAppender<>();
+		appender.start();
+		scannerLogger.addAppender(appender);
+	}
+
+	@AfterEach
+	void detachAppender() {
+		scannerLogger.detachAppender(appender);
+		appender.stop();
+		// A null original level means the logger inherited one, and setLevel(null)
+		// restores exactly that, so no other test sees a level this one pinned.
+		scannerLogger.setLevel(originalLevel);
+	}
+
+	@Test
+	@DisplayName("Reports the count at INFO and withholds the class names below TRACE")
+	void reportsCountAndWithholdsNames() throws IOException {
+		JavaProjectScanner scanner = scannerOverTwoTestClasses();
+		// DEBUG is what the shipped logback.xml gives this logger, and it is pinned
+		// here so the assertion does not depend on ambient configuration.
+		scannerLogger.setLevel(Level.DEBUG);
+
+		scanner.scanForTestClasses();
+
+		List<ILoggingEvent> events = List.copyOf(appender.list);
+		assertEquals(1, events.size(), "the scan should report itself exactly once");
+		assertEquals(Level.INFO, events.get(0).getLevel());
+		assertTrue(events.get(0).getFormattedMessage().contains("2 test class(es)"),
+				"the count belongs in the message, was: " + events.get(0).getFormattedMessage());
+		assertFalse(events.get(0).getFormattedMessage().contains("checks."),
+				"the class names must not appear below TRACE");
+	}
+
+	@Test
+	@DisplayName("Reports the class names only once TRACE is enabled for this logger")
+	void reportsNamesAtTrace() throws IOException {
+		JavaProjectScanner scanner = scannerOverTwoTestClasses();
+		scannerLogger.setLevel(Level.TRACE);
+
+		scanner.scanForTestClasses();
+
+		List<ILoggingEvent> events = List.copyOf(appender.list);
+		assertEquals(2, events.size(), "TRACE adds the names to the count, it does not replace it");
+		assertEquals(Level.INFO, events.get(0).getLevel());
+		assertEquals(Level.TRACE, events.get(1).getLevel());
+		String names = events.get(1).getFormattedMessage();
+		assertTrue(names.contains("checks.AlphaTest"), "was: " + names);
+		assertTrue(names.contains("checks.BetaTest"), "was: " + names);
+	}
+
+	private JavaProjectScanner scannerOverTwoTestClasses() throws IOException {
+		Path production = Files.createDirectories(root.resolve("custom/main"));
+		Path tests = Files.createDirectories(root.resolve("custom/test"));
+		Files.writeString(production.resolve("Application.java"), """
+				package checks;
+				class Application { public static void main(java.lang.String... arguments) {} }
+				""");
+		Files.writeString(tests.resolve("AlphaTest.java"), """
+				package checks;
+				import org.junit.jupiter.api.Test;
+				class AlphaTest { @Test void alpha() {} }
+				""");
+		Files.writeString(tests.resolve("BetaTest.java"), """
+				package checks;
+				import de.tum.cit.ase.ares.api.jupiter.PublicTest;
+				class BetaTest { @PublicTest void beta() {} }
+				""");
+		return new JavaProjectScanner(new BuildToolConfiguration(BuildMode.MAVEN, root, List.of(production),
+				List.of(tests), root.resolve("target/classes"), root.resolve("target/test-classes")));
+	}
+}


### PR DESCRIPTION
## Summary

Report how many classes the no-policy scan recognised as test classes, so that the derived exempt set can be observed at all.

## Linked issues

Follows up on review feedback on #158, where a reviewer was asked to "note which classes Ares reports as test classes" and could not find anywhere that Ares reports them.

## 1. Problem

Only the no-policy path derives the exempt test classes from project code. `TestCaseAbstractFactoryAndBuilder` reads `theFollowingClassesAreTestClasses` when a policy is present, and calls `projectScanner.scanForTestClasses()` only when one is not.

That derived set was completely invisible. `JavaProjectScanner` had no logger at all, so an exercise author whose test was unexpectedly supervised, or unexpectedly exempt, had nothing to inspect but the JUnit XML report, which shows what *ran* rather than what Ares *trusted*. Those are different questions, and the second one is the one that matters when the no-policy fallback misbehaves.

The root cause sits in the project-scanning layer, upstream of enforcement. It is a diagnostics gap rather than a defect: no forbidden code is let through and no correct submission is failed, but the fallback cannot be audited.

## 2. Improvement from the user's perspective

An instructor using the no-policy fallback can now see that the scan ran and how many classes it recognised, and can raise the level for this one logger to see which. Previously the only way to reason about the exempt set was to infer it from which tests executed.

## 3. Improvement from the maintainer's perspective

The no-policy path becomes auditable in CI output, so a future report of "my test was skipped" or "this class was exempt" can be answered from a log line rather than by reconstructing the scan by hand.

## Why the count is at INFO and the names are not

The count is harmless wherever build output ends up. The fully-qualified class names are not: a build log that reaches students would disclose the hidden-test structure. The names therefore go to TRACE, which the shipped `src/main/resources/logback.xml` leaves off, its root level being `debug`. DEBUG would not have been sufficient for the same reason. An instructor who needs the names raises the level for `de.tum.cit.ase.ares.api.securitytest.java.projectScanner.JavaProjectScanner` alone.

## 4. Testing manual

Scenario: *I have an Ares 2 exercise* that runs locally, with **no** security policy file, so the no-policy path is taken. No Artemis instance is involved. The change is build-tool independent; the commands below use Maven, and Gradle behaves identically.

**Prerequisites**

1. JDK 17 and Maven. No Artemis, database or network service.
2. Ares built and installed from this branch: `mvn -o install -DskipTests`.
3. A minimal exercise project depending on the Ares built above, with no policy file. `examples/ares-exercise-maven` on the `docs/setup-manual-and-exercise-template` branch is such a project once its `@Policy` annotation is removed; otherwise any throwaway project with one supervised class and one JUnit test class will do.

**Steps**

1. Run `mvn test` in the exercise project.
   *Expected:* the output contains exactly one line `No-policy scan recognised N test class(es).` at `[INFO]`, where N is the number of test classes in the project. The class names do **not** appear.
2. Re-run with the names enabled, for example by adding a logger entry at level `TRACE` for `de.tum.cit.ase.ares.api.securitytest.java.projectScanner.JavaProjectScanner` in the exercise's own logback configuration.
   *Expected:* the INFO count is still emitted, and a second line at `[TRACE]` lists the fully-qualified names, sorted. TRACE adds to the count, it does not replace it.
3. Add a `SecurityPolicy.yaml` and a `@Policy` annotation to the test, then run `mvn test` again.
   *Expected:* neither line appears, because the policy path never consults the scanner.

**Expected result**

The no-policy fallback states how many classes it recognised, and states which ones only when explicitly asked. Before this change neither was available at any level.

**Negative case (what must still be rejected)**

This change adds a diagnostic and alters no decision, so nothing that was previously blocked becomes permitted. Two properties must nonetheless hold, and both are covered by tests:

- The names must not be emitted at the shipped level. `JavaProjectScannerDiagnosticsTest.reportsCountAndWithholdsNames` pins the logger to DEBUG, the level `logback.xml` gives it, and asserts that no event contains a class name.
- The policy path must not scan at all. `TestCaseAbstractFactoryAndBuilderTest.exemptClassesComeFromPolicyNotScan` already asserts `verify(mockProjectScanner, never()).scanForTestClasses()`, which is a stronger guarantee than asserting the absence of a log line, so no new test was added for it.

**Modes exercised**

<!-- Test-class discovery runs upstream of, and independently from, the four enforcement combinations, and this change adds only a log statement to it. -->

No mode-specific behaviour changed.

- [ ] ArchUnit + AspectJ
- [ ] ArchUnit + instrumentation
- [ ] WALA + AspectJ
- [ ] WALA + instrumentation

## 5. Test case coverage regarding this PR

| Class | Line coverage | Confirmation (meaningful assertions) |
| --- | ---: | :---: |
| `JavaProjectScanner` | the added `reportRecognisedTestClasses` is fully covered by the two new tests | yes — `JavaProjectScannerDiagnosticsTest` captures the logger with a Logback `ListAppender` and asserts the event count, the level of each event, that the count appears in the message, and that the names appear at TRACE and only at TRACE |

## Breaking changes and migration

None to the public API under `de.tum.cit.ase.ares.api`, the policy file format, the generated security test code, or the minimum JDK, Maven or Gradle version.

**Release note:** this must ship in a release **after** 2.1.1. `v2.1.1` is already tagged at `b26fd151` and Maven Central releases are immutable, so this cannot be published under that version. The setup manual deliberately does not document the new log line yet; that paragraph is added once the release carrying it is on Central.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
- [x] Tests were added or updated for the behaviour changed here.
- [ ] Documentation (`docs/`, `README.adoc`, Javadoc) was updated where the change is user-facing.
<!-- Deliberately deferred: the manual is versioned, and documenting a diagnostic that no released artefact yet emits would send readers looking for an unavailable version. Added once the release carrying this is on Central. -->
- [x] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test
