### PR TITLE
Name the declaring class in a denial message, not a fragment of it

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -53,8 +53,64 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      # The examples pin the version a tutor downloads, which is the last release.
+      # The version built here is the development version, which runs ahead of it
+      # between a version bump and the release that catches up. Reading it from the
+      # POM is what keeps those two facts independent: without it, this job resolves
+      # a coordinate that the local repository does not hold, and main turns red for
+      # the bump rather than for anything wrong with the examples.
+      #
+      # The help plugin is pinned to a version rather than invoked by prefix, so that
+      # the reading does not depend on whichever plugin release is current on the day
+      # of the run.
+      #
+      # The value is validated before it is exported, because it is interpolated into
+      # GITHUB_ENV, into the generated Groovy below and into a path that is removed
+      # with `rm -rf`. The first character must be alphanumeric for that last reason
+      # in particular: `..` consists only of permitted characters and would name the
+      # parent of the coordinate.
+      - name: Read the version built in this job
+        run: |
+          ares_version="$(mvn -B -ntp -q -Dstyle.color=never \
+            org.apache.maven.plugins:maven-help-plugin:3.5.2:evaluate \
+            -Dexpression=project.version -DforceStdout)"
+          case "${ares_version}" in
+            '' | [!0-9A-Za-z]* | *[!0-9A-Za-z.-]*)
+              echo "::error::project.version did not read as a version"
+              exit 1
+              ;;
+          esac
+          echo "ARES_VERSION=${ares_version}" >> "${GITHUB_ENV}"
+          echo "Testing the examples against Ares ${ares_version}"
+
+      # setup-java caches the whole local repository, so a previous run of this
+      # workflow can leave a `de.tum.cit.ase:ares` of exactly this version behind.
+      # `install` overwrites what this build produces, but it does not remove what it
+      # no longer produces, so a packaging regression that dropped the agent
+      # classifier would be masked by the cached agent JAR from the run before. The
+      # coordinate is therefore emptied first, which makes "the artefact built in this
+      # job" true of the version as well as of the repository.
+      - name: Empty this coordinate in the local repository
+        run: rm -rf "${HOME}/.m2/repository/de/tum/cit/ase/ares/${ARES_VERSION}"
+
       - name: Install Ares from this commit
         run: mvn -B -ntp install -DskipTests
+
+      # Asserted rather than assumed: everything downstream reads the local
+      # repository, and an absent classifier there fails as a resolution error in an
+      # example, which reads like a broken example rather than a broken packaging.
+      - name: Confirm the local repository holds the JARs this build produced
+        run: |
+          repository="${HOME}/.m2/repository/de/tum/cit/ase/ares/${ARES_VERSION}"
+          for classifier in "" "-agent"; do
+            built="target/ares-${ARES_VERSION}${classifier}.jar"
+            installed="${repository}/ares-${ARES_VERSION}${classifier}.jar"
+            if ! cmp -s "${built}" "${installed}"; then
+              echo "::error::${installed} is absent or differs from ${built}"
+              exit 1
+            fi
+            echo "${installed} is the JAR this build produced"
+          done
 
       - name: Verify the Gradle wrapper JAR is the one we generated
         if: matrix.tool == 'gradle'
@@ -69,14 +125,37 @@ jobs:
       # exclusiveContent, rather than a plain mavenLocal(): it makes the local
       # repository the ONLY source of de.tum.cit.ase, so this job cannot quietly
       # fall through to Central and test a published artefact instead of the one
-      # built above. A plain mavenLocal() passes today only because 2.1.1 is not
-      # on Central yet; once it is, the fallback would make this whole workflow
-      # vacuous without failing. Being first in the repository order is not
-      # enough, because Gradle continues to the next repository when a module is
-      # absent from the first.
+      # built above. Every released version is on Central, so a plain mavenLocal()
+      # would fall through and make this whole workflow vacuous without failing:
+      # it would report on the published artefact rather than on this commit.
+      # Being first in the repository order is not enough, because Gradle
+      # continues to the next repository when a module is absent from the first.
+      #
+      # The version is redirected for the same reason the repository is: the
+      # exercise file names the released coordinate, and this job has to resolve
+      # the one it built. eachDependency rewrites every requested version of the
+      # module, so the plain dependency and the one carrying the agent classifier
+      # are both redirected, and the exercise file stays untouched.
       - name: Pin Ares to the artefact built in this job (CI only)
         run: |
