### PR TITLE
Make the WALA backend work without jqwik and let AspectJ report the resolved runtime declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.tum.cit.ase</groupId>
 	<artifactId>ares</artifactId>
-	<version>2.1.1</version>
+	<version>2.1.2</version>
 	<properties>
 		<!-- 0. General Project Settings -->
 		<maven.compiler.source>17</maven.compiler.source>

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJAbstractAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJAbstractAdviceDefinitions.aj
@@ -674,22 +674,6 @@ public abstract aspect JavaAspectJAbstractAdviceDefinitions {
 	// <editor-fold desc="Signature handling (AspectJ-only)">
 
 	/**
-	 * Formats a join-point signature in the same shape produced by the Byte Buddy /
-	 * Instrumentation advice:
-	 * {@code <declaringType>.<methodName>(<paramType1>,<paramType2>,...)}.
-	 * <p>
-	 * AspectJ's {@link org.aspectj.lang.Signature#toLongString()} prepends Java
-	 * modifiers (e.g. {@code "public transient "}) and, for constructors, omits
-	 * {@code .<init>} altogether
-	 * ({@code "java.lang.ProcessBuilder(java.lang.String[])"}). The Instrumentation
-	 * side and the JSON expectation files use {@code <init>}-style signatures, so
-	 * this helper converts AspectJ's join-point shape to that form.
-	 *
-	 * @param sig the AspectJ {@link org.aspectj.lang.Signature} from the join point
-	 * @return normalized signature string with no leading modifiers and an explicit
-	 *         {@code <init>} marker for constructors
-	 */
-	/**
 	 * Appends the resolved runtime declaration of a denied call to its static
 	 * signature, when the two differ.
 	 * <p>
@@ -775,6 +759,22 @@ public abstract aspect JavaAspectJAbstractAdviceDefinitions {
 		}
 	}
 
+	/**
+	 * Formats a join-point signature in the same shape produced by the Byte Buddy /
+	 * Instrumentation advice:
+	 * {@code <declaringType>.<methodName>(<paramType1>,<paramType2>,...)}.
+	 * <p>
+	 * AspectJ's {@link org.aspectj.lang.Signature#toLongString()} prepends Java
+	 * modifiers (e.g. {@code "public transient "}) and, for constructors, omits
+	 * {@code .<init>} altogether
+	 * ({@code "java.lang.ProcessBuilder(java.lang.String[])"}). The Instrumentation
+	 * side and the JSON expectation files use {@code <init>}-style signatures, so
+	 * this helper converts AspectJ's join-point shape to that form.
+	 *
+	 * @param sig the AspectJ {@link org.aspectj.lang.Signature} from the join point
+	 * @return normalized signature string with no leading modifiers and an explicit
+	 *         {@code <init>} marker for constructors
+	 */
 	@Nonnull
 	protected static String formatSignature(@Nonnull Signature sig) {
 		return formatSignature(sig, sig.getDeclaringTypeName());

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJAbstractAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJAbstractAdviceDefinitions.aj
@@ -15,8 +15,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.Signature;
 import org.aspectj.lang.reflect.CodeSignature;
+import org.aspectj.lang.reflect.MethodSignature;
 //</editor-fold>
 
 public abstract aspect JavaAspectJAbstractAdviceDefinitions {
@@ -687,10 +689,101 @@ public abstract aspect JavaAspectJAbstractAdviceDefinitions {
 	 * @return normalized signature string with no leading modifiers and an explicit
 	 *         {@code <init>} marker for constructors
 	 */
+	/**
+	 * Appends the resolved runtime declaration of a denied call to its static
+	 * signature, when the two differ.
+	 * <p>
+	 * The AspectJ backend weaves {@code call(...)} join points, so its signature
+	 * names the <em>static</em> receiver type at the call site, whereas the
+	 * Instrumentation backend advises the implementation whose bytecode runs and
+	 * reports that class through {@code @Advice.Origin("#t")}. The same blocked
+	 * operation therefore appears as {@code java.nio.channels.DatagramChannel} in
+	 * one backend and {@code sun.nio.ch.DatagramChannelImpl} in the other. This
+	 * helper reports both, so a denial message carries the call-site identity that
+	 * only AspectJ observes as well as the implementation identity that only
+	 * Instrumentation observes.
+	 * <p>
+	 * This is best-effort diagnostic normalisation for ordinary public virtual
+	 * calls on platform classes, <em>not</em> a reconstruction of dispatch.
+	 * {@code super.method()}, bridge methods, private or package-private hiding and
+	 * null receivers all fall back to the static signature.
+	 * <p>
+	 * Two restrictions are deliberate and security-relevant. First, resolution
+	 * happens only for targets defined by the bootstrap or platform loader, so this
+	 * never runs student-controlled class loading while {@code ADVICE_IN_PROGRESS}
+	 * is set. Second, the result is used solely to render the message; every
+	 * enforcement key keeps using the unchanged static
+	 * {@code fullMethodSignature}, because those keys drive the ignore maps (for
+	 * example {@code java.io.File.delete}) and a dynamically resolved subclass name
+	 * would silently change which parameters and fields get inspected.
+	 *
+	 * @param joinPoint           the join point of the denied call
+	 * @param fullMethodSignature the static signature already used for enforcement
+	 * @return the static signature, optionally followed by the resolved runtime
+	 *         declaration
+	 */
+	@Nonnull
+	protected static String describeDeniedCall(@Nonnull JoinPoint joinPoint, @Nonnull String fullMethodSignature) {
+		@Nullable
+		String runtimeDeclaration = resolveRuntimeDeclaration(joinPoint);
+		if (runtimeDeclaration == null || runtimeDeclaration.equals(fullMethodSignature)) {
+			return fullMethodSignature;
+		}
+		return fullMethodSignature + " [resolved runtime declaration: " + runtimeDeclaration + "]"; //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	/**
+	 * Resolves the class declaring the method implementation that virtual dispatch
+	 * selects for this join point's receiver, or {@code null} when it cannot be
+	 * established cheaply and safely.
+	 */
+	@Nullable
+	private static String resolveRuntimeDeclaration(@Nonnull JoinPoint joinPoint) {
+		if (!(joinPoint.getSignature() instanceof MethodSignature methodSignature)) {
+			// Constructor and field join points already name the concrete type.
+			return null;
+		}
+		@Nullable
+		Object target = joinPoint.getTarget();
+		if (target == null) {
+			// Static call, or a receiver AspectJ cannot bind. Both legitimately keep the
+			// static declaration; a null receiver is about to raise NullPointerException.
+			return null;
+		}
+		@Nonnull
+		Class<?> runtimeType = target.getClass();
+		@Nullable
+		ClassLoader definingLoader = runtimeType.getClassLoader();
+		if (definingLoader != null && definingLoader != ClassLoader.getPlatformClassLoader()) {
+			// Never reflect over application- or student-loaded classes here: resolving
+			// their members can trigger their own class loading, which would run while
+			// the advice guard suppresses nested interception.
+			return null;
+		}
+		try {
+			@Nonnull
+			Method dispatched = runtimeType.getMethod(methodSignature.getName(), methodSignature.getParameterTypes());
+			@Nonnull
+			Class<?> declaring = dispatched.getDeclaringClass();
+			if (declaring.getName().equals(methodSignature.getDeclaringTypeName())) {
+				return null;
+			}
+			return formatSignature(methodSignature, declaring.getName());
+		} catch (NoSuchMethodException | RuntimeException | LinkageError unresolvableDeclaration) {
+			// Diagnostics must never turn a denial into a different failure.
+			return null;
+		}
+	}
+
 	@Nonnull
 	protected static String formatSignature(@Nonnull Signature sig) {
+		return formatSignature(sig, sig.getDeclaringTypeName());
+	}
+
+	@Nonnull
+	private static String formatSignature(@Nonnull Signature sig, @Nonnull String declaringTypeName) {
 		@Nonnull
-		String declaring = sig.getDeclaringTypeName();
+		String declaring = declaringTypeName;
 		@Nonnull
 		String name = sig.getName();
 		@Nonnull

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJCommandSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJCommandSystemAdviceDefinitions.aj
@@ -849,7 +849,7 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 		if (criticalCommandFieldUnreadable) {
 			throw new SecurityException(localize(
 					"security.advice.illegal.command.execution", commandSystemMethodToCheck, action, "<unknown>",
-					fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
+					describeDeniedCall(thisJoinPoint, fullMethodSignature) + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 							+ " | " + buildDenialReason(noAllowRuleConfigured)));
 		}
 		// <editor-fold desc="Check parameters">
@@ -862,7 +862,7 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 			throw new SecurityException(localize(
 					"security.advice.illegal.command.execution", commandSystemMethodToCheck, action,
 					commandIllegallyExecutedThroughParameter,
-					fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
+					describeDeniedCall(thisJoinPoint, fullMethodSignature) + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 							+ " | " + buildDenialReason(noAllowRuleConfigured)));
 		}
 		@Nullable
@@ -878,7 +878,7 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 			throw new SecurityException(localize(
 					"security.advice.illegal.file.execution", commandSystemMethodToCheck, action,
 					pathIllegallyExecutedThroughParameter,
-					fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
+					describeDeniedCall(thisJoinPoint, fullMethodSignature) + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 							+ " | " + localize("security.advice.denial.reason.command.executable.path.not.allowed")));
 		}
 		// </editor-fold>
@@ -892,7 +892,7 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 			throw new SecurityException(localize(
 					"security.advice.illegal.command.execution", commandSystemMethodToCheck, action,
 					commandIllegallyExecutedThroughAttribute,
-					fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
+					describeDeniedCall(thisJoinPoint, fullMethodSignature) + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 							+ " | " + buildDenialReason(noAllowRuleConfigured)));
 		}
 		@Nullable
@@ -908,7 +908,7 @@ public aspect JavaAspectJCommandSystemAdviceDefinitions extends JavaAspectJAbstr
 			throw new SecurityException(localize(
 					"security.advice.illegal.file.execution", commandSystemMethodToCheck, action,
 					pathIllegallyExecutedThroughAttribute,
-					fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
+					describeDeniedCall(thisJoinPoint, fullMethodSignature) + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 							+ " | " + localize("security.advice.denial.reason.command.executable.path.not.allowed")));
 		}
 		// </editor-fold>

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJFileSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJFileSystemAdviceDefinitions.aj
@@ -661,21 +661,21 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 	private boolean checkCopyOrTransferSpecialCase(@Nonnull String action, @Nonnull String declaringTypeName,
 			@Nonnull String methodName, @Nullable Object[] parameters, @Nullable Object instance,
 			@Nonnull String systemMethodToCheck, @Nullable String studentCalledMethod,
-			@Nonnull String fullMethodSignature) {
+			@Nonnull String fullMethodSignature, @Nonnull JoinPoint thisJoinPoint) {
 		if ("java.nio.file.Files".equals(declaringTypeName) && "copy".equals(methodName)) {
 			if ("read".equals(action)) {
 				// source (index 0). The other overloads' index-0 argument
 				// (InputStream) is not Path-shaped and resolves to no target, so this
 				// is a safe no-op for them.
 				checkSinglePathRole("read", "pathsAllowedToBeRead", isolateParameter(parameters, 0), false,
-						systemMethodToCheck, studentCalledMethod, fullMethodSignature);
+						systemMethodToCheck, studentCalledMethod, fullMethodSignature, thisJoinPoint);
 			} else if ("overwrite".equals(action)) {
 				// destination (index 1): create or overwrite depending on REPLACE_EXISTING.
 				boolean replaceExisting = hasReplaceExisting(parameters);
 				String resolvedAction = replaceExisting ? "overwrite" : "create";
 				String settingKey = replaceExisting ? "pathsAllowedToBeOverwritten" : "pathsAllowedToBeCreated";
 				checkSinglePathRole(resolvedAction, settingKey, isolateParameter(parameters, 1), true,
-						systemMethodToCheck, studentCalledMethod, fullMethodSignature);
+						systemMethodToCheck, studentCalledMethod, fullMethodSignature, thisJoinPoint);
 			} else {
 				throw new SecurityException(localize("security.advice.file.system.unknown.action", action));
 			}
@@ -687,7 +687,7 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 				// itself a channel and is not checked here — see class-level Javadoc above.
 				checkSinglePathRole("read", "pathsAllowedToBeRead",
 						instance == null ? new Object[0] : new Object[] { instance }, false, systemMethodToCheck,
-						studentCalledMethod, fullMethodSignature);
+						studentCalledMethod, fullMethodSignature, thisJoinPoint);
 			} else {
 				throw new SecurityException(localize("security.advice.file.system.unknown.action", action));
 			}
