### PR TITLE
Test the examples against the version this job builds

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -53,8 +53,64 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      # The examples pin the version a tutor downloads, which is the last release.
+      # The version built here is the development version, which runs ahead of it
+      # between a version bump and the release that catches up. Reading it from the
+      # POM is what keeps those two facts independent: without it, this job resolves
+      # a coordinate that the local repository does not hold, and main turns red for
+      # the bump rather than for anything wrong with the examples.
+      #
+      # The help plugin is pinned to a version rather than invoked by prefix, so that
+      # the reading does not depend on whichever plugin release is current on the day
+      # of the run.
+      #
+      # The value is validated before it is exported, because it is interpolated into
+      # GITHUB_ENV, into the generated Groovy below and into a path that is removed
+      # with `rm -rf`. The first character must be alphanumeric for that last reason
+      # in particular: `..` consists only of permitted characters and would name the
+      # parent of the coordinate.
+      - name: Read the version built in this job
+        run: |
+          ares_version="$(mvn -B -ntp -q -Dstyle.color=never \
+            org.apache.maven.plugins:maven-help-plugin:3.5.2:evaluate \
+            -Dexpression=project.version -DforceStdout)"
+          case "${ares_version}" in
+            '' | [!0-9A-Za-z]* | *[!0-9A-Za-z.-]*)
+              echo "::error::project.version did not read as a version"
+              exit 1
+              ;;
+          esac
+          echo "ARES_VERSION=${ares_version}" >> "${GITHUB_ENV}"
+          echo "Testing the examples against Ares ${ares_version}"
+
+      # setup-java caches the whole local repository, so a previous run of this
+      # workflow can leave a `de.tum.cit.ase:ares` of exactly this version behind.
+      # `install` overwrites what this build produces, but it does not remove what it
+      # no longer produces, so a packaging regression that dropped the agent
+      # classifier would be masked by the cached agent JAR from the run before. The
+      # coordinate is therefore emptied first, which makes "the artefact built in this
+      # job" true of the version as well as of the repository.
+      - name: Empty this coordinate in the local repository
+        run: rm -rf "${HOME}/.m2/repository/de/tum/cit/ase/ares/${ARES_VERSION}"
+
       - name: Install Ares from this commit
         run: mvn -B -ntp install -DskipTests
+
+      # Asserted rather than assumed: everything downstream reads the local
+      # repository, and an absent classifier there fails as a resolution error in an
+      # example, which reads like a broken example rather than a broken packaging.
+      - name: Confirm the local repository holds the JARs this build produced
+        run: |
+          repository="${HOME}/.m2/repository/de/tum/cit/ase/ares/${ARES_VERSION}"
+          for classifier in "" "-agent"; do
+            built="target/ares-${ARES_VERSION}${classifier}.jar"
+            installed="${repository}/ares-${ARES_VERSION}${classifier}.jar"
+            if ! cmp -s "${built}" "${installed}"; then
+              echo "::error::${installed} is absent or differs from ${built}"
+              exit 1
+            fi
+            echo "${installed} is the JAR this build produced"
+          done
 
       - name: Verify the Gradle wrapper JAR is the one we generated
         if: matrix.tool == 'gradle'
@@ -69,14 +125,37 @@ jobs:
       # exclusiveContent, rather than a plain mavenLocal(): it makes the local
       # repository the ONLY source of de.tum.cit.ase, so this job cannot quietly
       # fall through to Central and test a published artefact instead of the one
-      # built above. A plain mavenLocal() passes today only because 2.1.1 is not
-      # on Central yet; once it is, the fallback would make this whole workflow
-      # vacuous without failing. Being first in the repository order is not
-      # enough, because Gradle continues to the next repository when a module is
-      # absent from the first.
+      # built above. Every released version is on Central, so a plain mavenLocal()
+      # would fall through and make this whole workflow vacuous without failing:
+      # it would report on the published artefact rather than on this commit.
+      # Being first in the repository order is not enough, because Gradle
+      # continues to the next repository when a module is absent from the first.
+      #
+      # The version is redirected for the same reason the repository is: the
+      # exercise file names the released coordinate, and this job has to resolve
+      # the one it built. eachDependency rewrites every requested version of the
+      # module, so the plain dependency and the one carrying the agent classifier
+      # are both redirected, and the exercise file stays untouched.
       - name: Pin Ares to the artefact built in this job (CI only)
         run: |