-          printf 'allprojects {\n    repositories {\n        exclusiveContent {\n            forRepository { mavenLocal() }\n            filter { includeGroup "de.tum.cit.ase" }\n        }\n    }\n}\n' > "${RUNNER_TEMP}/local-repo.init.gradle"
+          cat > "${RUNNER_TEMP}/local-repo.init.gradle" <<EOF
+          allprojects {
+              repositories {
+                  exclusiveContent {
+                      forRepository { mavenLocal() }
+                      filter { includeGroup "de.tum.cit.ase" }
+                  }
+              }
+              configurations.all {
+                  resolutionStrategy.eachDependency { details ->
+                      if (details.requested.group == "de.tum.cit.ase" && details.requested.name == "ares") {
+                          details.useVersion "${ARES_VERSION}"
+                          details.because "CI tests the artefact built in this job"
+                      }
+                  }
+              }
+          }
+          EOF
           cat "${RUNNER_TEMP}/local-repo.init.gradle"
 
       - name: Run the exercise
@@ -85,7 +164,7 @@ jobs:
           TOOL: ${{ matrix.tool }}
         run: |
           if [ "${TOOL}" = "maven" ]; then
-            mvn -B -ntp test
+            mvn -B -ntp -Dares.version="${ARES_VERSION}" test
           else
             ./gradlew --no-daemon --init-script "${RUNNER_TEMP}/local-repo.init.gradle" test
           fi
@@ -103,7 +182,7 @@ jobs:
             > "${work}/src/main/java/de/tum/cit/ase/ares/api/Impostor.java"
           cd "${work}"
           if [ "${TOOL}" = "maven" ]; then
-            mvn -B -ntp test > output.log 2>&1 && status=0 || status=$?
+            mvn -B -ntp -Dares.version="${ARES_VERSION}" test > output.log 2>&1 && status=0 || status=$?
           else
             ./gradlew --no-daemon --init-script "${RUNNER_TEMP}/local-repo.init.gradle" test > output.log 2>&1 && status=0 || status=$?
           fi

--- a/src/main/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCase.java
@@ -291,11 +291,15 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 		@Nonnull
 		String targetResolved = target != null ? target : "unknown";
 
-		// Extract parent caller from the caller (class.method -> extract class)
+		// Extract parent caller from the caller (class.method -> extract class).
+		//
+		// The separator is searched before the parameter list, not across the whole
+		// string. A caller carrying a fully qualified parameter type ends in a dot of
+		// its own, so searching the whole string cuts inside the parameter list:
+		// "a.b.C.m(java.lang.String)" yielded "a.b.C.m(java.lang". This surfaced
+		// through the WALA path, whose callers carry such parameter types.
 		@Nonnull
-		String parentCaller = callerResolved.contains(".")
-				? callerResolved.substring(0, callerResolved.lastIndexOf('.'))
-				: callerResolved;
+		String parentCaller = extractDeclaringType(callerResolved);
 
 		// Determine the action based on the rule name
 		@Nonnull