@@ -699,7 +699,7 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 				// itself a channel and is not checked here — see class-level Javadoc above.
 				checkSinglePathRole("overwrite", "pathsAllowedToBeOverwritten",
 						instance == null ? new Object[0] : new Object[] { instance }, false, systemMethodToCheck,
-						studentCalledMethod, fullMethodSignature);
+						studentCalledMethod, fullMethodSignature, thisJoinPoint);
 			} else {
 				throw new SecurityException(localize("security.advice.file.system.unknown.action", action));
 			}
@@ -717,7 +717,8 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 	 */
 	private void checkSinglePathRole(@Nonnull String actionLabel, @Nonnull String allowedPathsSettingKey,
 			@Nonnull Object[] candidates, boolean allowNonExistingPaths, @Nonnull String systemMethodToCheck,
-			@Nullable String studentCalledMethod, @Nonnull String fullMethodSignature) {
+			@Nullable String studentCalledMethod, @Nonnull String fullMethodSignature,
+			@Nonnull JoinPoint thisJoinPoint) {
 		if (candidates.length == 0) {
 			return;
 		}
@@ -734,7 +735,7 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 			return;
 		}
 		throw new SecurityException(localize("security.advice.illegal.file.execution", systemMethodToCheck,
-				actionLabel, violation, fullMethodSignature
+				actionLabel, violation, describeDeniedCall(thisJoinPoint, fullMethodSignature)
 						+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")") + " | "
 						+ buildDenialReason(noAllowRuleConfigured)));
 	}
@@ -1287,7 +1288,7 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 		@Nullable
 		String studentCalledMethod = findFirstMethodOutsideOfRestrictedPackage(restrictedPackage);
 		if (checkCopyOrTransferSpecialCase(action, declaringTypeName, methodName, parameters, instance,
-				systemMethodToCheck, studentCalledMethod, fullMethodSignature)) {
+				systemMethodToCheck, studentCalledMethod, fullMethodSignature, thisJoinPoint)) {
 			return;
 		}
 		List<Map.Entry<String, Boolean>> actionsToValidate = deriveActionChecks(action, declaringTypeName, parameters);
@@ -1354,7 +1355,7 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 					throw new SecurityException(localize(
 							"security.advice.illegal.file.execution", systemMethodToCheck, messageAction,
 							illegallyInteractedThroughParameter,
-							fullMethodSignature
+							describeDeniedCall(thisJoinPoint, fullMethodSignature)
 									+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 									+ " | " + buildDenialReason(noAllowRuleConfigured)));
 				}
@@ -1390,7 +1391,7 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 					throw new SecurityException(localize(
 							"security.advice.illegal.file.execution", systemMethodToCheck, messageAction,
 							illegallyInteractedThroughReceiver,
-							fullMethodSignature
+							describeDeniedCall(thisJoinPoint, fullMethodSignature)
 									+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 									+ " | " + buildDenialReason(noAllowRuleConfigured)));
 				}
@@ -1437,7 +1438,7 @@ public aspect JavaAspectJFileSystemAdviceDefinitions extends JavaAspectJAbstract
 					throw new SecurityException(localize(
 							"security.advice.illegal.file.execution", systemMethodToCheck, messageAction,
 							illegallyInteractedThroughAttribute,
-							fullMethodSignature
+							describeDeniedCall(thisJoinPoint, fullMethodSignature)
 									+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 									+ " | " + buildDenialReason(noAllowRuleConfigured)));
 				}

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJNetworkSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJNetworkSystemAdviceDefinitions.aj
@@ -698,7 +698,7 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 	 * @author Kevin Fischer
 	 */
 	private static void checkNetworkSystemInteractionForAction(@Nonnull String action,
-			@Nonnull String fullMethodSignature, @Nonnull String declaringTypeName,
+			@Nonnull JoinPoint thisJoinPoint, @Nonnull String fullMethodSignature, @Nonnull String declaringTypeName,
 			@Nonnull String methodName, @Nullable Object[] parameters, @Nullable Object[] attributes,
 			@Nullable Object instance, @Nonnull String networkSystemMethodToCheck,
 			@Nullable String studentCalledMethod) {
@@ -737,7 +737,8 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 					networkSystemMethodToCheck,
 					action,
 					targetFromParameters.toDisplayString(),
-					fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
+					describeDeniedCall(thisJoinPoint, fullMethodSignature)
+							+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 							+ " | " + buildDenialReason(noAllowRuleConfigured)
 			));
 		}
@@ -767,7 +768,8 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 					networkSystemMethodToCheck,
 					action,
 					networkIllegallyInteractedThroughParameter,
-					fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
+					describeDeniedCall(thisJoinPoint, fullMethodSignature)
+							+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 							+ " | " + buildDenialReason(noAllowRuleConfigured)
 			));
 		}
@@ -783,7 +785,8 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 					networkSystemMethodToCheck,
 					action,
 					networkIllegallyInteractedThroughReceiver,
-					fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
+					describeDeniedCall(thisJoinPoint, fullMethodSignature)
+							+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 							+ " | " + buildDenialReason(noAllowRuleConfigured)
 			));
 		}
@@ -800,7 +803,8 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 					networkSystemMethodToCheck,
 					action,
 					networkIllegallyInteractedThroughAttribute,
-					fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
+					describeDeniedCall(thisJoinPoint, fullMethodSignature)
+							+ (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 							+ " | " + buildDenialReason(noAllowRuleConfigured)
 			));
 		}
