### PR TITLE
Ask for every coverage counter in the pull request template, not lines alone

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -143,9 +143,11 @@
   Report every counter JaCoCo produces per class, not lines alone. Read them from
   `site/jacoco/jacoco.csv` inside the artefact, where each counter is a MISSED/COVERED
   column pair: INSTRUCTION, BRANCH, LINE, COMPLEXITY and METHOD. Give each as a
-  percentage with the raw counts behind it, for example `81.0% (272/336)`, so a reviewer
-  can recompute the row. Where a counter has no total at all, for example a class
-  without branches, write `n/a (0/0)` rather than 100%.
+  percentage with the raw counts behind it, and write those counts as COVERED out of
+  MISSED plus COVERED rather than as the raw pair, for example `81.0% (272/336)` for a
+  class whose LINE_COVERED is 272 and whose LINE_MISSED is 64, so a reviewer can
+  recompute the row. Where a counter has no total at all, for example a class without
+  branches, write `n/a (0/0)` rather than 100%.
 
   Lines alone hide what matters here. Ares is itself the security boundary, so an
   untaken branch is a decision that was never enforced under test, and the advice and

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -137,22 +137,39 @@
   Coverage is produced by the "Coverage Report" job of the Maven workflow. It merges the
   JaCoCo execution data of every test job, publishes an aggregated table in the job
   summary and uploads a "coverage-report" artefact containing the HTML and CSV report.
-  Read the per-class line coverage out of that report and list every class this pull
-  request adds or changes non-trivially. Leave out rows for purely cosmetic changes.
+  List every class this pull request adds or changes non-trivially, and leave out rows
+  for purely cosmetic changes.
+
+  Report every counter JaCoCo produces per class, not lines alone. Read them from
+  `site/jacoco/jacoco.csv` inside the artefact, where each counter is a MISSED/COVERED
+  column pair: INSTRUCTION, BRANCH, LINE, COMPLEXITY and METHOD. Give each as a
+  percentage with the raw counts behind it, for example `81.0% (272/336)`, so a reviewer
+  can recompute the row. Where a counter has no total at all, for example a class
+  without branches, write `n/a (0/0)` rather than 100%.
+
+  Lines alone hide what matters here. Ares is itself the security boundary, so an
+  untaken branch is a decision that was never enforced under test, and the advice and
+  rule classes are mostly branches. A class can read as well covered by line and still
+  have half of its denial paths never taken; branch coverage is what says so. Method
+  coverage shows how many methods nothing reached at all, and complexity summarises how
+  much of the remaining execution-path space is still untested.
 
   The last column confirms that the covered lines are backed by meaningful assertions,
   not merely executed.
 
   Note that the aggregated figures are repository-wide and that the JaCoCo thresholds
-  are currently advisory, so they do not fail the build.
+  are currently advisory, so they do not fail the build. Only `src/main/java` is
+  reported on, so test classes never appear in the report and do not belong in the
+  table, even though the agent does instrument the ones under `de.tum.cit.ase.ares.api`.
 
-  If this pull request changes no Java code (documentation, CI or build configuration
-  only), replace the table with "No Java code changed".
+  If this pull request changes no production Java code (documentation, CI, build
+  configuration or tests only), replace the table with "No production Java code
+  changed".
 -->
 
-| Class | Line coverage | Confirmation (meaningful assertions) |
-| --- | ---: | :---: |
-|  |  |  |
+| Class | Instruction coverage | Branch coverage | Line coverage | Complexity coverage | Method coverage | Confirmation (meaningful assertions) |
+| --- | ---: | ---: | ---: | ---: | ---: | :---: |
+|  |  |  |  |  |  |  |
 
 ## Breaking changes and migration
 


### PR DESCRIPTION
## Summary

Section 5 of the pull request template asked for per-class line coverage only. It now asks for every counter JaCoCo already produces, so that a reviewer sees the branches an enforcement class never took rather than only the lines it executed.

## Linked issues

None. The gap surfaced while reviewing section 5 of #167, where the six changed classes all report a materially lower branch than line coverage, and the template gave no place to say so.

## 1. Problem

This is not a defect in Ares itself. It is a review-process gap, and it sits above all four layers rather than in one of them, so neither the false-positive nor the false-negative framing applies.

The Coverage Report job merges the JaCoCo execution data of every test job and uploads a `coverage-report` artefact whose `site/jacoco/jacoco.csv` carries five MISSED/COVERED counter pairs per class: `INSTRUCTION`, `BRANCH`, `LINE`, `COMPLEXITY` and `METHOD`. The template asked contributors to transcribe exactly one of them, and it asked for the weakest one.

Line coverage is the least informative counter for this repository in particular. Ares is itself the security boundary, and the classes that carry the boundary are the advice and rule classes, which are almost entirely branches. A denial path is a branch, not a line. A class whose lines are executed by a suite that never takes its deny branch reads as well covered and is not.

The effect is measurable on the current open pull requests. Reading the six classes changed by #167 out of the artefact of run [30809788300](https://github.com/ls1intum/Ares2/actions/runs/30809788300), every one has a branch coverage below its line coverage, three of them by more than ten points:

