### PR TITLE
Detect the supervised package instead of defaulting to it

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScanner.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScanner.java
@@ -30,6 +30,8 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.type.ArrayType;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
 
 import de.tum.cit.ase.ares.api.buildtoolconfiguration.BuildMode;
 import de.tum.cit.ase.ares.api.buildtoolconfiguration.BuildToolConfiguration;
@@ -78,6 +80,18 @@ public class JavaProjectScanner implements ProjectScanner {
 		this.buildConfiguration = Objects.requireNonNull(buildConfiguration, "buildConfiguration must not be null");
 	}
 
+	/**
+	 * The last-resort supervised package, used only when neither the production
+	 * sources nor the compiled production output declares one.
+	 * <p>
+	 * Prefer detection over this hook. A default that the project does not contain
+	 * mis-scopes enforcement silently: the analysis path resolves to a directory
+	 * that does not exist, no class is imported, and no resource domain is
+	 * enforced, while nothing fails. {@link #scanForPackageName()} therefore
+	 * reaches this value only when the project offers nothing to detect.
+	 *
+	 * @return the default package name
+	 */
 	@Nonnull
 	protected String getDefaultPackage() {
 		return "";
@@ -415,6 +429,31 @@ public class JavaProjectScanner implements ProjectScanner {
 		return packageName.isEmpty() ? nestedName : packageName + "." + nestedName;
 	}
 
+	/**
+	 * Derives the supervised package from the project, never from a default that
+	 * the project does not contain.
+	 * <p>
+	 * Resolution runs in three steps, and each falls through only when it finds
+	 * nothing at all:
+	 * <ol>
+	 * <li>the most frequent non-reserved package declared by the production
+	 * <em>sources</em>;</li>
+	 * <li>otherwise the most frequent non-reserved package declared by the compiled
+	 * production <em>output</em>. This covers every project whose build descriptor
+	 * the source-root discovery cannot parse, because the compiled output sits at
+	 * the build tool's own location whatever the descriptor says;</li>
+	 * <li>otherwise {@link #getDefaultPackage()}, with a warning naming the roots
+	 * that were searched. Reaching this step means the project declared nothing to
+	 * detect, and a default the project does not contain mis-scopes enforcement
+	 * silently, so the warning is the only signal a reader gets.</li>
+	 * </ol>
+	 * Step 2 is what keeps step 3 out of reach for a real project. The compiled
+	 * output is authoritative whatever the build descriptor says, because the build
+	 * tool writes it to its own location, so a descriptor that source-root
+	 * discovery cannot parse no longer costs the supervised scope.
+	 *
+	 * @return the supervised package name, possibly empty; never null
+	 */
 	@Override
 	@Nonnull
 	public String scanForPackageName() {
@@ -425,10 +464,69 @@ public class JavaProjectScanner implements ProjectScanner {
 				counts.merge(name, 1L, Long::sum);
 			}
 		}
-		return counts.entrySet().stream()
-				.sorted(Map.Entry.<String, Long>comparingByValue(Comparator.reverseOrder())
-						.thenComparing(Map.Entry::getKey))
-				.map(Map.Entry::getKey).findFirst().orElse(getDefaultPackage());
+		if (counts.isEmpty()) {
+			counts = compiledPackageCounts();
+		}
+		if (counts.isEmpty()) {
+			String defaultPackage = getDefaultPackage();
+			LOG.warn(
+					"No supervised package could be detected: no production source declared one under {} and no compiled class declared one under {}. "
+							+ "Falling back to the configured default \"{}\", which enforces nothing if the project does not contain it.",
+					productionRoots(), productionOutputRoot(), defaultPackage);
+			return defaultPackage;
+		}
+		return counts.entrySet().stream().sorted(
+				Map.Entry.<String, Long>comparingByValue(Comparator.reverseOrder()).thenComparing(Map.Entry::getKey))
+				.map(Map.Entry::getKey).findFirst().orElseThrow();
+	}
+
+	/**
+	 * Counts the non-reserved packages declared by the compiled production classes.
+	 * <p>
+	 * Only top-level classes are counted: a nested or anonymous class produces its
+	 * own class file, so counting every file would weight a package by how many
+	 * inner classes it happens to contain. Blank package names are skipped, which
+	 * also disposes of {@code module-info.class} at the root of the output tree.
+	 *
+	 * @return the package counts, empty when nothing is compiled or readable
+	 */
+	@Nonnull
+	private Map<String, Long> compiledPackageCounts() {
+		Path outputRoot = productionOutputRoot();
+		if (outputRoot == null || !Files.isDirectory(outputRoot) || !Files.isReadable(outputRoot)) {
+			return Map.of();
+		}
+		Map<String, Long> counts = new HashMap<>();
+		for (JavaClass javaClass : new ClassFileImporter().importPath(outputRoot)) {
+			// The binary name carries the '$', so it is what distinguishes a nested or
+			// anonymous class here. getSimpleName() does not: it answers "Inner" for
+			// Busy$Inner and the empty string for Busy$1.
+			if (javaClass.getName().contains("$")) {
+				continue;
+			}
+			String name = javaClass.getPackageName();
+			if (!name.isBlank() && ReservedPackageGuard.reservedPrefixOf(name) == null) {
+				counts.merge(name, 1L, Long::sum);
+			}
+		}
+		return counts;
+	}
+
+	/**
+	 * Resolves the compiled production output root for the discovered build tool.
+	 * <p>
+	 * Without a build configuration this mirrors
+	 * {@link BuildMode#getClasspath(Path, String)}, which resolves the build-tool
+	 * directory against the working directory of the test run.
+	 *
+	 * @return the production output root; never null
+	 */
+	@Nonnull
+	private Path productionOutputRoot() {
+		if (buildConfiguration != null) {
+			return buildConfiguration.productionOutputRoot();
+		}
+		return Path.of(scanForBuildMode().getBuildDirectory()).toAbsolutePath();
 	}
 
 	@Override