@@ -908,7 +912,7 @@ public aspect JavaAspectJNetworkSystemAdviceDefinitions extends JavaAspectJAbstr
 		// <editor-fold desc="Check actions">
 		List<Map.Entry<String, Boolean>> actionsToValidate = deriveActionChecks(action, methodName, instance);
 		for (Map.Entry<String, Boolean> actionCheck : actionsToValidate) {
-			checkNetworkSystemInteractionForAction(actionCheck.getKey(),
+			checkNetworkSystemInteractionForAction(actionCheck.getKey(), thisJoinPoint,
 					fullMethodSignature, declaringTypeName, methodName, parameters, attributes, instance,
 					networkSystemMethodToCheck, studentCalledMethod);
 		}

--- a/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJThreadSystemAdviceDefinitions.aj
+++ b/src/main/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJThreadSystemAdviceDefinitions.aj
@@ -833,7 +833,7 @@ public aspect JavaAspectJThreadSystemAdviceDefinitions extends JavaAspectJAbstra
 			if (checkIfThreadIsForbidden(new ThreadTarget(threadClassName), allowedThreadClasses, allowedThreadNumbers, decrementQuota)) {
 				throw new SecurityException(localize(
 						"security.advice.illegal.thread.execution", systemMethodToCheck, action, threadClassName,
-						fullMethodSignature + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
+						describeDeniedCall(thisJoinPoint, fullMethodSignature) + (studentCalledMethod == null ? "" : " (called by " + studentCalledMethod + ")")
 								+ " | " + buildDenialReason(noAllowRuleConfigured)));
 			}
 		}

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilder.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilder.java
@@ -121,10 +121,15 @@ public class CustomCallgraphBuilder {
 	 */
 	private final Set<Path> trustedFrameworkCodeSources;
 
+	/**
+	 * The filtered classpath this builder's scope, hierarchy and trust boundary
+	 * were derived from. A builder cannot analyse anything else.
+	 */
+	private final String constructionClassPath;
+
 	private final ClassFileImporter classFileImporter;
 	private final AnalysisScope scope;
 	private final ClassHierarchy classHierarchy;
-	private String analysedClassPath;
 	private CallGraph callGraph;
 
 	/**
@@ -136,6 +141,7 @@ public class CustomCallgraphBuilder {
 		this.classFileImporter = new ClassFileImporter();
 		this.trustedFrameworkCodeSources = effectiveTrustedFrameworkCodeSources(classPath);
 		String filteredClassPath = filterClassPath(classPath, trustedFrameworkCodeSources);
+		this.constructionClassPath = filteredClassPath;
 		String expandedClassPath = expandClassPathWithReachableDependencies(filteredClassPath,
 				trustedFrameworkCodeSources);
 		try {
@@ -463,9 +469,13 @@ public class CustomCallgraphBuilder {
 	 * present framework can never contribute a lone trusted origin.
 	 */
 	private static Set<Path> optionalFrameworkCandidateCodeSources() {
+		return optionalFrameworkCandidateCodeSources(OPTIONAL_FRAMEWORK_CLASS_NAMES);
+	}
+
+	static Set<Path> optionalFrameworkCandidateCodeSources(List<String> optionalFrameworkClassNames) {
 		ClassLoader definingLoader = CustomCallgraphBuilder.class.getClassLoader();
 		LinkedHashSet<Path> candidates = new LinkedHashSet<>();
-		for (String frameworkClassName : OPTIONAL_FRAMEWORK_CLASS_NAMES) {
+		for (String frameworkClassName : optionalFrameworkClassNames) {
 			Optional<Path> codeSource = optionalFrameworkCodeSource(frameworkClassName, definingLoader);
 			if (codeSource.isEmpty()) {
 				return Set.of();
@@ -715,10 +725,14 @@ public class CustomCallgraphBuilder {
 	public synchronized CallGraph buildCallGraph(String classPathToAnalyze) {
 		String filteredClassPathToAnalyse = filterClassPath(classPathToAnalyze, trustedFrameworkCodeSources);
 		validateClassPath(filteredClassPathToAnalyse);
+		// The class hierarchy and the effective trust boundary are both fixed at
+		// construction time from the constructor's classpath. Analysing a different
+		// target would silently reuse them, so reject it on the first call too and
+		// not only once a graph has been cached.
+		if (!constructionClassPath.equals(filteredClassPathToAnalyse)) {
+			throw new SecurityException(Messages.localized("security.architecture.build.call.graph.error"));
+		}
 		if (callGraph != null) {
-			if (!analysedClassPath.equals(filteredClassPathToAnalyse)) {
-				throw new SecurityException(Messages.localized("security.architecture.build.call.graph.error"));
-			}
 			return callGraph;
 		}
 		try {
@@ -757,7 +771,6 @@ public class CustomCallgraphBuilder {
 			// takes effect.
 			options.setSelector(new JdkOpaqueMethodTargetSelector(options.getMethodTargetSelector(), classHierarchy));
 			callGraph = builder.makeCallGraph(options, null);
-			analysedClassPath = filteredClassPathToAnalyse;
 			return callGraph;
 		} catch (Exception e) {
 			// Chain the cause so a genuine analysis failure is diagnosable and never

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilder.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilder.java
@@ -71,11 +71,17 @@ import de.tum.cit.ase.ares.api.util.FileTools;
 public class CustomCallgraphBuilder {
 
 	/**
-	 * Canonical code-source locations of the concrete framework artefacts loaded by
-	 * Ares. Trust is an origin decision: filenames and directory fragments are
-	 * entirely student-controlled and must never remove an entry from WALA's scope.
+	 * Canonical code-source locations of the concrete framework artefacts that Ares
+	 * always ships. Trust is an origin decision: filenames and directory fragments
+	 * are entirely student-controlled and must never remove an entry from WALA's
+	 * scope.
+	 * <p>
+	 * Every entry here comes from a compile-scope dependency, so the class literals
+	 * are guaranteed to resolve in any consumer and keep their compile-time
+	 * checking. Optional frameworks must never be added to this list; see
+	 * {@link #OPTIONAL_FRAMEWORK_CANDIDATE_CODE_SOURCES}.
 	 */
-	private static final Set<Path> TRUSTED_FRAMEWORK_CODE_SOURCES = trustedFrameworkCodeSources(
+	private static final Set<Path> REQUIRED_TRUSTED_FRAMEWORK_CODE_SOURCES = trustedFrameworkCodeSources(
 			CustomCallgraphBuilder.class, CallGraph.class, JavaClasses.class, org.apiguardian.api.API.class,
 			org.aspectj.lang.JoinPoint.class, org.assertj.core.api.Assertions.class, org.hamcrest.Matcher.class,
 			org.junit.Test.class, org.junit.jupiter.api.Test.class, org.junit.jupiter.params.ParameterizedTest.class,
@@ -83,8 +89,37 @@ public class CustomCallgraphBuilder {
 			org.junit.platform.engine.TestDescriptor.class, org.junit.platform.launcher.Launcher.class,
 			org.junit.platform.testkit.engine.EngineTestKit.class, org.mockito.Mockito.class,
 			org.opentest4j.AssertionFailedError.class, net.bytebuddy.ByteBuddy.class,
-			net.bytebuddy.agent.ByteBuddyAgent.class, net.jqwik.api.Property.class,
-			net.jqwik.engine.JqwikTestEngine.class);
+			net.bytebuddy.agent.ByteBuddyAgent.class);
+
+	/**
+	 * Fully qualified names of the optional framework classes whose origins may be
+	 * trusted when they are present.
+	 * <p>
+	 * jqwik is a {@code provided}-scope dependency, so it is absent from every
+	 * consumer that does not depend on it directly. Referencing it through a class
+	 * literal in a static initialiser made the whole class unusable in those
+	 * consumers, because the resulting {@link NoClassDefFoundError} is raised while
+	 * the argument array is built and therefore escapes the defensive handling in
+	 * {@link #trustedFrameworkCodeSources(Class...)}. Resolving these by name keeps
+	 * the optionality explicit and confined to the frameworks that really are
+	 * optional.
+	 */
+	private static final List<String> OPTIONAL_FRAMEWORK_CLASS_NAMES = List.of("net.jqwik.api.Property", //$NON-NLS-1$
+			"net.jqwik.engine.JqwikTestEngine"); //$NON-NLS-1$
+
+	/**
+	 * Candidate code-source locations of the optional frameworks. These are
+	 * candidates, not trusted origins: they become effective only after
+	 * {@link #effectiveTrustedFrameworkCodeSources(String)} has proven that none of
+	 * them lies inside the supervised project, and only ever as a complete set.
+	 */
+	private static final Set<Path> OPTIONAL_FRAMEWORK_CANDIDATE_CODE_SOURCES = optionalFrameworkCandidateCodeSources();
+
+	/**
+	 * Trusted framework origins effective for this analysis session, derived from
+	 * the unfiltered classpath handed to the constructor.
+	 */
+	private final Set<Path> trustedFrameworkCodeSources;
 
 	private final ClassFileImporter classFileImporter;
 	private final AnalysisScope scope;
@@ -99,8 +134,10 @@ public class CustomCallgraphBuilder {
 	 */
 	public CustomCallgraphBuilder(String classPath) {
 		this.classFileImporter = new ClassFileImporter();
-		String filteredClassPath = filterClassPath(classPath);
-		String expandedClassPath = expandClassPathWithReachableDependencies(filteredClassPath);
+		this.trustedFrameworkCodeSources = effectiveTrustedFrameworkCodeSources(classPath);
+		String filteredClassPath = filterClassPath(classPath, trustedFrameworkCodeSources);
+		String expandedClassPath = expandClassPathWithReachableDependencies(filteredClassPath,
+				trustedFrameworkCodeSources);
 		try {
 			this.scope = Java9AnalysisScopeReader.instance.makeJavaBinaryAnalysisScope(expandedClassPath,
 					FileTools.readFile(FileTools.resolveFileOnSourceDirectory("templates", "architecture", "java",
@@ -121,7 +158,7 @@ public class CustomCallgraphBuilder {
 	 * dispatch over every unrelated {@link Runnable} implementation prohibitively
 	 * expensive.
 	 */
-	private static String expandClassPathWithReachableDependencies(String classPath) {
+	private static String expandClassPathWithReachableDependencies(String classPath, Set<Path> trustedCodeSources) {
 		LinkedHashSet<String> entries = Arrays.stream(classPath.split(File.pathSeparator))
 				.filter(entry -> !entry.isBlank()).collect(Collectors.toCollection(LinkedHashSet::new));
 		Set<Path> projectClassRoots = discoverProjectClassRoots(entries);
@@ -140,7 +177,7 @@ public class CustomCallgraphBuilder {
 			}
 		}
 
-		addReachableDependencies(entries, pending, importer, projectClassRoots);
+		addReachableDependencies(entries, pending, importer, projectClassRoots, trustedCodeSources);
 		return String.join(File.pathSeparator, entries);
 	}
 
@@ -149,16 +186,24 @@ public class CustomCallgraphBuilder {
 	 * imported application classes. This is the same dependency expansion used for
 	 * the WALA scope and therefore invalidates cached verdicts when a reachable JAR
 	 * or class directory is replaced at the same path.
+	 * <p>
+	 * Only required framework origins are excluded here. This method has no
+	 * analysis classpath and therefore no supervised-project boundary to validate
+	 * optional origins against, so applying optional trust could drop
+	 * student-controlled bytecode from the fingerprint and leave a stale verdict
+	 * cached. Excluding less is always safe for a cache key; excluding too much is
+	 * not.
 	 */
 	static String dependencyFingerprint(JavaClasses applicationClasses) {
 		LinkedHashSet<String> entries = new LinkedHashSet<>();
 		Deque<JavaClass> pending = new ArrayDeque<>(applicationClasses);
-		addReachableDependencies(entries, pending, new ClassFileImporter(), Set.of());
+		addReachableDependencies(entries, pending, new ClassFileImporter(), Set.of(),
+				REQUIRED_TRUSTED_FRAMEWORK_CODE_SOURCES);
 		return fingerprintAnalysisEntries(entries);
 	}
 
 	private static void addReachableDependencies(LinkedHashSet<String> entries, Deque<JavaClass> pending,
-			ClassFileImporter importer, Set<Path> projectClassRoots) {
+			ClassFileImporter importer, Set<Path> projectClassRoots, Set<Path> trustedCodeSources) {
 		Set<String> visitedClasses = new HashSet<>();
 		Map<String, JavaClasses> importedJars = new HashMap<>();
 		while (!pending.isEmpty()) {
@@ -194,7 +239,7 @@ public class CustomCallgraphBuilder {
 					throw new SecurityException("Could not derive a classpath entry for reachable dependency " //$NON-NLS-1$
 							+ targetName);
 				}
-				if (isTrustedFrameworkLocation(location, classpathEntry.get())) {
+				if (isTrustedFrameworkLocation(location, classpathEntry.get(), trustedCodeSources)) {
 					visitedClasses.add(targetName);
 					continue;
 				}
@@ -321,16 +366,17 @@ public class CustomCallgraphBuilder {
 		}
 	}
 
-	private static boolean isTrustedFrameworkLocation(String classpathEntry) {
+	private static boolean isTrustedFrameworkLocation(String classpathEntry, Set<Path> trustedCodeSources) {
 		try {
-			return TRUSTED_FRAMEWORK_CODE_SOURCES.contains(Path.of(classpathEntry).toRealPath());
+			return trustedCodeSources.contains(Path.of(classpathEntry).toRealPath());
 		} catch (IOException | RuntimeException unavailableLocation) {
 			return false;
 		}
 	}
 
-	private static boolean isTrustedFrameworkLocation(URL classResource, String classpathEntry) {
-		if (isTrustedFrameworkLocation(classpathEntry)) {
+	private static boolean isTrustedFrameworkLocation(URL classResource, String classpathEntry,
+			Set<Path> trustedCodeSources) {
+		if (isTrustedFrameworkLocation(classpathEntry, trustedCodeSources)) {
 			return true;
 		}
 		if (!"file".equals(classResource.getProtocol())) { //$NON-NLS-1$
@@ -338,9 +384,109 @@ public class CustomCallgraphBuilder {
 		}
 		try {
 			Path classFile = Path.of(classResource.toURI()).toRealPath();
-			return TRUSTED_FRAMEWORK_CODE_SOURCES.stream().filter(Files::isDirectory).anyMatch(classFile::startsWith);
+			return trustedCodeSources.stream().filter(Files::isDirectory).anyMatch(classFile::startsWith);
 		} catch (IOException | java.net.URISyntaxException | RuntimeException unavailableLocation) {
 			return false;
+		}
+	}
+
+	/**
+	 * Resolves the trusted framework origins effective for one analysis session.
+	 * <p>
+	 * Required origins are always trusted. Optional origins are admitted only as a
+	 * complete set, and only once every candidate has been proven to lie outside
+	 * the supervised project. A student who places a forged {@code net.jqwik.api}
+	 * class in the project's own output tree therefore cannot have that output tree
+	 * dropped from WALA's scope. This cannot authenticate an unsigned artefact that
+	 * a student supplies from elsewhere on the classpath; that requires the
+	 * reserved-package boundary to cover every framework namespace.
+	 *
+	 * @param rawClassPath the unfiltered classpath handed to this analysis
+	 * @return the effective trusted origins, never {@code null}
+	 */
+	private static Set<Path> effectiveTrustedFrameworkCodeSources(String rawClassPath) {
+		return effectiveTrustedFrameworkCodeSources(rawClassPath, OPTIONAL_FRAMEWORK_CANDIDATE_CODE_SOURCES);
+	}
+
+	static Set<Path> effectiveTrustedFrameworkCodeSources(String rawClassPath, Set<Path> optionalCandidates) {
+		if (optionalCandidates.isEmpty()) {
+			return REQUIRED_TRUSTED_FRAMEWORK_CODE_SOURCES;
+		}
+		Set<Path> supervisedRoots = supervisedOriginRoots(rawClassPath);
+		for (Path candidate : optionalCandidates) {
+			if (isBeneathAny(candidate, supervisedRoots)) {
+				// All-or-nothing: one candidate inside the supervised project discards
+				// every optional origin rather than admitting a partially forged set.
+				return REQUIRED_TRUSTED_FRAMEWORK_CODE_SOURCES;
+			}
+		}
+		LinkedHashSet<Path> effective = new LinkedHashSet<>(REQUIRED_TRUSTED_FRAMEWORK_CODE_SOURCES);
+		effective.addAll(optionalCandidates);
+		return Set.copyOf(effective);
+	}
+
+	/**
+	 * Derives the supervised project boundary from the original, unfiltered
+	 * classpath entries. Both the conventional class-output roots and the project
+	 * roots containing them are returned, so a candidate anywhere in the project
+	 * tree is recognised.
+	 */
+	private static Set<Path> supervisedOriginRoots(String rawClassPath) {
+		LinkedHashSet<String> entries = Arrays.stream(rawClassPath.split(File.pathSeparator))
+				.filter(entry -> !entry.isBlank()).collect(Collectors.toCollection(LinkedHashSet::new));
+		LinkedHashSet<Path> roots = new LinkedHashSet<>();
+		for (Path outputRoot : discoverProjectClassRoots(entries)) {
+			canonicalOrigin(outputRoot).ifPresent(roots::add);
+			canonicalOrigin(containingProjectRoot(outputRoot)).ifPresent(roots::add);
+		}
+		return Set.copyOf(roots);
+	}
+
+	private static boolean isBeneathAny(Path candidate, Set<Path> roots) {
+		return roots.stream().anyMatch(root -> candidate.equals(root) || candidate.startsWith(root));
+	}
+
+	private static Optional<Path> canonicalOrigin(Path path) {
+		try {
+			return Optional.of(path.toRealPath());
+		} catch (IOException | RuntimeException unavailableLocation) {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Resolves the code sources of the optional frameworks, all of them or none.
+	 * <p>
+	 * Every name is probed with the loader that defined this class and without
+	 * running the framework's static initialisers. A single unresolvable name, an
+	 * unprovable origin, or any linkage failure yields an empty set, so a partially
+	 * present framework can never contribute a lone trusted origin.
+	 */
+	private static Set<Path> optionalFrameworkCandidateCodeSources() {
+		ClassLoader definingLoader = CustomCallgraphBuilder.class.getClassLoader();
+		LinkedHashSet<Path> candidates = new LinkedHashSet<>();
+		for (String frameworkClassName : OPTIONAL_FRAMEWORK_CLASS_NAMES) {
+			Optional<Path> codeSource = optionalFrameworkCodeSource(frameworkClassName, definingLoader);
+			if (codeSource.isEmpty()) {
+				return Set.of();
+			}
+			candidates.add(codeSource.get());
+		}
+		return Set.copyOf(candidates);
+	}
+
+	private static Optional<Path> optionalFrameworkCodeSource(String frameworkClassName, ClassLoader definingLoader) {
+		try {
+			Class<?> frameworkClass = Class.forName(frameworkClassName, false, definingLoader);
+			var codeSource = frameworkClass.getProtectionDomain().getCodeSource();
+			if (codeSource == null || codeSource.getLocation() == null) {
+				return Optional.empty();
+			}
+			return Optional.of(Path.of(codeSource.getLocation().toURI()).toRealPath());
+		} catch (ClassNotFoundException | IOException | java.net.URISyntaxException | RuntimeException
+				| LinkageError unavailableLocation) {
+			// If an origin cannot be proven, do not trust it and leave it in the scope.
+			return Optional.empty();
 		}
 	}
 
@@ -452,10 +598,10 @@ public class CustomCallgraphBuilder {
 	 * analysis: only entries actually referenced from student-code entry points end
 	 * up in the call graph.
 	 */
-	private static String filterClassPath(String classPath) {
+	private static String filterClassPath(String classPath, Set<Path> trustedCodeSources) {
 		String[] entries = classPath.split(File.pathSeparator);
 		LinkedHashSet<String> kept = Arrays.stream(entries).filter(entry -> !entry.isBlank())
-				.filter(entry -> !isTrustedFrameworkLocation(entry))
+				.filter(entry -> !isTrustedFrameworkLocation(entry, trustedCodeSources))
 				.collect(Collectors.toCollection(LinkedHashSet::new));
 
 		// Ares' BuildMode.getClasspath narrows the analysis classpath to a single
@@ -567,7 +713,7 @@ public class CustomCallgraphBuilder {
 	 * @return the constructed or cached call graph
 	 */
 	public synchronized CallGraph buildCallGraph(String classPathToAnalyze) {
-		String filteredClassPathToAnalyse = filterClassPath(classPathToAnalyze);
+		String filteredClassPathToAnalyse = filterClassPath(classPathToAnalyze, trustedFrameworkCodeSources);
 		validateClassPath(filteredClassPathToAnalyse);
 		if (callGraph != null) {
 			if (!analysedClassPath.equals(filteredClassPathToAnalyse)) {

--- a/src/test/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJAbstractAdviceDefinitionsTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJAbstractAdviceDefinitionsTest.java
@@ -226,10 +226,20 @@ class JavaAspectJAbstractAdviceDefinitionsTest {
 	 */
 	@Test
 	void describeDeniedCall_preservesTheEnforcementKeyPrefix() {
-		String staticForm = staticSignature("java.io.File", "delete", new Class<?>[0]);
+		// Deliberately a case where the declarations DO differ, otherwise nothing is
+		// appended and the assertion would hold vacuously.
+		String staticForm = staticSignature("java.nio.channels.DatagramChannel", "connect",
+				new Class<?>[] { SocketAddress.class });
 
-		String described = describe(new java.io.File("ares-diagnostic-probe"), "java.io.File", "delete");
+		String described;
+		try (DatagramChannel channel = DatagramChannel.open()) {
+			described = describe(channel, "java.nio.channels.DatagramChannel", "connect", SocketAddress.class);
+		} catch (java.io.IOException unavailableChannel) {
+			throw new AssertionError("could not open a channel for the probe", unavailableChannel);
+		}
 
+		assertTrue(described.length() > staticForm.length(),
+				"this test is vacuous unless a runtime declaration was actually appended: " + described);
 		assertTrue(described.startsWith(staticForm),
 				"the enforcement key must remain recoverable from the message: " + described);
 	}

--- a/src/test/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJAbstractAdviceDefinitionsTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/aop/java/aspectj/adviceandpointcut/JavaAspectJAbstractAdviceDefinitionsTest.java
@@ -1,0 +1,244 @@
+package de.tum.cit.ase.ares.api.aop.java.aspectj.adviceandpointcut;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.SocketAddress;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.nio.channels.DatagramChannel;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.reflect.ConstructorSignature;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the diagnostic normalisation that closes the reporting gap between
+ * the AspectJ and the Instrumentation backend.
+ * <p>
+ * AspectJ weaves {@code call(...)} join points and therefore names the static
+ * receiver type at the call site, while Instrumentation advises the
+ * implementation whose bytecode runs. The same blocked operation was reported
+ * under two different class names, so an expectation authored against one
+ * backend could never match the other. {@code describeDeniedCall} appends the
+ * resolved runtime declaration when it differs.
+ * <p>
+ * This is best-effort normalisation for ordinary public virtual calls on
+ * platform classes, so the fallback behaviour is asserted just as carefully as
+ * the resolution itself.
+ */
+class JavaAspectJAbstractAdviceDefinitionsTest {
+
+	private static JoinPoint methodJoinPoint(Object target, String declaringTypeName, String name,
+			Class<?>[] parameterTypes) {
+		MethodSignature signature = mock(MethodSignature.class);
+		when(signature.getDeclaringTypeName()).thenReturn(declaringTypeName);
+		when(signature.getName()).thenReturn(name);
+		when(signature.getParameterTypes()).thenReturn(parameterTypes);
+		JoinPoint joinPoint = mock(JoinPoint.class);
+		when(joinPoint.getSignature()).thenReturn(signature);
+		when(joinPoint.getTarget()).thenReturn(target);
+		return joinPoint;
+	}
+
+	private static String staticSignature(String declaringTypeName, String name, Class<?>[] parameterTypes) {
+		StringBuilder rendered = new StringBuilder(declaringTypeName).append('.').append(name).append('(');
+		for (int i = 0; i < parameterTypes.length; i++) {
+			if (i > 0) {
+				rendered.append(',');
+			}
+			rendered.append(parameterTypes[i].getName());
+		}
+		return rendered.append(')').toString();
+	}
+
+	private static String describe(Object target, String declaringTypeName, String name, Class<?>... parameterTypes) {
+		return JavaAspectJAbstractAdviceDefinitions.describeDeniedCall(
+				methodJoinPoint(target, declaringTypeName, name, parameterTypes),
+				staticSignature(declaringTypeName, name, parameterTypes));
+	}
+
+	/**
+	 * The concrete factory overrides the abstract method, so the resolved
+	 * declaration is the implementation Instrumentation would have reported.
+	 */
+	@Test
+	void describeDeniedCall_reportsOverridingImplementationForSocketFactory() {
+		String described = describe(SocketFactory.getDefault(), "javax.net.SocketFactory", "createSocket", String.class,
+				int.class);
+
+		assertTrue(described.startsWith("javax.net.SocketFactory.createSocket(java.lang.String,int)"),
+				"the guaranteed static signature must stay first: " + described);
+		assertTrue(described.contains("javax.net.DefaultSocketFactory.createSocket"),
+				"the resolved implementation must be appended: " + described);
+	}
+
+	@Test
+	void describeDeniedCall_reportsOverridingImplementationForSslSocketFactory() {
+		String described = describe(SSLSocketFactory.getDefault(), "javax.net.ssl.SSLSocketFactory", "createSocket",
+				String.class, int.class);
+
+		assertTrue(described.contains("sun.security.ssl.SSLSocketFactoryImpl.createSocket"), described);
+	}
+
+	@Test
+	void describeDeniedCall_reportsImplementationForDatagramChannel() throws Exception {
+		try (DatagramChannel channel = DatagramChannel.open()) {
+			String described = describe(channel, "java.nio.channels.DatagramChannel", "connect", SocketAddress.class);
+
+			assertTrue(described.contains("sun.nio.ch.DatagramChannelImpl.connect"), described);
+		}
+	}
+
+	/**
+	 * The runtime class here is {@code UnixAsynchronousSocketChannelImpl}, but the
+	 * method is declared one level up. Reading the runtime class directly would
+	 * report the wrong name, so this pins the declaring-class resolution.
+	 */
+	@Test
+	void describeDeniedCall_reportsDeclaringClassRatherThanRuntimeClass() throws Exception {
+		try (AsynchronousSocketChannel channel = AsynchronousSocketChannel.open()) {
+			String described = describe(channel, "java.nio.channels.AsynchronousSocketChannel", "connect",
+					SocketAddress.class);
+
+			assertTrue(described.contains("sun.nio.ch.AsynchronousSocketChannelImpl.connect"), described);
+			assertFalse(described.contains("UnixAsynchronousSocketChannelImpl"),
+					"the runtime class does not declare the method and must not be reported: " + described);
+		}
+	}
+
+	@Test
+	void describeDeniedCall_reportsImplementationForScheduledExecutorService() {
+		ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+		try {
+			String described = describe(executor, "java.util.concurrent.ScheduledExecutorService", "schedule",
+					Runnable.class, long.class, TimeUnit.class);
+
+			assertTrue(described.contains("Executors$DelegatedScheduledExecutorService.schedule"), described);
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	/**
+	 * An inherited method must resolve to the class that declares it, not to the
+	 * concrete pipeline subclass the runtime happens to use.
+	 */
+	@Test
+	void describeDeniedCall_reportsInheritedDeclaringClassForStream() {
+		String described = describe(Stream.of("element"), "java.util.stream.Stream", "parallel");
+
+		assertTrue(described.contains("java.util.stream.AbstractPipeline.parallel"), described);
+		assertFalse(described.contains("ReferencePipeline"),
+				"the declaring class, not the runtime class, must be reported: " + described);
+	}
+
+	/**
+	 * A static call has no receiver, so there is no dispatch to resolve and the
+	 * static signature must be returned untouched.
+	 */
+	@Test
+	void describeDeniedCall_fallsBackForNullTarget() {
+		String expected = staticSignature("java.nio.file.Files", "readString",
+				new Class<?>[] { java.nio.file.Path.class });
+
+		String described = describe(null, "java.nio.file.Files", "readString", java.nio.file.Path.class);
+
+		assertEquals(expected, described);
+	}
+
+	/**
+	 * Constructor join points already name the concrete type, so there is nothing
+	 * to normalise.
+	 */
+	@Test
+	void describeDeniedCall_fallsBackForConstructorSignature() {
+		ConstructorSignature signature = mock(ConstructorSignature.class);
+		JoinPoint joinPoint = mock(JoinPoint.class);
+		when(joinPoint.getSignature()).thenReturn(signature);
+
+		String described = JavaAspectJAbstractAdviceDefinitions.describeDeniedCall(joinPoint,
+				"java.lang.ProcessBuilder.<init>(java.lang.String[])");
+
+		assertEquals("java.lang.ProcessBuilder.<init>(java.lang.String[])", described);
+	}
+
+	/**
+	 * Resolving members of an application-loaded class can trigger that class's own
+	 * loading, which would run while the advice guard suppresses nested
+	 * interception. Such targets must never be reflected over.
+	 */
+	@Test
+	void describeDeniedCall_fallsBackForApplicationLoadedTarget() {
+		ApplicationLoadedTarget target = new ApplicationLoadedTarget();
+		assertFalse(
+				target.getClass().getClassLoader() == null
+						|| target.getClass().getClassLoader() == ClassLoader.getPlatformClassLoader(),
+				"this test is meaningless unless the target really is application-loaded");
+		String expected = staticSignature(ApplicationLoadedTarget.class.getName(), "run", new Class<?>[0]);
+
+		String described = describe(target, ApplicationLoadedTarget.class.getName(), "run");
+
+		assertEquals(expected, described);
+	}
+
+	/**
+	 * A signature that does not resolve against the runtime type must degrade to
+	 * the static signature rather than turning a denial into a different failure.
+	 */
+	@Test
+	void describeDeniedCall_fallsBackWhenMethodCannotBeResolved() {
+		String expected = staticSignature("java.util.stream.Stream", "noSuchMethod", new Class<?>[0]);
+
+		String described = describe(Stream.of("element"), "java.util.stream.Stream", "noSuchMethod");
+
+		assertEquals(expected, described);
+	}
+
+	/**
+	 * When the static declaration already is the declaring class, nothing is
+	 * appended, so unchanged messages stay byte-identical.
+	 */
+	@Test
+	void describeDeniedCall_addsNothingWhenDeclarationsAgree() {
+		String expected = staticSignature("java.lang.StringBuilder", "append", new Class<?>[] { String.class });
+
+		String described = describe(new StringBuilder(), "java.lang.StringBuilder", "append", String.class);
+
+		assertEquals(expected, described);
+	}
+
+	/**
+	 * The diagnostic form must never be substituted for the static signature: the
+	 * enforcement ignore maps are keyed on the static form (for example
+	 * {@code java.io.File.delete}), so a resolved subclass name would silently
+	 * change which parameters and fields get inspected.
+	 */
+	@Test
+	void describeDeniedCall_preservesTheEnforcementKeyPrefix() {
+		String staticForm = staticSignature("java.io.File", "delete", new Class<?>[0]);
+
+		String described = describe(new java.io.File("ares-diagnostic-probe"), "java.io.File", "delete");
+
+		assertTrue(described.startsWith(staticForm),
+				"the enforcement key must remain recoverable from the message: " + described);
+	}
+
+	private static final class ApplicationLoadedTarget {
+
+		@SuppressWarnings("unused")
+		public void run() {
+			// Never invoked; only its declaring class loader matters.
+		}
+	}
+}

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilderTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilderTest.java
@@ -5,17 +5,23 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.jar.JarFile;
 import java.util.regex.Pattern;
 
 import javax.activation.FileDataSource;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -179,11 +185,12 @@ public class CustomCallgraphBuilderTest {
 	@Test
 	void testExpandClassPathWithReachableJarDependency() throws Exception {
 		Method method = CustomCallgraphBuilder.class.getDeclaredMethod("expandClassPathWithReachableDependencies",
-				String.class);
+				String.class, Set.class);
 		method.setAccessible(true);
 		Path fixtureDirectory = Path.of("target", "test-classes", "de", "tum", "cit", "ase", "ares", "api",
 				"architecture", "java", "wala", "fixture");
-		String expandedClassPath = (String) method.invoke(null, fixtureDirectory.toString());
+		String expandedClassPath = (String) method.invoke(null, fixtureDirectory.toString(),
+				requiredTrustedFrameworkCodeSources());
 		URI commonsIoLocation = FileUtils.class.getProtectionDomain().getCodeSource().getLocation().toURI();
 		String commonsIoJar = Path.of(commonsIoLocation).toString();
 
@@ -194,9 +201,10 @@ public class CustomCallgraphBuilderTest {
 	@Test
 	void testExpandClassPathIncludesThirdPartyJavaxJarByOrigin() throws Exception {
 		Method method = CustomCallgraphBuilder.class.getDeclaredMethod("expandClassPathWithReachableDependencies",
-				String.class);
+				String.class, Set.class);
 		method.setAccessible(true);
-		String expandedClassPath = (String) method.invoke(null, FIXTURE_CLASSPATH);
+		String expandedClassPath = (String) method.invoke(null, FIXTURE_CLASSPATH,
+				requiredTrustedFrameworkCodeSources());
 		String activationJar = Path.of(FileDataSource.class.getProtectionDomain().getCodeSource().getLocation().toURI())
 				.toString();
 
@@ -276,11 +284,12 @@ public class CustomCallgraphBuilderTest {
 		Path actualAres = Path
 				.of(CustomCallgraphBuilder.class.getProtectionDomain().getCodeSource().getLocation().toURI())
 				.toRealPath();
-		Method method = CustomCallgraphBuilder.class.getDeclaredMethod("filterClassPath", String.class);
+		Method method = CustomCallgraphBuilder.class.getDeclaredMethod("filterClassPath", String.class, Set.class);
 		method.setAccessible(true);
 
 		String filtered = (String) method.invoke(null,
-				String.join(File.pathSeparator, fakeJunit.toString(), fakeAres.toString(), actualAres.toString()));
+				String.join(File.pathSeparator, fakeJunit.toString(), fakeAres.toString(), actualAres.toString()),
+				requiredTrustedFrameworkCodeSources());
 		Set<String> entries = Set.of(filtered.split(Pattern.quote(File.pathSeparator)));
 
 		Assertions.assertTrue(entries.contains(fakeJunit.toString()));
@@ -294,12 +303,172 @@ public class CustomCallgraphBuilderTest {
 				.getResource("/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilder.class").toURI();
 		Path packageDirectory = Path.of(classUri).getParent();
 		Method method = CustomCallgraphBuilder.class.getDeclaredMethod("isTrustedFrameworkLocation", java.net.URL.class,
-				String.class);
+				String.class, Set.class);
 		method.setAccessible(true);
 
-		boolean trusted = (boolean) method.invoke(null, classUri.toURL(), packageDirectory.toString());
+		boolean trusted = (boolean) method.invoke(null, classUri.toURL(), packageDirectory.toString(),
+				requiredTrustedFrameworkCodeSources());
 
 		Assertions.assertTrue(trusted);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Set<Path> requiredTrustedFrameworkCodeSources() throws Exception {
+		Field field = CustomCallgraphBuilder.class.getDeclaredField("REQUIRED_TRUSTED_FRAMEWORK_CODE_SOURCES");
+		field.setAccessible(true);
+		return (Set<Path>) field.get(null);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Set<Path> optionalFrameworkCandidateCodeSources() throws Exception {
+		Field field = CustomCallgraphBuilder.class.getDeclaredField("OPTIONAL_FRAMEWORK_CANDIDATE_CODE_SOURCES");
+		field.setAccessible(true);
+		return (Set<Path>) field.get(null);
+	}
+
+	/**
+	 * Regression test for the defect that made the WALA backend unusable in every
+	 * consumer without a direct jqwik dependency: jqwik is {@code provided}-scope,
+	 * and referencing it through a class literal in a static initialiser turned its
+	 * absence into a permanent {@link NoClassDefFoundError} for the whole class.
+	 * <p>
+	 * Loading the class in an isolated loader whose classpath omits jqwik is the
+	 * only way to reproduce the consumer's situation from inside a build where
+	 * jqwik is always present.
+	 */
+	@Test
+	void testCallgraphBuilderInitialisesWithoutOptionalJqwikOnTheClasspath() throws Exception {
+		Set<Path> jqwikOrigins = optionalFrameworkCandidateCodeSources();
+		Assumptions.assumeFalse(jqwikOrigins.isEmpty(), "jqwik must be present to build a classpath without it");
+		List<URL> withoutJqwik = new ArrayList<>();
+		for (Path entry : currentTestClassPath()) {
+			if (!jqwikOrigins.contains(entry)) {
+				withoutJqwik.add(entry.toUri().toURL());
+			}
+		}
+		Assertions.assertNotEquals(withoutJqwik.size(), currentTestClassPath().size(),
+				"the isolated classpath must actually be missing the jqwik entries");
+
+		try (URLClassLoader isolated = new URLClassLoader(withoutJqwik.toArray(URL[]::new),
+				ClassLoader.getPlatformClassLoader())) {
+			Class<?> isolatedBuilder = Class.forName(CustomCallgraphBuilder.class.getName(), true, isolated);
+
+			Assertions.assertNotSame(CustomCallgraphBuilder.class, isolatedBuilder);
+			Field required = isolatedBuilder.getDeclaredField("REQUIRED_TRUSTED_FRAMEWORK_CODE_SOURCES");
+			required.setAccessible(true);
+			Assertions.assertFalse(((Set<?>) required.get(null)).isEmpty(),
+					"required framework origins must still resolve without jqwik");
+			Field optional = isolatedBuilder.getDeclaredField("OPTIONAL_FRAMEWORK_CANDIDATE_CODE_SOURCES");
+			optional.setAccessible(true);
+			Assertions.assertTrue(((Set<?>) optional.get(null)).isEmpty(),
+					"absent optional frameworks must contribute no trusted origin");
+		}
+	}
+
+	/**
+	 * The API and the engine may ship in separate JARs, so a partially present
+	 * framework must contribute nothing rather than a lone origin. Admitting one
+	 * half would let a forged counterpart pass unnoticed.
+	 */
+	@Test
+	void testOptionalFrameworkOriginsAreDiscardedWhenAnyClassIsAbsent() throws Exception {
+		Method method = CustomCallgraphBuilder.class.getDeclaredMethod("optionalFrameworkCodeSource", String.class,
+				ClassLoader.class);
+		method.setAccessible(true);
+		ClassLoader loader = CustomCallgraphBuilder.class.getClassLoader();
+
+		Optional<?> present = (Optional<?>) method.invoke(null, "net.jqwik.api.Property", loader);
+		Optional<?> absent = (Optional<?>) method.invoke(null, "net.jqwik.api.NoSuchPropertyClass", loader);
+
+		Assertions.assertTrue(present.isPresent());
+		Assertions.assertTrue(absent.isEmpty(), "an unresolvable optional framework class must not throw");
+	}
+
+	/**
+	 * A student who drops a forged {@code net.jqwik.api.Property} into the
+	 * project's own class output must not thereby have that output directory
+	 * removed from WALA's scope.
+	 */
+	@Test
+	void testOptionalFrameworkOriginInsideSupervisedProjectIsRejected() throws Exception {
+		Path projectRoot = Files.createDirectory(temporaryDirectory.resolve("project"));
+		Files.writeString(projectRoot.resolve("pom.xml"), "<project/>");
+		Path outputRoot = Files.createDirectories(projectRoot.resolve("target/classes"));
+		Path forgedOrigin = outputRoot.toRealPath();
+
+		Set<Path> effective = CustomCallgraphBuilder.effectiveTrustedFrameworkCodeSources(outputRoot.toString(),
+				Set.of(forgedOrigin));
+
+		Assertions.assertFalse(effective.contains(forgedOrigin),
+				"an optional origin inside the supervised project must never be trusted");
+		Assertions.assertEquals(requiredTrustedFrameworkCodeSources(), effective);
+	}
+
+	/**
+	 * An optional origin outside the supervised project is admitted, so a genuine
+	 * jqwik dependency keeps being filtered out of WALA's scope exactly as before.
+	 */
+	@Test
+	void testOptionalFrameworkOriginOutsideSupervisedProjectIsAdmitted() throws Exception {
+		Path outsideOrigin = Files.createDirectory(temporaryDirectory.resolve("elsewhere")).toRealPath();
+		Path projectRoot = Files.createDirectory(temporaryDirectory.resolve("consumer"));
+		Files.writeString(projectRoot.resolve("pom.xml"), "<project/>");
+		Path outputRoot = Files.createDirectories(projectRoot.resolve("target/classes"));
+
+		Set<Path> effective = CustomCallgraphBuilder.effectiveTrustedFrameworkCodeSources(outputRoot.toString(),
+				Set.of(outsideOrigin));
+
+		Assertions.assertTrue(effective.contains(outsideOrigin));
+		Assertions.assertTrue(effective.containsAll(requiredTrustedFrameworkCodeSources()));
+	}
+
+	/**
+	 * {@code dependencyFingerprint} has no analysis classpath and therefore no
+	 * supervised-project boundary to validate optional origins against, so it must
+	 * exclude only required framework origins. Excluding an unvalidated optional
+	 * origin could drop student bytecode from the cache key.
+	 */
+	@Test
+	void testRequiredTrustedOriginsExcludeOptionalFrameworkOrigins() throws Exception {
+		Set<Path> required = requiredTrustedFrameworkCodeSources();
+		Set<Path> optional = optionalFrameworkCandidateCodeSources();
+		Assumptions.assumeFalse(optional.isEmpty(), "jqwik must be present for this distinction to be observable");
+
+		Assertions.assertTrue(optional.stream().noneMatch(required::contains),
+				"optional origins must not leak into the required set used for cache fingerprinting");
+	}
+
+	private static List<Path> currentTestClassPath() throws Exception {
+		List<Path> entries = new ArrayList<>();
+		for (String entry : System.getProperty("java.class.path").split(Pattern.quote(File.pathSeparator))) {
+			if (entry.isBlank()) {
+				continue;
+			}
+			Path path = Path.of(entry);
+			if (Files.exists(path)) {
+				entries.add(path.toRealPath());
+			}
+		}
+		// Surefire may hand over a manifest-only booter JAR; expand its Class-Path so
+		// the isolated loader sees the real dependencies.
+		if (entries.size() == 1 && entries.get(0).toString().endsWith(".jar")) {
+			try (JarFile booter = new JarFile(entries.get(0).toFile())) {
+				String classPathAttribute = booter.getManifest().getMainAttributes().getValue("Class-Path");
+				if (classPathAttribute != null) {
+					entries.clear();
+					for (String url : classPathAttribute.split(" ")) {
+						if (url.isBlank()) {
+							continue;
+						}
+						Path path = Path.of(URI.create(url));
+						if (Files.exists(path)) {
+							entries.add(path.toRealPath());
+						}
+					}
+				}
+			}
+		}
+		return entries;
 	}
 
 	@Test

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilderTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilderTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 
 import javax.activation.FileDataSource;
@@ -340,13 +341,18 @@ public class CustomCallgraphBuilderTest {
 	void testCallgraphBuilderInitialisesWithoutOptionalJqwikOnTheClasspath() throws Exception {
 		Set<Path> jqwikOrigins = optionalFrameworkCandidateCodeSources();
 		Assumptions.assumeFalse(jqwikOrigins.isEmpty(), "jqwik must be present to build a classpath without it");
+		List<Path> testClassPath = currentTestClassPath();
+		// Failing to derive the runner's classpath is a missing fixture, not a defect
+		// in the code under test, so skip rather than report a false failure.
+		Assumptions.assumeTrue(testClassPath.stream().anyMatch(jqwikOrigins::contains),
+				"the derived test classpath must still contain the jqwik origins to remove them");
 		List<URL> withoutJqwik = new ArrayList<>();
-		for (Path entry : currentTestClassPath()) {
+		for (Path entry : testClassPath) {
 			if (!jqwikOrigins.contains(entry)) {
 				withoutJqwik.add(entry.toUri().toURL());
 			}
 		}
-		Assertions.assertNotEquals(withoutJqwik.size(), currentTestClassPath().size(),
+		Assertions.assertNotEquals(withoutJqwik.size(), testClassPath.size(),
 				"the isolated classpath must actually be missing the jqwik entries");
 
 		try (URLClassLoader isolated = new URLClassLoader(withoutJqwik.toArray(URL[]::new),
@@ -372,6 +378,10 @@ public class CustomCallgraphBuilderTest {
 	 */
 	@Test
 	void testOptionalFrameworkOriginsAreDiscardedWhenAnyClassIsAbsent() throws Exception {
+		// jqwik is provided-scope, so it is genuinely absent in the very consumers this
+		// change is for. Treat that as a missing fixture, not as a defect.
+		Assumptions.assumeFalse(optionalFrameworkCandidateCodeSources().isEmpty(),
+				"jqwik must be present for the all-or-nothing distinction to be observable");
 		Method method = CustomCallgraphBuilder.class.getDeclaredMethod("optionalFrameworkCodeSource", String.class,
 				ClassLoader.class);
 		method.setAccessible(true);
@@ -465,14 +475,24 @@ public class CustomCallgraphBuilderTest {
 		// the isolated loader sees the real dependencies.
 		if (entries.size() == 1 && entries.get(0).toString().endsWith(".jar")) {
 			try (JarFile booter = new JarFile(entries.get(0).toFile())) {
-				String classPathAttribute = booter.getManifest().getMainAttributes().getValue("Class-Path");
+				// A single .jar entry does not prove this is Surefire's booter JAR, and a
+				// JAR need not carry a manifest at all, so do not dereference blindly.
+				Manifest manifest = booter.getManifest();
+				String classPathAttribute = manifest == null ? null
+						: manifest.getMainAttributes().getValue("Class-Path");
 				if (classPathAttribute != null) {
 					entries.clear();
 					for (String url : classPathAttribute.split(" ")) {
 						if (url.isBlank()) {
 							continue;
 						}
-						Path path = Path.of(URI.create(url));
+						// Manifest Class-Path entries are relative URLs by specification;
+						// only Surefire's absolute file: URLs are usable here.
+						URI entryUri = URI.create(url);
+						if (!entryUri.isAbsolute() || !"file".equals(entryUri.getScheme())) {
+							continue;
+						}
+						Path path = Path.of(entryUri);
 						if (Files.exists(path)) {
 							entries.add(path.toRealPath());
 						}

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilderTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/wala/CustomCallgraphBuilderTest.java
@@ -382,6 +382,18 @@ public class CustomCallgraphBuilderTest {
 
 		Assertions.assertTrue(present.isPresent());
 		Assertions.assertTrue(absent.isEmpty(), "an unresolvable optional framework class must not throw");
+
+		// The composition itself must be all-or-nothing: one absent name has to
+		// discard the present one too, otherwise a partially present framework
+		// contributes a lone origin that a forged counterpart could sit beside.
+		Set<Path> bothPresent = CustomCallgraphBuilder.optionalFrameworkCandidateCodeSources(
+				List.of("net.jqwik.api.Property", "net.jqwik.engine.JqwikTestEngine"));
+		Set<Path> oneAbsent = CustomCallgraphBuilder.optionalFrameworkCandidateCodeSources(
+				List.of("net.jqwik.api.Property", "net.jqwik.api.NoSuchPropertyClass"));
+
+		Assertions.assertFalse(bothPresent.isEmpty(), "both jqwik artefacts are present in this build");
+		Assertions.assertTrue(oneAbsent.isEmpty(),
+				"a single absent name must discard every optional origin, not just its own");
 	}
 
 	/**

--- a/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/AspectJDeclarationNormalisationTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/AspectJDeclarationNormalisationTest.java
@@ -1,0 +1,71 @@
+package de.tum.cit.ase.ares.integration.aop.forbidden;
+
+import org.junit.jupiter.api.Assertions;
+
+import de.tum.cit.ase.ares.api.Policy;
+import de.tum.cit.ase.ares.api.jupiter.PublicTest;
+import de.tum.cit.ase.ares.integration.aop.forbidden.subject.networkSystem.connect.unixdomainsocket.UnixDomainSocketConnectMain;
+
+/**
+ * End-to-end tests that the two AOP backends name the same blocked call in a
+ * mutually recognisable way.
+ * <p>
+ * The backends observe a call from different positions. AspectJ weaves the
+ * {@code call(...)} join point in the supervised code, so its signature names
+ * the static receiver type ({@code java.nio.channels.SocketChannel}).
+ * Instrumentation advises the implementation whose bytecode runs and reports
+ * that class through {@code @Advice.Origin("#t")}
+ * ({@code sun.nio.ch.SocketChannelImpl}). An expectation authored against one
+ * backend could therefore never match the other, even though both raise the
+ * same denial for the same target.
+ * <p>
+ * AspectJ now appends the resolved runtime declaration, so its message contains
+ * the Instrumentation form as a substring while keeping the call-site identity
+ * that only AspectJ observes. These assertions are deliberately made against a
+ * real woven call rather than a synthetic join point, because the whole
+ * mechanism depends on {@code thisJoinPoint.getTarget()} being populated for
+ * {@code call} join points.
+ */
+class AspectJDeclarationNormalisationTest extends SystemAccessTest {
+
+	private static final String UNIX_DOMAIN_SOCKET_CONNECT_WITHIN_PATH = "test-classes/de/tum/cit/ase/ares/integration/aop/forbidden/subject/networkSystem/connect/unixdomainsocket";
+
+	private static final String STATIC_DECLARATION = "java.nio.channels.SocketChannel.connect";
+	private static final String RESOLVED_DECLARATION = "sun.nio.ch.SocketChannelImpl.connect";
+
+	/**
+	 * The AspectJ message must keep its own call-site identity and additionally
+	 * carry the implementation identity that Instrumentation reports.
+	 */
+	@PublicTest
+	@Policy(value = ARCHUNIT_ASPECTJ_POLICY_ONE_NETWORK_CONNECTION_ALLOWED, withinPath = UNIX_DOMAIN_SOCKET_CONNECT_WITHIN_PATH)
+	void test_aspectJReportsBothTheCallSiteAndTheResolvedDeclaration() {
+		SecurityException exception = assertAresSecurityExceptionNetwork(
+				UnixDomainSocketConnectMain::connectViaUnixDomainSocket, UnixDomainSocketConnectMain.class);
+		String message = exception.getMessage();
+
+		Assertions.assertTrue(message.contains(STATIC_DECLARATION),
+				"the call-site declaration only AspectJ observes must be kept: " + message);
+		Assertions.assertTrue(message.contains("[resolved runtime declaration: " + RESOLVED_DECLARATION),
+				"the resolved implementation must be appended: " + message);
+	}
+
+	/**
+	 * Pins the property the reporting gap was actually about: an expectation
+	 * recorded from the Instrumentation backend must be findable in the AspectJ
+	 * message. Consumers match the API name as a substring, so this is what makes a
+	 * single expectation file usable for both backends.
+	 */
+	@PublicTest
+	@Policy(value = ARCHUNIT_INSTRUMENTATION_POLICY_ONE_NETWORK_CONNECTION_ALLOWED, withinPath = UNIX_DOMAIN_SOCKET_CONNECT_WITHIN_PATH)
+	void test_instrumentationReportsTheResolvedDeclaration() {
+		SecurityException exception = assertAresSecurityExceptionNetwork(
+				UnixDomainSocketConnectMain::connectViaUnixDomainSocket, UnixDomainSocketConnectMain.class);
+		String message = exception.getMessage();
+
+		Assertions.assertTrue(message.contains(RESOLVED_DECLARATION),
+				"the Instrumentation backend reports the implementation class: " + message);
+		Assertions.assertFalse(message.contains("[resolved runtime declaration:"),
+				"Instrumentation already names the implementation and must not be annotated: " + message);
+	}
+}


### PR DESCRIPTION
## Summary

Makes the WALA architecture mode usable in any consumer that does not itself depend on jqwik, where it previously failed to initialise at all, and lets AspectJ denial messages name the implementation that instrumentation names, so one expectation file can serve both AOP modes.

## Linked issues

None. Both defects were found by the CI matrix of `ls1intum/SCOREReproducibilityPackage`, which runs Ares across all four mode combinations; no issue was filed before this pull request.

## 1. Problem

Two unrelated defects, both present in released 2.1.0 and 2.1.1, both surfaced by the same run. Of the twelve matrix jobs there (four modes x three JDKs), only ArchUnit + instrumentation was green.

**a. WALA is dead on arrival in consumers without jqwik (false positive, enforcement layer).**

Observed on JDK 17, 21 and 25, Gradle, both AOP modes, whenever the architecture mode is WALA:

```
java.lang.NoClassDefFoundError: net/jqwik/api/Property
  at ...wala.CustomCallgraphBuilder.<clinit>(CustomCallgraphBuilder.java:86)
  at ...wala.JavaWalaTestCase.classpathFingerprint(JavaWalaTestCase.java:342)
Caused by: java.lang.ClassNotFoundException: net.jqwik.api.Property
```

Expected instead: the analysis runs and the policy is enforced.

Root cause: `CustomCallgraphBuilder` built its trusted-framework origin set from 21 class literals in a static initialiser. jqwik is the only `provided`-scope entry among them, so it is absent from any consumer that does not depend on it directly. The literals are resolved while the varargs array is built, which is *before* `trustedFrameworkCodeSources` is entered, so the defensive catch inside that method is unreachable for this failure: `NoClassDefFoundError` is an `Error`, not a `RuntimeException`, and it is thrown at the call site. The class is then permanently erroneous, so one absent JAR produced 221 identical failures in a single job.

This is a **false positive**: correct submissions cannot be graded at all under WALA, because Ares aborts before analysing anything. It sits in the enforcement (architecture) layer.

**b. The two AOP modes name the same blocked call differently (usability defect, enforcement layer).**

Observed under ArchUnit + AspectJ on all three JDKs. The block always worked and the target was always correct; only the reported class differed:

| Instrumentation reports | AspectJ reports |
| --- | --- |
| `javax.net.DefaultSocketFactory.createSocket` | `javax.net.SocketFactory.createSocket` |
| `sun.security.ssl.SSLSocketFactoryImpl.createSocket` | `javax.net.ssl.SSLSocketFactory.createSocket` |
| `sun.nio.ch.AsynchronousSocketChannelImpl.connect` | `java.nio.channels.AsynchronousSocketChannel.connect` |
| `sun.nio.ch.DatagramChannelImpl.connect` | `java.nio.channels.DatagramChannel.connect` |
| `Executors$DelegatedScheduledExecutorService.schedule` | `java.util.concurrent.ScheduledExecutorService.schedule` |
| `java.util.stream.AbstractPipeline.parallel` | `java.util.stream.Stream.parallel` |

Root cause: AspectJ weaves `call(...)` join points in the supervised code, so `thisJoinPoint.getSignature()` names the **static receiver type at the call site**. Instrumentation advises the implementation whose bytecode runs and reports it through `@Advice.Origin("#t")`. AspectJ never observes `sun.nio.ch.DatagramChannelImpl` at all. Both are correct; they name the same operation at different levels of the hierarchy.

This is **neither a false positive nor a false negative**: enforcement is identical in both modes. It is a diagnostics gap, but a consequential one, because an expectation authored against one mode can never match the other, which makes a cross-mode comparison impossible to express.

## 2. Improvement from the user's perspective

- Instructors can actually ship an exercise on the WALA architecture mode. Previously any exercise repository without a direct jqwik dependency failed before the first rule ran, and the message named a library the instructor never referenced.
- A denial message now carries both identities: the API the student's code called, and the implementation that actually ran. Previously an instructor reading an AspectJ failure saw only the interface, which is often not the class documented in a stack trace elsewhere.
- One expectation file can serve both AOP modes, so an exercise no longer needs mode-specific expected output.

## 3. Improvement from the maintainer's perspective

- Optionality is now explicit and contained. Required compile-scope frameworks keep their class literals and their compile-time checking; only genuinely optional ones are resolved by name, so the next `provided`-scope dependency added to that list cannot silently reintroduce this defect.
- Trust is resolved per analysis rather than in a global static, and `dependencyFingerprint` is now explicitly excluded from optional trust, which removes a path where an unvalidated origin could have dropped student bytecode from the verdict cache key.
- `buildCallGraph` now rejects a classpath the builder was not constructed for on the *first* call, not only once a graph has been cached. Every current caller passes the same value to both, so this was unreachable, but the scope, hierarchy and trust boundary are all fixed at construction and the guard did not say so.
- Two mode-comparison behaviours are now pinned by tests instead of being implicit.

## 4. Testing manual

Scenario: *I have an Ares 2 exercise.* No Artemis instance is involved.

**Prerequisites**

1. JDK 17 (Temurin) and Maven 3.8+.
2. This branch built and installed: `mvn -o install -DskipTests`.
3. An exercise whose policy uses `JAVA_USING_MAVEN_WALA_AND_INSTRUMENTATION` (for part a) and one using `JAVA_USING_MAVEN_ARCHUNIT_AND_ASPECTJ` (for part b). The forbidden-access subjects in `src/test/java/de/tum/cit/ase/ares/integration/aop/forbidden/subject/` serve as ready-made examples.
4. For network tests, the echo server described in `AGENTS.md`.

**Steps**

1. *Part a, the WALA regression.* In an exercise consuming Ares from step 2, ensure jqwik is **not** on the test classpath (it is `provided`-scope, so this is the default unless declared). Run the exercise's tests under a WALA policy.
2. Reproduce the old behaviour by checking out `main` in place of this branch, installing it, and repeating step 1.
3. *Part a, isolated.* `mvn -o test -Dtest=CustomCallgraphBuilderTest` in this repository. `testCallgraphBuilderInitialisesWithoutOptionalJqwikOnTheClasspath` builds a `URLClassLoader` over the real test classpath with the jqwik entries removed and loads `CustomCallgraphBuilder` through it.
4. *Part b.* `mvn -o test -Pfunctional-tests -Dtest=AspectJDeclarationNormalisationTest` in this repository. It drives one forbidden `SocketChannel.connect` through a real woven call under both an AspectJ and an instrumentation policy.

**Expected result**

- Step 1: the analysis runs and the policy is enforced; no `NoClassDefFoundError`.
- Step 2: the run fails immediately with `NoClassDefFoundError: net/jqwik/api/Property` from `CustomCallgraphBuilder.<clinit>`, repeated for every test.
- Step 3: 29 tests pass.
- Step 4: 2 tests pass. The messages the assertions pin are:

```
AspectJ:         via java.nio.channels.SocketChannel.connect(java.net.SocketAddress) [resolved runtime declaration: sun.nio.ch.SocketChannelImpl.connect(java.net.SocketAddress)]
Instrumentation: via sun.nio.ch.SocketChannelImpl.connect(java.net.SocketAddress)
```

**Negative case (what must still be rejected)**

This change must not make Ares more permissive anywhere, and enforcement is deliberately untouched.

1. Every forbidden-access integration test must still fail with a `SecurityException`: `mvn -o test -Pfunctional-tests -Dtest='de.tum.cit.ase.ares.integration.aop.forbidden.*Test'`. A permissive regression shows up as a test that no longer throws.
2. Enforcement keys must still be the **static** signature, not the resolved one. The ignore maps are keyed on `java.lang.Runtime.exec`, `java.lang.ProcessBuilder.start` and `java.io.File.delete`, and `java.io.File` is not final, so had the resolved name been substituted a student subclass overriding `delete()` could have shifted the key, missed the map and changed which fields are inspected. Confirm with `grep -n "extractMethodNameWithoutModifiers(fullMethodSignature)"` across the four advice files: all seven occurrences must use the raw `fullMethodSignature`, and all fourteen `describeDeniedCall` call sites must sit inside a `throw new SecurityException(localize(...))`.
3. A forged optional-framework origin must never be trusted: `testOptionalFrameworkOriginInsideSupervisedProjectIsRejected` places a candidate inside the supervised project's own output root and asserts it is not admitted.
4. A partially present optional framework must contribute nothing: `testOptionalFrameworkOriginsAreDiscardedWhenAnyClassIsAbsent`.
5. Application-loaded receivers must never be reflected over inside the advice guard: `describeDeniedCall_fallsBackForApplicationLoadedTarget`, confirmed end to end by a real run where a `TestHttpClient` receiver produces no appended clause.

**Modes exercised**

- [x] ArchUnit + AspectJ
- [x] ArchUnit + instrumentation
- [x] WALA + AspectJ
- [x] WALA + instrumentation

All four were exercised: the forbidden-access suite alone carries 172, 172, 171 and 171 policies for the four combinations respectively, and the whole suite ran green (1105 tests, 0 failures) on JDK 17. The new `AspectJDeclarationNormalisationTest` itself covers only ArchUnit + AspectJ and ArchUnit + instrumentation, because the behaviour it pins is a property of the AOP mode and is independent of the architecture mode.

## 5. Test case coverage regarding this PR

Read from `site/jacoco/jacoco.csv` in the `coverage-report` artefact of the Coverage Report job on run [30809788300](https://github.com/ls1intum/Ares2/actions/runs/30809788300) (commit `eb23cfd0`), which merges the JaCoCo execution data of every test job. All five counters are reported per #170; the table previously carried line coverage only.

| Class | Instruction coverage | Branch coverage | Line coverage | Complexity coverage | Method coverage | Confirmation (meaningful assertions) |
| --- | ---: | ---: | ---: | ---: | ---: | :---: |
| `CustomCallgraphBuilder` | 86.2% (1550/1798) | 74.7% (133/178) | 81.0% (272/336) | 68.5% (98/143) | 94.4% (51/54) | yes |
| `JavaAspectJThreadSystemAdviceDefinitions` | 70.6% (878/1244) | 67.5% (164/243) | 73.1% (201/275) | 55.3% (84/152) | 96.7% (29/30) | yes |
| `JavaAspectJFileSystemAdviceDefinitions` | 72.4% (1644/2272) | 56.4% (261/463) | 71.8% (367/511) | 44.9% (123/274) | 92.3% (36/39) | yes |
| `JavaAspectJCommandSystemAdviceDefinitions` | 66.2% (1038/1569) | 53.1% (187/352) | 68.2% (225/330) | 37.5% (78/208) | 93.8% (30/32) | yes |
| `JavaAspectJAbstractAdviceDefinitions` | 63.0% (700/1111) | 66.2% (104/157) | 65.1% (181/278) | 61.8% (68/110) | 90.0% (27/30) | yes |
| `JavaAspectJNetworkSystemAdviceDefinitions` | 53.5% (772/1442) | 50.2% (146/291) | 56.1% (180/321) | 34.9% (61/175) | 70.4% (19/27) | yes |

The four `*SystemAdviceDefinitions` classes change only at their denial throw sites. Those lines are covered by the forbidden-access suite, which asserts on the thrown `SecurityException` and its message rather than merely executing the path, and the two new tests assert the message text directly.

`CustomCallgraphBuilder` carries the larger share of new logic; its optional-origin resolution, all-or-nothing composition, supervised-root rejection and the isolated-classloader initialisation path each have a dedicated test.

The wider table makes a pre-existing gap visible, and it is worth stating plainly rather than leaving it to be read out of the numbers. Branch and complexity coverage sit well below line coverage across the four advice classes, lowest at `JavaAspectJNetworkSystemAdviceDefinitions` with 50.2% of branches and 34.9% of complexity. This is not introduced here: the advice files are generated-shaped pointcut and guard code whose untaken branches are the per-API dispatch arms that no forbidden-access subject exercises, and this pull request changes only the throw sites, which are covered. It does mean the denial paths of this repository are less exhaustively pinned than the line figures alone suggested, and closing that belongs in its own pull request against the forbidden-access subject set rather than here.

## Breaking changes and migration

No change to the public API under `de.tum.cit.ase.ares.api`, the policy file format, the generated security test code, or the minimum JDK, Maven or Gradle version.

One behaviour change is visible to consumers: **AspectJ denial messages may now carry a trailing `[resolved runtime declaration: ...]` clause.** The change is additive and the guaranteed static signature stays first, so any assertion that matches a substring of the message continues to match. An exercise that compares the *entire* message for exact equality against a recorded string will need that string updated. No migration is needed otherwise.

The version is set to 2.1.2 and is **not** released. Consumers pinned to 2.1.0 or 2.1.1 need that release to pick either fix up; until then, adding jqwik as a test dependency is a workaround for the WALA defect only.

## Known limitations, deliberately not addressed here

- `RESERVED_PACKAGE_PREFIXES` does not cover several namespaces that Ares trusts or excludes **by name** (`net/jqwik`, `org/junit`, `org/mockito`, `org/hamcrest`, `org/assertj`, `org/apiguardian`, `net/bytebuddy`), so supervised code may declare classes in namespaces Ares treats as infrastructure. Pre-existing, and neither introduced nor worsened here. Fixing it needs a boundary version bump with the Java list, both build fragments, tests and migration notes together, and it may break existing exercises, so it belongs in its own pull request. It should ship in the same release if possible.
- No path rule authenticates an unsigned artefact when the classpath is attacker-controlled. The supervised-origin check recognises the four conventional Maven and Gradle output layouts; a custom output directory or a project-owned JAR yields no supervised root. This narrows the partial-spoof surface and does not widen the existing one, but it is not an authentication mechanism.
- The resolved declaration is best-effort normalisation for ordinary public virtual calls on platform classes, not a reconstruction of dispatch. `super.method()`, bridge methods, private or package-private hiding, null receivers and constructors all fall back to today's behaviour.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
- [x] Tests were added or updated for the behaviour changed here.
<!-- Documentation was not updated: neither fix changes a documented setup step, policy option or public API. The behaviour change to AspectJ message text is recorded under "Breaking changes and migration" above. -->
- [x] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test


