### PR TITLE
Fix Phobos timeout unit serialization

### DIFF
--- a/src/main/java/de/tum/cit/ase/ares/api/phobos/JavaPhobosTestCase.java
+++ b/src/main/java/de/tum/cit/ase/ares/api/phobos/JavaPhobosTestCase.java
@@ -240,8 +240,35 @@ public class JavaPhobosTestCase extends PhobosTestCase {
 			return;
 		}
 		out.append('[').append(header).append("]\n");
-		limits.forEach((k, v) -> out.append(k).append('=').append(v).append('\n'));
+		limits.forEach((k, v) -> out.append(k).append('=').append(serialiseLimitValue(k, v)).append('\n'));
 		out.append('\n');
+	}
+
+	/**
+	 * Serialises a single {@code [limits]} value for the Phobos configuration.
+	 * <p>
+	 * The {@code timeout} limit is defined in <em>milliseconds</em> by
+	 * {@link ResourceLimitsPermission}, whereas the Phobos configuration field is
+	 * expressed in <em>seconds</em>. This method is the single authoritative
+	 * conversion point: milliseconds are rendered as canonical decimal seconds
+	 * {@code S.mmm} (exactly three fractional digits, formatted with
+	 * {@link java.util.Locale#ROOT} so it never depends on the platform locale, and
+	 * containing only digits and one dot). The Phobos runtime validates that exact
+	 * representation and appends an {@code s} suffix before handing it to GNU
+	 * {@code timeout}, so no second conversion happens anywhere else and no
+	 * sub-second precision is lost. All other keys are emitted verbatim.
+	 *
+	 * @param key   the limit key, e.g. {@code "timeout"}
+	 * @param value the limit value; for {@code timeout} this is milliseconds
+	 * @return the serialised value written after {@code key=}
+	 */
+	private static String serialiseLimitValue(String key, long value) {
+		if (!"timeout".equals(key)) {
+			return Long.toString(value);
+		}
+		long seconds = value / 1000L;
+		long milliseconds = value % 1000L;
+		return String.format(java.util.Locale.ROOT, "%d.%03d", seconds, milliseconds);
 	}
 
 	/**

--- a/src/test/java/de/tum/cit/ase/ares/api/phobos/JavaPhobosTestCaseTest.java
+++ b/src/test/java/de/tum/cit/ase/ares/api/phobos/JavaPhobosTestCaseTest.java
@@ -1,9 +1,13 @@
 package de.tum.cit.ase.ares.api.phobos;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +38,45 @@ class JavaPhobosTestCaseTest {
 		JavaPhobosTestCase timeout = JavaPhobosTestCase.builder()
 				.javaPhobosTestCaseSupported(JavaPhobosTestCaseSupported.TIMEOUT)
 				.resourceAccessSupplier(() -> List.of(new ResourceLimitsPermission(1234))).build();
-		assertTrue(timeout.writePhobosTestCase().contains("timeout=1234"));
+		assertTrue(timeout.writePhobosTestCase().contains("timeout=1.234"));
+	}
+
+	@Test
+	void timeoutIsSerialisedAsCanonicalDecimalSeconds() {
+		// ResourceLimitsPermission carries milliseconds, but the Phobos [limits]
+		// timeout
+		// field is seconds. The generator converts once at this serialisation boundary,
+		// emitting canonical S.mmm decimal seconds (locale-independent, full
+		// millisecond
+		// precision, digits and one dot only).
+		assertEquals("2.000", timeoutValue(2000));
+		assertEquals("10.000", timeoutValue(10000));
+		assertEquals("2.500", timeoutValue(2500));
+		// Sub-second must not collapse to zero (which Phobos would treat as disabled).
+		assertEquals("0.500", timeoutValue(500));
+		assertEquals("0.001", timeoutValue(1));
+
+		// An absent timeout yields no [limits] section; its default behaviour is
+		// decided
+		// elsewhere, not at this serialisation boundary.
+		JavaPhobosTestCase none = JavaPhobosTestCase.builder()
+				.javaPhobosTestCaseSupported(JavaPhobosTestCaseSupported.TIMEOUT)
+				.resourceAccessSupplier(() -> List.of()).build();
+		assertFalse(none.writePhobosTestCase().contains("[limits]"));
+
+		// Non-positive milliseconds are rejected at the API boundary (unchanged).
+		assertThrows(IllegalArgumentException.class, () -> new ResourceLimitsPermission(0));
+		assertThrows(IllegalArgumentException.class, () -> new ResourceLimitsPermission(-1));
+	}
+
+	private static String timeoutValue(long millis) {
+		JavaPhobosTestCase timeout = JavaPhobosTestCase.builder()
+				.javaPhobosTestCaseSupported(JavaPhobosTestCaseSupported.TIMEOUT)
+				.resourceAccessSupplier(() -> List.of(new ResourceLimitsPermission(millis))).build();
+		String cfg = timeout.writePhobosTestCase();
+		Matcher matcher = Pattern.compile("(?m)^timeout=(\\S+)$").matcher(cfg);
+		assertTrue(matcher.find(), "generated cfg must contain a timeout line, was:\n" + cfg);
+		return matcher.group(1);
 	}
 
 	@Test


### PR DESCRIPTION
  ## Summary

  Ares expresses policy timeouts in milliseconds, but wrote the raw millisecond integer into the generated Phobos configuration, which reads that field as seconds. The value is now serialised as canonical decimal seconds, so a 3000 ms policy limit produces `timeout=3.000` instead of `timeout=3000`.

  ## Linked issues

  None. This change is coordinated with the Phobos runtime update in https://github.com/ls1intum/phobos/pull/2, which must merge and ship before this behaviour is released.

  ## 1. Problem

  `ResourceLimitsPermission` is a millisecond value. The policy schema documents it that way (`- timeout: 10000  # REQUIRED (milliseconds)`, `SecurityPolicyManual.md` section 8.6), and the record rejects anything that is not strictly positive.

  `JavaPhobosTestCase.appendLimitsSection` previously emitted that number verbatim into the `[limits]` section of the generated `SpecificExercise.cfg`. The Phobos sandbox parses that field as **seconds** and hands it to GNU `timeout`. A policy that says `timeout: 3000` therefore described three seconds and
  produced a three thousand second limit, a factor of one thousand too permissive.

  Observed with `examples/ares-exercise-maven` (Java 21, Maven, ArchUnit + AspectJ, Windows), whose policy already carries `regardingTimeouts: - timeout: 3000`. Running the generation entry point on `main` writes `timeout=3000`; the expected content is `timeout=3.000`.

  The root cause sits in the **serialisation boundary between the policy layer and the generated Phobos configuration**, not in the enforcement layer. Neither the AOP nor the architecture path is involved, and the policy model itself was already correct.

  This is a **false negative**: the limit is too loose, so supervised code runs far longer than the instructor specified. It is not a false positive and cannot fail a correct submission.

  Scope of the live impact, stated precisely so the severity is not overread: in Ares 2.1.x the Phobos family is a **generation-only** stage. `JavaTestCaseFactoryAndBuilder.executeTestCases` dispatches only the architecture and AOP cases, so a normal `mvn test` run through the JUnit extension is not bounded
  by this value today (`SecurityPolicyManual.md` section 8.6 documents this). The defect is therefore latent in the in-process path, and live for any consumer that feeds the generated configuration to a real Phobos sandbox. It becomes a live weakening the moment Phobos dispatch is enabled, which is why it
  is worth fixing at the boundary now rather than after that migration.

  ## 2. Improvement from the user's perspective

  Instructors get the limit they wrote. A policy saying `timeout: 3000` yields a three second sandbox limit rather than a fifty minute one, and sub-second limits survive instead of truncating: `timeout: 500` becomes `0.500` rather than collapsing to `0`, which Phobos treats as "disabled".

  Students are unaffected in either direction. Nothing that passed before now fails, because the value only ever bounded execution in the Phobos sandbox path.

  ## 3. Improvement from the maintainer's perspective

  The millisecond to second conversion now happens in exactly one place, `serialiseLimitValue`, with the cross-repository contract written down at that point. Previously the unit boundary was implicit and split across two repositories, so neither side documented who owned the conversion.

  The output is a canonical, locale-independent `S.mmm` form produced with `Locale.ROOT`, so it cannot drift on a machine whose default locale uses a decimal comma. The Phobos side validates exactly that shape, which makes an accidental double conversion a parse error rather than a silent thousandfold
  change.

  ## 4. Testing manual

  **Prerequisites**

  1. JDK 21 and Maven.
  2. This branch, `fix/i-090-timeout-units`, checked out in the Ares repository.
  3. `examples/ares-exercise-maven` as shipped. Its policy already contains `regardingTimeouts: - timeout: 3000`, so nothing has to be authored.
  4. No Docker, no Phobos runtime and no echo server are needed. This change is observed in a generated file.

  **Steps**

  1. Install the Ares build from this branch into the local repository, from the repository root:

     ```
     mvn -B -ntp install -DskipTests
     ```

     Expected result: `BUILD SUCCESS`. Note the project version (currently `2.1.2`); it is used as `<ARES_VERSION>` below.

  2. Copy the example out of the repository so the generated files do not dirty the working tree, and change into the copy:

     ```
     cp -r examples/ares-exercise-maven /path/to/scratch/genproj
     cd /path/to/scratch/genproj
     ```

  3. Resolve the example against the build from step 1:

     ```
     mvn -q -B -ntp -Dares.version=<ARES_VERSION> dependency:build-classpath -Dmdep.outputFile=cp.txt
     ```

     Expected result: `cp.txt` is written and the build succeeds.

  4. Run the generation entry point, which is what writes the Phobos configuration. Use `:` as the classpath separator on Linux and macOS, `;` on Windows:

     ```
     java -cp "target/classes:$(cat cp.txt)" de.tum.cit.ase.ares.api.Main src/test/resources/SecurityPolicy.yaml .
     ```

     Expected result: exit code 0. Two files appear in the project root, `SpecificExercise.cfg` and `PhobosCopyTool.sh`.

  5. Read the generated configuration:

     ```
     cat SpecificExercise.cfg
     ```

     Expected result: the `[limits]` section carries decimal seconds, not the raw millisecond integer:

     ```
     [readonly]
     allowed.txt

     [limits]
     timeout=3.000
     ```

     On `main` the same step yields `timeout=3000`. That single line is the whole change.

  6. Vary the policy value to confirm the conversion is exact rather than a whole-second rounding. Edit `regardingTimeouts` in `src/test/resources/SecurityPolicy.yaml`, delete `SpecificExercise.cfg`, and repeat step 4 for each value.

     Expected result, confirmed for all three:

     | Policy value | Generated line |
     |---|---|
     | `timeout: 2000` | `timeout=2.000` |
     | `timeout: 1234` | `timeout=1.234` |
     | `timeout: 500` | `timeout=0.500` |

  7. Run the focused unit test from the Ares repository root:

     ```
     mvn -o test -Dtest=JavaPhobosTestCaseTest
     ```

     Expected result: `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`.

  **Expected result**

  Stated per step above. The single observable claim is the `timeout=` line of the generated `SpecificExercise.cfg`, read directly from the file.

  **Negative case (what must still be rejected)**

  1. **The conversion must happen once, not twice.** `timeout: 3000` must produce `timeout=3.000`, never `timeout=0.003`. A second division would show up immediately in step 5.
  2. **An absent limit must not invent one.** Set `regardingTimeouts: [ ]`, delete `SpecificExercise.cfg` and repeat step 4. Confirmed: the generated file contains **no `[limits]` section at all**, so Phobos keeps its existing disabled behaviour rather than receiving `timeout=0.000`.
  3. **Non-positive limits stay rejected at the API boundary.** `new ResourceLimitsPermission(0)` and `new ResourceLimitsPermission(-1)` must still throw `IllegalArgumentException`; `JavaPhobosTestCaseTest` asserts both. The serialisation change deliberately did not loosen that validation.
  4. **Sub-second limits must not silently become "no limit".** `timeout: 500` must produce `0.500`. Integer-second truncation would produce `0`, which Phobos reads as disabled, and that would be a security regression rather than a rounding detail.

  **Modes exercised**

  No mode-specific behaviour changed. `serialiseLimitValue` runs during Phobos configuration generation and is reached identically regardless of the architecture or AOP mode; neither an ArchUnit rule nor an AspectJ or instrumentation advice is involved. All four combinations were nevertheless run by CI on
  this branch and passed.

  <!-- Not applicable: the change cannot alter mode-specific behaviour, see above.
  - [ ] ArchUnit + AspectJ
  - [ ] ArchUnit + instrumentation
  - [ ] WALA + AspectJ
  - [ ] WALA + instrumentation
  -->

  ## 5. Test case coverage regarding this PR

  Read from `site/jacoco/jacoco.csv` in the `coverage-report` artefact of the Coverage Report job on this branch (workflow run `30921639445`). `JavaPhobosTestCase` is the only production class this pull request changes; the nested `JavaPhobosTestCase.Builder` is reported separately by JaCoCo and is
  untouched here, so it is not listed.

  | Class | Instruction coverage | Branch coverage | Line coverage | Complexity coverage | Method coverage | Confirmation (meaningful assertions) |
  | --- | ---: | ---: | ---: | ---: | ---: | :---: |
  | `de.tum.cit.ase.ares.api.phobos.JavaPhobosTestCase` | 91.9% (399/434) | 85.0% (17/20) | 95.2% (79/83) | 89.3% (25/28) | 100.0% (17/17) | yes |

  Both branches of `serialiseLimitValue` are taken: the `timeout` key by the three serialisation assertions, and the non-`timeout` key by the existing file-system and network cases that emit their values verbatim. The assertions compare the exact generated string (`2.000`, `1.234`, `0.500`) rather than
  asserting mere execution, and the sub-second case specifically pins the value that integer truncation would destroy.

  ## Breaking changes and migration

  **Yes, for the generated Phobos configuration.** This is not a source-compatibility break:

  - the public API under `de.tum.cit.ase.ares.api` is unchanged (`serialiseLimitValue` is private, and `ResourceLimitsPermission` keeps its millisecond contract);
  - the security policy file format and schema are unchanged, and instructors keep writing milliseconds exactly as documented;
  - the minimum JDK, Maven and Gradle versions are unchanged.

  What changes is the **content of the generated `SpecificExercise.cfg`**. A Phobos runtime that predates https://github.com/ls1intum/phobos/pull/2 accepts only integer seconds and would not parse `3.000`, so the two must be released in order: **the updated Phobos runtime image first, this change second**.
  Instructors do not have to touch an existing exercise; no policy file needs editing.

  Existing native Phobos configurations that use integer seconds remain valid, and integer values are not reinterpreted as milliseconds, so hand-written Phobos configuration is unaffected.

  ## Known follow-up, not addressed here

  Ares bundles a snapshot of the Phobos runtime scripts under `src/main/resources/de/tum/cit/ase/ares/api/templates/phobos/`. Those copies still carry the old integer-only parser (`phobos-common.sh`, the `^timeout[[:space:]]*=[[:space:]]*([0-9]+)$` branch) and still invoke GNU `timeout` without the explicit
  seconds suffix (`phobos-filesystem.sh`).

  They are **not deployed**: `PhobosCopyFiles.csv` copies only `PhobosCopyTool.sh` and `PhobosEditFiles.csv` generates only `SpecificExercise.cfg`, which the run in section 4 confirms, since those two files are the only ones written. They are exercised solely by `PhobosShellContractTest`, which asserts
  unknown-section rejection and fail-closed runtime errors and does not touch timeout parsing, so this pull request neither breaks nor is broken by them.

  They will nonetheless drift from `ls1intum/phobos` once the coordinated pull request merges. Resynchronising that snapshot belongs in its own change, together with a decision on whether Ares should vendor those scripts at all.

  ## Checklist

  - [x] The title of this pull request describes the change, not the implementation.
  - [x] I followed the [guidelines for inclusive, diversity-sensitive and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
  - [x] I have self-reviewed the diff of this pull request.
  - [x] Tests were added or updated for the behaviour changed here.
  - [x] Documentation (`docs/`, `README.adoc`, Javadoc) was updated where the change is user-facing. Javadoc on `serialiseLimitValue` records the cross-repository contract. The policy documentation already states milliseconds and stays correct; the generated configuration format is not described in `docs/`.
  - [x] CI is green, or every remaining failure is explained above. All fifteen checks pass, including all four mode combinations, both example exercises and the Coverage Report job.
  - [x] No secrets, tokens or absolute local paths are contained in the diff.

  ## Review progress

  - [ ] Code review
  - [ ] Manual test