--- a/src/main/java/de/tum/cit/ase/ares/api/util/ProjectSourcesFinder.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/util/ProjectSourcesFinder.java
@@ -36,8 +36,21 @@ public final class ProjectSourcesFinder {
 	private static final String DEFAULT_TEST_SOURCE = "src/test/java";
 	private static final Pattern PROPERTY_ASSIGNMENT = Pattern
 			.compile("(?m)^\\s*(?:def|val|var)?\\s*([A-Za-z_][A-Za-z0-9_.-]*)\\s*=\\s*['\"]([^'\"]+)['\"]");
+	// The plural alternative must come first, and the singular one must refuse a
+	// following 's'. Matched the other way round, 'srcDir' consumes the prefix of
+	// 'srcDirs' and the capture starts at the leftover "s = [", which
+	// resolveGradlePath cannot resolve: every srcDirs declaration was then dropped
+	// without a trace, and a project declaring its main sources that way looked to
+	// Ares like a project with no production sources at all.
+	//
+	// Known gaps, deliberately not covered here: Kotlin's setSrcDirs(...) and
+	// srcDirs.set(...)/from(...), and lists spread over several lines. A
+	// line-oriented regex cannot follow the Gradle DSL, and pretending otherwise
+	// trades one silent failure for another. They are non-fatal instead: when the
+	// descriptor cannot be parsed, JavaProjectScanner.scanForPackageName falls back
+	// to the compiled output, which is authoritative whatever the build file says.
 	private static final Pattern SOURCE_DIRECTORY = Pattern
-			.compile("(?:srcDir\\s*(?:\\(\\s*)?|srcDirs\\s*(?:=|\\()\\s*)([^)\\]\\n}]+)");
+			.compile("(?:srcDirs\\s*(?:\\+?=|\\()\\s*|srcDir(?!s)\\s*(?:\\(\\s*)?)([^)\\]\\n}]+)");
 	private static String pomXmlPath = "pom.xml";
 	private static String buildGradlePath = "build.gradle";
 

--- a/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScannerPackageFallbackTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/securitytest/java/projectScanner/JavaProjectScannerPackageFallbackTest.java
@@ -1,0 +1,159 @@
+package de.tum.cit.ase.ares.api.securitytest.java.projectScanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import de.tum.cit.ase.ares.api.buildtoolconfiguration.BuildMode;
+import de.tum.cit.ase.ares.api.buildtoolconfiguration.BuildToolConfiguration;
+
+/**
+ * Covers the supervised-package fallback of {@link JavaProjectScanner}.
+ * <p>
+ * The scanner must derive the supervised package from the project and never
+ * invent one. A package that the project does not contain resolves to an
+ * analysis directory that does not exist, so no class is imported and no
+ * resource domain is enforced, without anything failing.
+ */
+@DisplayName("JavaProjectScanner supervised-package fallback")
+class JavaProjectScannerPackageFallbackTest {
+
+	@TempDir
+	Path projectRoot;
+
+	@Test
+	@DisplayName("Derives the package from the compiled output when no source root is discoverable")
+	void derivesPackageFromCompiledOutputWhenSourceRootsAreUndiscoverable() throws IOException {
+		Path outputRoot = compile("""
+				package de.tum.cit.aet;
+
+				public class Calculator {
+					public Runnable inner() {
+						return new Runnable() {
+							@Override
+							public void run() {
+							}
+						};
+					}
+				}
+				""", "de/tum/cit/aet/Calculator.java");
+
+		String packageName = new JavaProjectScanner(configurationWithoutSourceRoots(outputRoot)).scanForPackageName();
+
+		assertEquals("de.tum.cit.aet", packageName);
+	}
+
+	@Test
+	@DisplayName("Weights the compiled output by top-level class, not by class file")
+	void ignoresNestedAndAnonymousClassesWhenWeightingPackages() throws IOException {
+		// 'crowded' holds one top-level class plus two extra class files; 'sparse'
+		// holds two top-level classes. Counting class files would pick 'crowded'.
+		Path outputRoot = compile("""
+				package crowded;
+
+				public class Busy {
+					class Inner {
+					}
+
+					Runnable anonymous() {
+						return new Runnable() {
+							@Override
+							public void run() {
+							}
+						};
+					}
+				}
+				""", "crowded/Busy.java");
+		compileInto(outputRoot, """
+				package sparse;
+
+				public class First {
+				}
+				""", "sparse/First.java");
+		compileInto(outputRoot, """
+				package sparse;
+
+				public class Second {
+				}
+				""", "sparse/Second.java");
+
+		String packageName = new JavaProjectScanner(configurationWithoutSourceRoots(outputRoot)).scanForPackageName();
+
+		assertEquals("sparse", packageName);
+	}
+
+	/**
+	 * The compiled output must win over the configured default, so that a project
+	 * whose build descriptor cannot be parsed is still scoped to its own package
+	 * rather than to a name it may not contain.
+	 */
+	@Test
+	@DisplayName("Prefers the compiled output over the configured default package")
+	void prefersCompiledOutputOverTheConfiguredDefault() throws IOException {
+		Path outputRoot = compile("""
+				package de.tum.cit.aet;
+
+				public class Calculator {
+				}
+				""", "de/tum/cit/aet/Calculator.java");
+
+		String packageName = new JavaProgrammingExerciseProjectScanner(configurationWithoutSourceRoots(outputRoot))
+				.scanForPackageName();
+
+		assertEquals("de.tum.cit.aet", packageName);
+		assertNotEquals("de.tum.cit.ase", packageName);
+	}
+
+	/**
+	 * Only when the project declares nothing at all does the configured default
+	 * apply. It is the last resort, not the first answer.
+	 */
+	@Test
+	@DisplayName("Falls back to the configured default only when nothing is detectable")
+	void fallsBackToTheConfiguredDefaultOnlyWhenNothingIsDetectable() throws IOException {
+		Path outputRoot = Files.createDirectories(projectRoot.resolve("build/classes/java/main"));
+		BuildToolConfiguration configuration = configurationWithoutSourceRoots(outputRoot);
+
+		assertEquals("", new JavaProjectScanner(configuration).scanForPackageName());
+		assertEquals("de.tum.cit.ase", new JavaProgrammingExerciseProjectScanner(configuration).scanForPackageName());
+	}
+
+	/**
+	 * A configuration whose production source roots are empty, which is what an
+	 * unparsed build descriptor leaves behind. The test source root doubles as the
+	 * required non-empty root list.
+	 */
+	private BuildToolConfiguration configurationWithoutSourceRoots(Path outputRoot) throws IOException {
+		Path testRoot = Files.createDirectories(projectRoot.resolve("test"));
+		return new BuildToolConfiguration(BuildMode.GRADLE, projectRoot, List.of(), List.of(testRoot), outputRoot,
+				Files.createDirectories(projectRoot.resolve("build/classes/java/test")));
+	}
+
+	private Path compile(String source, String relativeSourcePath) throws IOException {
+		Path outputRoot = Files.createDirectories(projectRoot.resolve("build/classes/java/main"));
+		compileInto(outputRoot, source, relativeSourcePath);
+		return outputRoot;
+	}
+
+	private void compileInto(Path outputRoot, String source, String relativeSourcePath) throws IOException {
+		Path sourceFile = projectRoot.resolve("sources").resolve(relativeSourcePath);
+		Files.createDirectories(sourceFile.getParent());
+		Files.writeString(sourceFile, source);
+		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+		int status = compiler.run(null, null, null, "-d", outputRoot.toString(), sourceFile.toString());
+		if (status != 0) {
+			throw new IllegalStateException("Could not compile the fixture " + relativeSourcePath);
+		}
+	}
+}

--- a/src/test/java/de/tum/cit/ase/ares/api/util/ProjectSourcesFinderTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/util/ProjectSourcesFinderTest.java
@@ -51,6 +51,48 @@ class ProjectSourcesFinderTest {
 		}
 	}
 