-          printf 'allprojects {\n    repositories {\n        exclusiveContent {\n            forRepository { mavenLocal() }\n            filter { includeGroup "de.tum.cit.ase" }\n        }\n    }\n}\n' > "${RUNNER_TEMP}/local-repo.init.gradle"
+          cat > "${RUNNER_TEMP}/local-repo.init.gradle" <<EOF
+          allprojects {
+              repositories {
+                  exclusiveContent {
+                      forRepository { mavenLocal() }
+                      filter { includeGroup "de.tum.cit.ase" }
+                  }
+              }
+              configurations.all {
+                  resolutionStrategy.eachDependency { details ->
+                      if (details.requested.group == "de.tum.cit.ase" && details.requested.name == "ares") {
+                          details.useVersion "${ARES_VERSION}"
+                          details.because "CI tests the artefact built in this job"
+                      }
+                  }
+              }
+          }
+          EOF
           cat "${RUNNER_TEMP}/local-repo.init.gradle"
 
       - name: Run the exercise
@@ -85,7 +164,7 @@ jobs:
           TOOL: ${{ matrix.tool }}
         run: |
           if [ "${TOOL}" = "maven" ]; then
-            mvn -B -ntp test
+            mvn -B -ntp -Dares.version="${ARES_VERSION}" test
           else
             ./gradlew --no-daemon --init-script "${RUNNER_TEMP}/local-repo.init.gradle" test
           fi
@@ -103,7 +182,7 @@ jobs:
             > "${work}/src/main/java/de/tum/cit/ase/ares/api/Impostor.java"
           cd "${work}"
           if [ "${TOOL}" = "maven" ]; then
-            mvn -B -ntp test > output.log 2>&1 && status=0 || status=$?
+            mvn -B -ntp -Dares.version="${ARES_VERSION}" test > output.log 2>&1 && status=0 || status=$?
           else
             ./gradlew --no-daemon --init-script "${RUNNER_TEMP}/local-repo.init.gradle" test > output.log 2>&1 && status=0 || status=$?
           fi


### PR DESCRIPTION
## Summary

The Examples workflow resolves Ares from the local repository but still asks for the version the exercise files name, which is the last release. It now asks for the version this job actually built, so the workflow reports on this commit rather than failing whenever the development version has moved ahead of the release.

## Linked issues