| Class | Line | Branch |
| --- | ---: | ---: |
| `CustomCallgraphBuilder` | 81.0% | 74.7% |
| `JavaAspectJThreadSystemAdviceDefinitions` | 73.1% | 67.5% |
| `JavaAspectJFileSystemAdviceDefinitions` | 71.8% | 56.4% |
| `JavaAspectJCommandSystemAdviceDefinitions` | 68.2% | 53.1% |
| `JavaAspectJAbstractAdviceDefinitions` | 65.1% | 66.2% |
| `JavaAspectJNetworkSystemAdviceDefinitions` | 56.1% | 50.2% |

`JavaAspectJNetworkSystemAdviceDefinitions` has half of its branches untaken, and it is the class holding the network denial paths. That pull request conformed to the template exactly, its figures are accurate, and none of this was visible in it, because the template had no column for it.

Two smaller inaccuracies in the same section are corrected while it is open:

- It said only `src/main/java` is *instrumented*. The agent's `<includes>` is `de.tum.cit.ase.ares.api.*`, which matches 98 test sources; they are instrumented. They are absent from the report because the report analyses the production output directory, exactly as the comment at `pom.xml:1119` already says. The word was wrong, not the conclusion.
- A pull request changing only tests matched neither the instruction to list every non-trivially changed class nor the "No Java code changed" fallback, so it had no correct answer.

## 2. Improvement from the user's perspective

No Improvement. Nothing an instructor authors or a student runs changes.

## 3. Improvement from the maintainer's perspective

- A reviewer sees untaken denial branches at review time instead of inferring them from a line figure that cannot show them.
- The figures stay checkable. Each cell carries the raw counts behind the percentage, so a reviewer can recompute a row against the CSV rather than trusting it.
- The CSV is named as the source. The job-summary script prints instruction, branch, line and method coverage but omits complexity, so a contributor working from the summary alone could not have filled the table.
- Test-only pull requests now have a correct answer for the section rather than three wrong ones.

## 4. Testing manual

**Prerequisites**

1. Write access to a fork or branch of this repository. No build tool, JDK or exercise is involved.

**Steps**

Not reproducible from an exercise. This changes a GitHub pull request template and no Java, policy or build behaviour, so there is nothing to run. A reviewer verifies it as follows.

1. Open <https://github.com/ls1intum/Ares2/compare/main...chore/pull-request-template-full-coverage-table> and read the diff of `.github/PULL_REQUEST_TEMPLATE.md`.
2. Confirm the counter names against JaCoCo's own output: download the `coverage-report` artefact of run [30809788300](https://github.com/ls1intum/Ares2/actions/runs/30809788300) and read the header line of `site/jacoco/jacoco.csv`.
3. Confirm the artefact-relative path in step 2 is the one the template states.
4. Push any branch off this one and open a draft pull request against it, then read the prefilled body.

**Expected result**

- Step 1: section 5 carries seven columns, five of them coverage counters, and the alignment row has seven entries so the table renders rather than falling back to literal pipes.
- Step 2: the header contains `INSTRUCTION_MISSED,INSTRUCTION_COVERED,BRANCH_MISSED,BRANCH_COVERED,LINE_MISSED,LINE_COVERED,COMPLEXITY_MISSED,COMPLEXITY_COVERED,METHOD_MISSED,METHOD_COVERED`, matching the five names the template lists and confirming there is no sixth per-class counter being dropped.
- Step 3: the file is at `site/jacoco/jacoco.csv` relative to the artefact root.
- Step 4: the new section 5 appears prefilled, and the rest of the template is unchanged.

**Negative case (what must still be rejected)**

This pull request cannot make Ares more permissive: it touches no Java, no policy schema, no generated test code and no workflow. The corresponding negative case is that the template must not become easier to satisfy without evidence.

1. The table must not accept a bare figure with no provenance. Confirm the template still requires the raw counts behind each percentage, so an unsupported cell is visibly unsupported.
2. The "no coverage needed" escape must stay narrow. Confirm the fallback is reachable only when no production Java changed, and that a test-only pull request therefore cannot use it to skip the section while claiming the change is covered.
3. Confirm the last column is unchanged, so the existing requirement that covered lines be backed by meaningful assertions is neither dropped nor weakened by the wider table.

**Modes exercised**

No mode-specific behaviour changed.

## 5. Test case coverage regarding this PR

No production Java code changed.

## Breaking changes and migration

None for consumers: no public API, policy format, generated test code or minimum tool version is affected.

One process note. GitHub applies a template only when a pull request is created, so the nine currently open pull requests keep their three-column section 5. Their existing figures stay valid; the additional counters have to be filled in by hand if they are wanted there. #167 has been updated already, as the first pull request whose section 5 follows the new shape.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
<!-- No tests were added or updated: this pull request changes a GitHub pull request template and no executable behaviour, so there is nothing a test could pin. -->
<!-- Documentation was not updated: the template is itself the contributor-facing documentation for this step, and no other document describes section 5. -->
- [x] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test