@@ -303,6 +307,32 @@ public class JavaArchitectureTestCase extends ArchitectureTestCase {
 
 		throw new SecurityException(Messages.localized("security.archunit.violation.error", callerResolved, action,
 				targetResolved, parentCaller));
+	}
+
+	/**
+	 * Extracts the declaring type from a rendered method or constructor reference.
+	 * <p>
+	 * The reference may carry a parameter list, and a fully qualified parameter
+	 * type contains dots of its own. The method separator is therefore searched
+	 * only in the part preceding the parameter list, so that
+	 * {@code a.b.C.m(java.lang.String)} yields {@code a.b.C} rather than
+	 * {@code a.b.C.m(java.lang}.
+	 *
+	 * @since 2.1.3
+	 * @author Markus Paulsen
+	 * @param reference The rendered method or constructor reference
+	 * @return The declaring type, or the reference itself when it carries no
+	 *         separator
+	 */
+	@Nonnull
+	private static String extractDeclaringType(@Nonnull String reference) {
+		int parameterListStart = reference.indexOf('(');
+		int searchEnd = parameterListStart >= 0 ? parameterListStart - 1 : reference.length() - 1;
+		if (searchEnd < 0) {
+			return reference;
+		}
+		int methodSeparator = reference.lastIndexOf('.', searchEnd);
+		return methodSeparator >= 0 ? reference.substring(0, methodSeparator) : reference;
 	}
 
 	/**

--- a/src/test/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCaseTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/architecture/java/JavaArchitectureTestCaseTest.java
@@ -9,6 +9,8 @@ import org.mockito.Mockito;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 
+import de.tum.cit.ase.ares.api.localization.Messages;
+
 public class JavaArchitectureTestCaseTest {
 
 	@Test
@@ -105,5 +107,42 @@ public class JavaArchitectureTestCaseTest {
 				thrown.getMessage().contains("Ares Security Error")
 						|| thrown.getMessage().contains("Ares Sicherheitsfehler"),
 				"Exception message should contain Ares Security Error prefix");
+	}
+
+	@Test
+	void testParseErrorMessage_callerWithQualifiedParameterType_namesTheDeclaringType() {
+		// A caller rendered with a fully qualified parameter type ends in a dot of its
+		// own. The declaring type must be taken from the part before the parameter
+		// list, otherwise the reported caller is cut inside that list.
+		String message = "Architecture Violation [Priority: MEDIUM] - Rule 'Accesses file system' was violated (1 times):\n"
+				+ "Method <com.example.Sender.sendWithDataOutputStream(java.lang.String)> "
+				+ "calls method <java.io.DataOutputStream.writeUTF(java.lang.String)> in (Sender.java:1)";
+		AssertionError error = new AssertionError(message);
+		SecurityException thrown = assertThrows(SecurityException.class,
+				() -> JavaArchitectureTestCase.parseErrorMessage(error),
+				"parseErrorMessage should throw SecurityException for a file system violation");
+		// Compared against the localized message for the whole expected parse, so the
+		// assertion holds in any locale and pins every argument rather than a suffix.
+		String expected = Messages.localized("security.archunit.violation.error",
+				"com.example.Sender.sendWithDataOutputStream(java.lang.String)", "access the file system",
+				"java.io.DataOutputStream.writeUTF(java.lang.String)", "com.example.Sender");
+		assertEquals(expected, thrown.getMessage(),
+				"The declaring type should be reported without cutting inside the parameter list");
+	}
+
+	@Test
+	void testParseErrorMessage_callerWithEmptyParameterList_namesTheDeclaringType() {
+		// The shape the ArchUnit path produces, kept as a regression guard: an empty
+		// parameter list carries no dot, so this spelling was already handled and must
+		// keep reporting the same declaring type.
+		String message = "Architecture Violation [Priority: MEDIUM] - Rule 'Accesses network' was violated (1 times):\n"
+				+ "Method <com.example.Sender.send()> calls method <java.net.Socket.connect()> in (Sender.java:1)";
+		AssertionError error = new AssertionError(message);
+		SecurityException thrown = assertThrows(SecurityException.class,
+				() -> JavaArchitectureTestCase.parseErrorMessage(error),
+				"parseErrorMessage should throw SecurityException for a network violation");
+		String expected = Messages.localized("security.archunit.violation.error", "com.example.Sender.send()",
+				"access the network", "java.net.Socket.connect()", "com.example.Sender");
+		assertEquals(expected, thrown.getMessage(), "The declaring type should be reported unchanged");
 	}
 }


### PR DESCRIPTION
## Summary

A denial message named the calling class by cutting the caller string at its last dot, which lands inside the parameter list when a parameter type is fully qualified. The declaring type is now taken from the part before the parameter list, so the message names a class rather than a fragment of one.

## Linked issues

None. Found by running the CI matrix of [`ls1intum/SCOREReproducibilityPackage`](https://github.com/ls1intum/SCOREReproducibilityPackage) against Ares 2.1.2.

## 1. Problem

Every WALA-mode denial reported by the architecture layer carried a malformed caller. Observed on JDK 17, 21 and 25, under Gradle, in both AOP modes, with the architecture mode set to WALA:

```
anonymous.networksystem.send.NetworkSystemSendAccess.sendWithDataOutputStream(java.lang.String)
tried to illegally access the file system via java.io.DataOutputStream.writeUTF(java.lang.String)
(called by anonymous.networksystem.send.NetworkSystemSendAccess.sendWithDataOutputStream(java.lang)
but was blocked by Ares.
```

The expected reading of the last clause is a class. What it printed was the whole caller with its parameter list chopped mid-type: `...sendWithDataOutputStream(java.lang`.

The root cause sits in the enforcement (architecture) layer, in `JavaArchitectureTestCase.parseErrorMessage`:

```java
String parentCaller = callerResolved.contains(".")
        ? callerResolved.substring(0, callerResolved.lastIndexOf('.'))
        : callerResolved;
```

The comment above it says "class.method -> extract class", which is what `lastIndexOf('.')` does for a caller written without parameters. A caller carrying a fully qualified parameter type ends in dots of its own, and the search does not stop at the parameter list, so the last dot found is the one inside `java.lang.String`. This surfaced through the WALA path, whose callers carry such parameter types; it is not specific to WALA in principle, only in which inputs reach it today.

This is neither a false positive nor a false negative. Enforcement is unaffected: the same code is blocked, for the same reason, with the same target. It is a diagnostics defect, and a consequential one for anyone comparing modes, because an exercise asserting on the message cannot express a caller that is a valid class name.

It has been latent since the message was introduced. It became observable in 2.1.2 because that is the first release in which the WALA architecture mode runs at all: in 2.1.0 and 2.1.1 it aborted in `CustomCallgraphBuilder`'s static initialiser whenever jqwik was absent, which #167 fixed.

## 2. Improvement from the user's perspective

An instructor reading a WALA denial sees the declaring class of the calling method, so the clause is usable for locating the call and for writing an expectation against it. Previously it named a string that is not a class, not a method and not a package.

The limitation worth stating: this corrects only how the caller is rendered. Which violation the static analysis reports, and how it attributes that violation to a branch of the supervised code, is unchanged by this pull request.

## 3. Improvement from the maintainer's perspective

The parsing is now a named helper with its intent in its name, rather than a substring expression whose correctness depended on the caller never carrying a qualified parameter type. The two spellings that reach it are pinned by tests that compare the whole localized message, so a future change to either the parse or the template is caught by value rather than by substring.

## 4. Testing manual

**Prerequisites**

1. JDK 21 and Maven 3.8+ to run the unit tests. No exercise, Artemis instance or policy file is involved for steps 1 and 2.
2. For step 3, an exercise whose policy uses a `..._WALA_AND_ASPECTJ` or `..._WALA_AND_INSTRUMENTATION` configuration, and this branch built and installed with `mvn -o install -DskipTests`.

**Steps**

1. Run `mvn -o test -Dtest=JavaArchitectureTestCaseTest`.
   *Expected:* 9 tests pass, including `testParseErrorMessage_callerWithQualifiedParameterType_namesTheDeclaringType` and `testParseErrorMessage_callerWithEmptyParameterList_namesTheDeclaringType`.
2. Revert only `JavaArchitectureTestCase.java` with `git checkout` and run the same command again.
   *Expected:* exactly one failure, `testParseErrorMessage_callerWithQualifiedParameterType_namesTheDeclaringType`, reporting a message whose last clause ends `...sendWithDataOutputStream(java.lang)`. This is the defect. Restore the file afterwards.
3. In an exercise on a WALA configuration, provoke any architecture-layer denial whose calling method takes a parameter of a fully qualified type, for example a method declared `void send(java.lang.String payload)` that opens a forbidden resource, and read the `SecurityException`.
   *Expected:* the clause reads `(called by your.package.YourClass)`. Before this change it read `(called by your.package.YourClass.send(java.lang)`.

**Expected result**

The caller clause names the declaring class in both spellings, and nothing else about the message changes: the violating method, the action and the target are byte-for-byte what they were.

**Negative case (what must still be rejected)**

Nothing that was previously blocked becomes permitted, and nothing previously permitted becomes blocked. This change touches only the construction of the message thrown after a violation has already been decided, so no policy, rule, advice or generated test code is affected. Step 3 confirms the denial still occurs; only its wording changes. The `security.archunit.violation.error` template and its four arguments are otherwise unchanged, which the two tests assert by comparing the complete localized message.

**Modes exercised**

<!-- The defect is in shared architecture-layer code. The malformed output was observed under both WALA combinations, on three JDKs; the two ArchUnit combinations reach the same code with callers that carry no qualified parameter type and are unaffected, which the second unit test pins. -->

- [ ] ArchUnit + AspectJ
- [ ] ArchUnit + instrumentation
- [x] WALA + AspectJ
- [x] WALA + instrumentation

## 5. Test case coverage regarding this PR

<!--
  The Coverage Report artefact for this branch is produced by this pull request's own CI run, so
  the figures below cannot be filled in before that run completes. The single changed production
  class is listed so the row can be completed from `site/jacoco/jacoco.csv` of this run.
-->

| Class | Instruction coverage | Branch coverage | Line coverage | Complexity coverage | Method coverage | Confirmation (meaningful assertions) |
| --- | ---: | ---: | ---: | ---: | ---: | :---: |
| `JavaArchitectureTestCase` | see this run's artefact | see this run's artefact | see this run's artefact | see this run's artefact | see this run's artefact | Yes, both new tests compare the complete localized message rather than asserting a substring |

## Breaking changes and migration

None for the public API under `de.tum.cit.ase.ares.api`, the policy file format, the generated security test code or the minimum JDK, Maven and Gradle versions.

Worth noting for anyone who pins denial messages: the text of the `called by` clause changes for callers rendered with a qualified parameter type. An exercise or test fixture that recorded the malformed form has to be updated to the class name. No such fixture exists in this repository.

The helper is tagged `@since 2.1.3` on the assumption that 2.1.2 is released from `main` as it stands. If this merges before that release, the tag should read 2.1.2.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
- [x] Tests were added or updated for the behaviour changed here.
<!-- Documentation was not updated: no documented behaviour, policy option or setup step changes; the wording of one runtime message is not described anywhere in docs/ or README.adoc. -->
- [x] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test