None. The failure was observed on `main` at 86249b10, in run [Examples / Run the gradle exercise](https://github.com/ls1intum/Ares2/actions?query=workflow%3AExamples+branch%3Amain).

## 1. Problem

`main` has been red on the Examples workflow since 06e7cd75 set the development version to 2.1.2, on both the Maven and the Gradle leg:

```
> Could not resolve all files for configuration ':aspect'.
   > Could not find de.tum.cit.ase:ares:2.1.1.
     Searched in the following locations:
       - file:/home/runner/.m2/repository/de/tum/cit/ase/ares/2.1.1/ares-2.1.1.pom
```

The root cause sits in the build integration, specifically in how this workflow substitutes the artefact under test. It pins the *repository*, so `de.tum.cit.ase` can only come from the local repository and the job cannot silently fall through to Central. It does not pin the *version*. Those two are one decision, not two: the workflow's stated purpose is to consume "the artefact built in this job", and the version is half of what identifies that artefact.

The exercise files name the version a tutor downloads, which is the last release. The version installed in the job is the development version. Between a version bump and the release that catches up, those differ by construction, and the local repository then holds exactly one version that the exercise never asks for. The job fails at dependency resolution, before compiling a line of the exercise, so the workflow reports nothing about the examples at all.

This is neither a false positive nor a false negative in enforcement: no policy decision is involved, and nothing an instructor or a student runs is affected. It is a defect in CI, and a consequential one, because this workflow is the only thing standing between the setup manual and silent rot: while it is red for a reason unrelated to the examples, a genuine break in them is indistinguishable from the version drift.

A second, quieter gap in the same guarantee surfaced while fixing the first. `setup-java` caches the whole local repository, and `install` overwrites what a build produces without removing what it no longer produces. A packaging regression that stopped attaching the `agent` classifier would therefore have been masked by the agent JAR left behind by the previous run, and the job would have reported green on an artefact it did not build. `exclusiveContent` guarantees where an artefact came from, not when.

## 2. Improvement from the user's perspective

No Improvement. The exercise files under `examples/` are byte-for-byte unchanged, so what a tutor downloads and what the setup manual documents are exactly what they were.

## 3. Improvement from the maintainer's perspective

- `main` stops going red for a version bump. A red Examples run again means the examples are broken, which is the only reading that makes the workflow worth having.
- The substitution is complete rather than half-done: repository, version and freshness all come from this job, so the run cannot report on an artefact other than the one it built. The coordinate is emptied before `install`, and both consumed JARs are byte-compared against `target/` afterwards, so a dropped `agent` classifier fails as a packaging error with that name rather than surfacing later as a resolution error in an example.
- A release no longer has to be sequenced around this workflow. Bumping the development version first and aligning the documented version later is now a valid order, rather than one that leaves `main` red in between.
- The comment justifying `exclusiveContent` claimed that a plain `mavenLocal()` passes "only because 2.1.1 is not on Central yet". It is on Central, which made the stated reason obsolete while its conclusion stayed correct. The reason is now stated in terms that do not expire.

## 4. Testing manual

**Prerequisites**

1. Write access to a branch of this repository. Nothing is built locally; this change is a CI workflow only.

**Steps**

Not reproducible from an exercise. This changes `.github/workflows/examples.yml` and no Java, policy or build behaviour of Ares itself. A reviewer verifies it as follows.

1. Read the diff. Confirm that nothing under `examples/` is touched, so the exercise files a tutor downloads are unchanged.
2. Open the Examples run for this pull request and read the "Read the version built in this job" step.
   *Expected:* it prints `Testing the examples against Ares 2.1.2`, which is `<version>` in `pom.xml`, not the `2.1.1` the exercise files name.
3. In the same run, read the "Confirm the local repository holds the JARs this build produced" step.
   *Expected:* two lines naming `ares-2.1.2.jar` and `ares-2.1.2-agent.jar` under `~/.m2/repository/de/tum/cit/ase/ares/2.1.2/`, each stated to be the JAR this build produced. The step fails if either is absent or differs from `target/`.
4. In the same run, read the "Pin Ares to the artefact built in this job (CI only)" step, which echoes the generated init script.
   *Expected:* the script contains `details.useVersion "2.1.2"` alongside the existing `exclusiveContent` block.
5. Read the "Run the exercise" step of both matrix legs.
   *Expected:* both reach `Tests run: 3, Failures: 0, Errors: 0` (Maven) and `BUILD SUCCESSFUL` (Gradle). Before this change both failed at dependency resolution with `Could not find de.tum.cit.ase:ares:2.1.1`.
6. Read the "Confirm the reserved-package boundary rejects an impostor" step of both legs.
   *Expected:* `Reserved-package boundary rejected the impostor class, as required.` This is the step that proves the substitution reached a real build rather than merely resolving.

**Expected result**

Both matrix legs are green, and the Gradle leg additionally reports `Configuration cache entry reused` in the configuration-cache step. The examples are exercised against the artefact built from this commit, at the version this commit declares.

**Negative case (what must still be rejected)**

- The job must still be unable to resolve Ares from Maven Central. `exclusiveContent` is unchanged, and step 3 above confirms it is still in the generated script. A reviewer who wants to see it fail can point `useVersion` at a released version such as `2.1.1` in a scratch branch: the build then fails, because the local repository holds only what this job installed, which is what makes the workflow non-vacuous.
- The reserved-package boundary must still reject an impostor class, which step 6 asserts, and which fails the job with an explicit diagnostic if the boundary is inactive.
- A local repository holding a stale artefact of this version must no longer be usable: the coordinate is emptied before `install`, and the byte comparison in step 3 fails if what the examples would consume is not what this build wrote.
- Nothing that was previously blocked becomes permitted: no policy, advice, rule or generated test code is touched.

**Modes exercised**

<!-- This changes a CI workflow only. It runs the examples, whose policies are fixed by the exercise files, and it alters no code that any of the four combinations reaches. -->

No mode-specific behaviour changed.

- [ ] ArchUnit + AspectJ
- [ ] ArchUnit + instrumentation
- [ ] WALA + AspectJ
- [ ] WALA + instrumentation

## 5. Test case coverage regarding this PR

No production Java code changed.

## Breaking changes and migration

None.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
<!-- Tests were not added: the change is a CI workflow, and the workflow is its own test. Its Examples run either resolves and builds the examples or it does not, and steps 2 to 5 of the testing manual read that run. -->
- [x] Documentation (`docs/`, `README.adoc`, Javadoc) was updated where the change is user-facing. The change is not user-facing; the documented setup and the version it names are unchanged.
- [x] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test