+	/**
+	 * Regression: 'srcDir' is a prefix of 'srcDirs', so an alternation that tried
+	 * the singular form first consumed it and captured the leftover "s = [", which
+	 * resolved to nothing. Every srcDirs declaration was dropped without a trace,
+	 * and a project declaring its main sources that way looked like a project with
+	 * no production sources at all.
+	 */
+	@Test
+	void discoversGradleRootsDeclaredWithSrcDirsList() throws IOException {
+		Files.createDirectories(temporaryDirectory.resolve("assignment/src"));
+		Files.createDirectories(temporaryDirectory.resolve("test"));
+		Files.writeString(temporaryDirectory.resolve("build.gradle"), """
+				def assignmentSrcDir = "assignment/src"
+				sourceSets {
+				  test { java { srcDir 'test' } }
+				  main { java { srcDirs = [assignmentSrcDir] } }
+				}
+				""");
+		var configuration = ProjectSourcesFinder.discover(temporaryDirectory);
+		assertEquals(temporaryDirectory.resolve("assignment/src").toRealPath(),
+				configuration.productionSourceRoots().get(0));
+		assertEquals(temporaryDirectory.resolve("test").toRealPath(), configuration.testSourceRoots().get(0));
+	}
+
+	@Test
+	void discoversGradleRootsFromLiteralListsAndAppendedAssignments() throws IOException {
+		Files.createDirectories(temporaryDirectory.resolve("first"));
+		Files.createDirectories(temporaryDirectory.resolve("second"));
+		Files.createDirectories(temporaryDirectory.resolve("appended"));
+		Files.writeString(temporaryDirectory.resolve("build.gradle"), """
+				sourceSets {
+				  main { java { srcDirs = ['first', 'second'] } }
+				  test { java { srcDirs += ['appended'] } }
+				}
+				""");
+		var configuration = ProjectSourcesFinder.discover(temporaryDirectory);
+		assertEquals(2, configuration.productionSourceRoots().size());
+		assertEquals(temporaryDirectory.resolve("first").toRealPath(), configuration.productionSourceRoots().get(0));
+		assertEquals(temporaryDirectory.resolve("second").toRealPath(), configuration.productionSourceRoots().get(1));
+		assertEquals(temporaryDirectory.resolve("appended").toRealPath(), configuration.testSourceRoots().get(0));
+	}
+
 	@Test
 	void rejectsAmbiguousMissingAndEscapingProjects() throws IOException {
 		Files.writeString(temporaryDirectory.resolve("pom.xml"), "<project/>");


### PR DESCRIPTION
## Summary

Gradle source-root discovery silently dropped every `srcDirs` declaration, so a project declaring its main
sources that way looked to Ares like a project with no production sources at all. Without a policy, the
supervised package then fell straight through to a configured default the project need not contain, and
enforcement was scoped to a directory that does not exist.

## Linked issues

None. Found while migrating a set of Artemis ITP exercises from Ares 1 to Ares 2 and removing their `@Policy`
annotations to use the policy-free configuration.

## 1. Problem

Observed with Ares 2.1.2 on JDK 17, Gradle 9.0.0, ArchUnit + AspectJ, macOS, in an Artemis exercise test
repository whose test classes carry Ares test annotations but no `@Policy`, so the policy-free configuration of
setup manual section 6 applies.

Expected behaviour, as documented there: "File system, network, command execution and thread creation: denied."

Observed behaviour: supervised code performed all three unhindered. With the forbidden operation in the
student-facing class and the test asserting the rejection, `java.nio.file.Files.readString`,
`new ProcessBuilder("echo","x").start()` and `new Thread(...).start()` all executed and the run stayed green.
`System.exit(3)` was still blocked, which shows the extension was registered and the build wiring intact: only
the five resource domains were left unarmed.

Root cause, in the **build integration**. `ProjectSourcesFinder.SOURCE_DIRECTORY` was

```java
Pattern.compile("(?:srcDir\\s*(?:\\(\\s*)?|srcDirs\\s*(?:=|\\()\\s*)([^)\\]\\n}]+)")
```

Alternation tries `srcDir` first, and `srcDir` is a prefix of `srcDirs`. On `srcDirs = ["assignment/src"]` the
first alternative consumes `srcDir`, so the capture begins at the leftover and yields `s = ["assignment/src"`,
which `resolveGradlePath` cannot resolve. The entry is dropped with no diagnostic, and the `srcDirs` alternative
is unreachable. Confirmed in isolation: `ProjectSourcesFinder.discover` on such a project returns
`productionRoots = []` while `testRoots` is populated, because the test source set of these exercises uses the
singular `srcDir 'test'`.

The consequence lands in the **generated security test**. With no policy,
`TestCaseAbstractFactoryAndBuilder` derives the supervised package from `JavaProjectScanner.scanForPackageName()`,
which counts package declarations under the production source roots. That list was empty, so the method fell
through in a single step to `getDefaultPackage()`, which `JavaProgrammingExerciseProjectScanner` overrides to
`"de.tum.cit.ase"`. For an exercise in `de.tum.cit.aet`, one letter away, `BuildToolConfiguration.classpath` then
resolved `build/classes/java/main/de/tum/cit/ase`, a directory that does not exist. `ClassFileImporter.importPath`
returns an empty set for a missing directory rather than failing, so ArchUnit analysed zero classes and the
aspects were armed over a package containing none.

Nothing rejected the value on the way: `ReservedPackageGuard.validatePackage("de.tum.cit.ase")` passes, because
only `de/tum/cit/ase/ares/api/**` is reserved, and no component asserts that the supervised package actually
contains a class.

**This is a false negative**: forbidden student code ran unhindered under a configuration documented as denying
it, and the build stayed green. It is masked whenever a policy is present, because the package is then pinned by
`theSupervisedCodeUsesTheFollowingPackage` and the scanner is never consulted, which is how it survived to 2.1.2.

## 2. Improvement from the user's perspective

Instructors using the policy-free configuration get the enforcement the manual promises. Before this change, an
exercise whose main source set is declared with `srcDirs`, which includes Artemis Java exercises built from the
standard template, enforced nothing in the file, network, command and thread domains while reporting a green run.
Students see no change in a correctly configured exercise; in an affected one, code that should have been
rejected is now rejected.

## 3. Improvement from the maintainer's perspective

Discovery no longer collapses to a configured default in one step. A second detection step reads the compiled
production output, which is authoritative whatever the descriptor says because the build tool writes it to its
own location, so an unparsed descriptor no longer costs the supervised scope. Where nothing at all is
detectable, the default still applies but now says so in a warning naming the roots that were searched, instead
of passing silently. The parser's remaining known gaps are documented at the pattern rather than implied.

## 4. Testing manual

The parsing defect is Gradle-only, so the manual uses Gradle. The scanner change affects both build tools.

**Prerequisites**

1. JDK 17 and Gradle. No echo server is needed; nothing here touches the network.
2. Build and install this branch: `mvn install -DskipTests`.
3. Use `examples/ares-exercise-gradle`.

**Steps**

1. In `examples/ares-exercise-gradle/build.gradle`, replace the main source-set declaration
   `srcDir 'src/main/java'` with the list form `srcDirs = ['src/main/java']`, and change nothing else. This is
   the only edit needed to reproduce the defect, and it is what the Artemis exercise template does.
2. Remove the `@Policy` annotation and its `import` from the example's test class, so the policy-free
   configuration applies. Leave the Ares test annotation in place: it is what activates Ares.
3. Add a method to the student-facing class that reads a file in the project directory, and do not create that
   file:
   ```java
   public String readForbiddenFile() throws java.io.IOException {
       return java.nio.file.Files.readString(java.nio.file.Path.of("secret.txt"));
   }
   ```
4. Add a test that asserts the rejection, so the outcome is visible either way:
   ```java
   @PublicTest
   void forbiddenReadIsRejected() {
       SecurityException violation = assertThrows(SecurityException.class,
               () -> new Penguin("Julian").readForbiddenFile());
       assertTrue(violation.getMessage().contains("secret.txt"));
   }
   ```
5. Run `./gradlew clean test`.
6. Repeat steps 1 to 5 against Ares 2.1.2 to see the previous behaviour.

**Expected result**

- Step 5, on this branch: the build is green and `forbiddenReadIsRejected` passes, that is Ares threw. In the
  test output, the line `Resolved Ares analysis/import path for GRADLE: .../build/classes/java/main/<your
  package path>` names the package of the example's own classes.
- Step 6, on 2.1.2: `forbiddenReadIsRejected` fails, and its message shows
  `java.nio.file.NoSuchFileException: secret.txt` rather than a `SecurityException`, that is the read reached the
  file system. The same log line ends in `de/tum/cit/ase`, a directory that does not exist under
  `build/classes/java/main`, which is the defect made visible.
- The new `No supervised package could be detected` warning must **not** appear in step 5. It appears only when
  neither the sources nor the compiled output declares a package.

**Negative case (what must still be rejected)**

- Ares has not become more permissive: with a `SecurityPolicy.yaml` and `@Policy` restored, the same forbidden
  read is still rejected, exactly as before.
- The reserved-package boundary is untouched: a student class declaring `package de.tum.cit.ase.ares.api;` must
  still fail the build with the reserved-package diagnostic.
- The default no longer wins over evidence: with production sources undiscoverable but
  `build/classes/java/main/de/tum/cit/aet/Calculator.class` present, `scanForPackageName()` answers
  `de.tum.cit.aet` and not `de.tum.cit.ase`. Covered by `JavaProjectScannerPackageFallbackTest`.
- The existing behaviour when a project genuinely declares nothing is unchanged, and
  `de.tum.cit.ase.ares.integration.SecurityTest` still passes in full, which is what proves it.

**Modes exercised**

- [x] ArchUnit + AspectJ
- [ ] ArchUnit + instrumentation
- [ ] WALA + AspectJ
- [ ] WALA + instrumentation

The policy-free path fixes the modes itself, to ArchUnit and AspectJ, so that is the only combination this
change can be exercised in from a policy-free exercise. Neither changed class reads the architecture or AOP
mode; both run before either is selected. The full suite covers all four.

## 5. Test case coverage regarding this PR

<!-- Filled from the Coverage Report job artefact of this pull request's Maven workflow run. -->

| Class | Instruction coverage | Branch coverage | Line coverage | Complexity coverage | Method coverage | Confirmation (meaningful assertions) |
| --- | ---: | ---: | ---: | ---: | ---: | :---: |
| `JavaProjectScanner` | TBD | TBD | TBD | TBD | TBD | yes |
| `ProjectSourcesFinder` | TBD | TBD | TBD | TBD | TBD | yes |

## Breaking changes and migration

None for the public API under `de.tum.cit.ase.ares.api`, the policy file format, the generated security test
code or the minimum JDK, Maven and Gradle versions. Instructors need do nothing to upgrade.

One behaviour change is the point of the pull request: an exercise that relied on the policy-free configuration
and declares its main sources with `srcDirs` was enforcing nothing in the five resource domains and now enforces
them. Supervised code performing file, network, command or thread operations will now be rejected, which is the
documented behaviour. An exercise that needs such an operation must declare it in a policy, as it always had to.

## Follow-up worth considering separately

`JavaProgrammingExerciseProjectScanner.getDefaultPackage()` returning `"de.tum.cit.ase"` is kept here, because
Ares's own integration tests depend on it: the policy-free test users, such as `SecurityUser`, pin only a
`withinPath` and rely on that coarse prefix to make the test-user classes themselves supervised. Deriving the
supervised package from the pinned `withinPath` instead, which would be more precise and would let the default
go, makes those meta-tests unsupervised and `SecurityTest.test_useCommonPoolGood` then fails, since the operation
happens in `de.tum.cit.ase.ares.integration.testuser` rather than under the pinned
`subject/helloWorld`. Rescoping those fixtures is a change to what the self-tests assert and belongs in its own
pull request, with maintainer agreement on the intended scope.

## Checklist

- [x] The title of this pull request describes the change, not the implementation.
- [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I have self-reviewed the diff of this pull request.
- [x] Tests were added or updated for the behaviour changed here.
- [x] Documentation (`docs/`, `README.adoc`, Javadoc) was updated where the change is user-facing.
      The user-facing contract is unchanged: setup manual section 6.2 already states that the policy-free
      configuration denies file, network, command and thread access. This change makes the implementation match
      that statement, so the manuals needed no edit. The new resolution order, and why a default must not win
      over evidence, are documented in the Javadoc of `scanForPackageName()` and `getDefaultPackage()`, and the
      parser's remaining known gaps at the pattern in `ProjectSourcesFinder`.
- [ ] CI is green, or every remaining failure is explained above.
- [x] No secrets, tokens or absolute local paths are contained in the diff.

## Review progress

- [ ] Code review
- [ ] Manual test
